### PR TITLE
chore(test): replace local e2e helpers with shared e2e-utils exports

### DIFF
--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -1,4 +1,5 @@
-import { device, expect, element, by } from 'detox';
+import { expect as jestExpect } from '@jest/globals';
+import { device, expect, element, by, waitFor } from 'detox';
 import {
   AndroidElementAttributes,
   IosElementAttributes,
@@ -6,13 +7,28 @@ import {
 } from 'detox/detox';
 import isVersionEqualOrHigherThan from './helpers/isVersionEqualOrHigherThan';
 import {
+  CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
   CLASS_NAME_ANDROID_CHECK_BOX,
   CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
   CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
   CLASS_NAME_ANDROID_RADIO_BUTTON,
+  CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
+  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
+  CLASS_NAME_UI_CONTEXT_MENU_CELL,
+  CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
+  CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW,
+  CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW,
+  CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
+  CLASS_NAME_UI_IMAGE_VIEW,
+  CLASS_NAME_UI_MODERN_BAR_BUTTON,
+  CLASS_NAME_UI_TAB_BAR,
 } from './native-class-names';
 
 const { getIOSVersionNumber } = require('../../scripts/e2e/ios-devices.js');
+
+/** Default for waits Detox's idle sync already mostly covers. */
+const DEFAULT_TIMEOUT_MS = 3000;
 
 export const describeIfiOS =
   device.getPlatform() === 'ios' ? describe : describe.skip;
@@ -21,10 +37,8 @@ export const describeIfAndroid =
   device.getPlatform() === 'android' ? describe : describe.skip;
 
 /**
- * Detox exposes no runtime UIUserInterfaceIdiom query, so the idiom is inferred
- * from the simulator name requested via `RNS_APPLE_SIM_NAME` (see
- * scripts/e2e/ios-devices.js). iPad-only suites self-skip on the default iPhone
- * run and execute only with e.g. RNS_APPLE_SIM_NAME="iPad Pro 13-inch (M4)".
+ * Inferred from `RNS_APPLE_SIM_NAME` (Detox has no idiom query), e.g.
+ * RNS_APPLE_SIM_NAME="iPad Pro 13-inch (M4)". See scripts/e2e/ios-devices.js.
  */
 export const isIPadTarget =
   device.getPlatform() === 'ios' &&
@@ -32,11 +46,7 @@ export const isIPadTarget =
 
 export const describeIfiPad = isIPadTarget ? describe : describe.skip;
 
-/**
- * True when running on iOS at `version` or newer. Use it to pick between the
- * legacy and iOS 26 variants of the private UIKit class names in
- * ./native-class-names.
- */
+/** `true` on iOS at `version` or newer; `false` on Android. */
 export function isIOSVersionAtLeast(version: string): boolean {
   return (
     device.getPlatform() === 'ios' &&
@@ -44,11 +54,7 @@ export function isIOSVersionAtLeast(version: string): boolean {
   );
 }
 
-/**
- * Suites for iOS 26+ only features (e.g. `bottomAccessory`, the header overflow
- * button). `isIOSVersionAtLeast` is false on Android, so these stay iOS-only
- * and additionally self-skip on iOS 18 and older.
- */
+/** Suites for iOS 26+ only features; skipped on Android and older iOS. */
 export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
   ? describe
   : describe.skip;
@@ -61,27 +67,40 @@ export type ScrollOptions = {
   pixels?: number;
   /** Swipe start, as a fraction of height. `NaN` leaves it to Detox. */
   startPercentage?: number;
+  /** Scroll direction; `whileElement` only ever scrolls one way. */
+  direction?: 'up' | 'down';
 };
 
+/** A `testID`, or any matcher for targets that carry no `testID`. */
+export type ScrollTarget = string | NativeMatcher;
+
+function toMatcher(target: ScrollTarget): NativeMatcher {
+  return typeof target === 'string' ? by.id(target) : target;
+}
+
 export async function scrollUntilVisible(
-  id: string,
+  target: ScrollTarget,
   scrollViewId: string,
-  { pixels = 600, startPercentage = 0.85 }: ScrollOptions = {},
+  {
+    pixels = 600,
+    startPercentage = 0.85,
+    direction = 'down',
+  }: ScrollOptions = {},
 ) {
-  await waitFor(element(by.id(id)))
+  await waitFor(element(toMatcher(target)))
     .toBeVisible()
     .whileElement(by.id(scrollViewId))
-    .scroll(pixels, 'down', Number.NaN, startPercentage);
+    .scroll(pixels, direction, Number.NaN, startPercentage);
 }
 
 /** Rewinds to the top first — `whileElement` only scrolls one way. */
 export async function rewindAndScrollUntilVisible(
-  id: string,
+  target: ScrollTarget,
   scrollViewId: string,
   options: ScrollOptions = {},
 ) {
   await element(by.id(scrollViewId)).scrollTo('top');
-  await scrollUntilVisible(id, scrollViewId, options);
+  await scrollUntilVisible(target, scrollViewId, options);
 }
 
 export async function selectIssueTestScreen(screenName: string) {
@@ -108,67 +127,49 @@ export async function selectIssueTestScreen(screenName: string) {
   await element(by.id(`issue-tests-${screenName}`)).tap();
 }
 
-export async function selectComponentIntegrationTestsScreen(
+/** Root → `section` list → `scenarioGroup` list → `screenKey`. */
+async function selectTestsScreen(
+  section: 'single-feature-tests' | 'component-integration-tests',
   scenarioGroup: string,
   screenKey: string,
 ) {
   const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
-  await scrollUntilVisible(
-    'root-screen-component-integration-tests',
+  const sectionScrollView = `${section}-scrollview`;
+  const groupScrollView = `${scenarioGroupId}-scenarios-scrollview`;
+
+  await scrollToAndTapInList(
+    `root-screen-${section}`,
     'root-screen-examples-scrollview',
   );
-  await element(by.id('root-screen-component-integration-tests')).tap();
-
-  await waitFor(element(by.id('component-integration-tests-scrollview')))
+  await waitFor(element(by.id(sectionScrollView)))
     .toBeVisible()
-    .withTimeout(3000);
+    .withTimeout(DEFAULT_TIMEOUT_MS);
 
-  await scrollUntilVisible(
-    `component-integration-tests-${scenarioGroupId}`,
-    'component-integration-tests-scrollview',
+  await scrollToAndTapInList(
+    `${section}-${scenarioGroupId}`,
+    sectionScrollView,
   );
-
-  await element(by.id(`component-integration-tests-${scenarioGroupId}`)).tap();
-  await waitFor(element(by.id(`${scenarioGroupId}-scenarios-scrollview`)))
+  await waitFor(element(by.id(groupScrollView)))
     .toBeVisible()
-    .withTimeout(3000);
+    .withTimeout(DEFAULT_TIMEOUT_MS);
 
-  await scrollUntilVisible(
-    `${screenKey}`,
-    `${scenarioGroupId}-scenarios-scrollview`,
-  );
-  await element(by.id(`${screenKey}`)).tap();
+  await scrollToAndTapInList(screenKey, groupScrollView);
 }
 
-export async function selectSingleFeatureTestsScreen(
+async function scrollToAndTapInList(id: string, scrollViewId: string) {
+  await scrollUntilVisible(id, scrollViewId);
+  await element(by.id(id)).tap();
+}
+
+export const selectSingleFeatureTestsScreen = (
   scenarioGroup: string,
   screenKey: string,
-) {
-  const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
-  await scrollUntilVisible(
-    'root-screen-single-feature-tests',
-    'root-screen-examples-scrollview',
-  );
-  await element(by.id('root-screen-single-feature-tests')).tap();
-  await waitFor(element(by.id('single-feature-tests-scrollview')))
-    .toBeVisible()
-    .withTimeout(3000);
+) => selectTestsScreen('single-feature-tests', scenarioGroup, screenKey);
 
-  await scrollUntilVisible(
-    `single-feature-tests-${scenarioGroupId}`,
-    'single-feature-tests-scrollview',
-  );
-  await element(by.id(`single-feature-tests-${scenarioGroupId}`)).tap();
-  await waitFor(element(by.id(`${scenarioGroupId}-scenarios-scrollview`)))
-    .toBeVisible()
-    .withTimeout(3000);
-
-  await scrollUntilVisible(
-    `${screenKey}`,
-    `${scenarioGroupId}-scenarios-scrollview`,
-  );
-  await element(by.id(`${screenKey}`)).tap();
-}
+export const selectComponentIntegrationTestsScreen = (
+  scenarioGroup: string,
+  screenKey: string,
+) => selectTestsScreen('component-integration-tests', scenarioGroup, screenKey);
 
 /** @see apps/src/shared/SettingsPicker.tsx — derives option `testID`s. */
 export function pickerOptionId(pickerLabel: string, option: string): string {
@@ -194,37 +195,57 @@ type PickerSelection = {
 };
 
 /**
- * Closes the picker again: its option rows stay in the hierarchy while open and
- * would collide with the `by.text` matchers used for native popups.
- *
- * Returns early when the picker already shows `option`. The check reads the same
- * line the closing assertion checks, and `getAttributes` has no visibility
- * constraint, so an already-set picker costs one read and no gesture at all.
- * It assumes the picker is collapsed — true unless an earlier call threw partway,
- * which fails its own test first.
+ * Sets a picker to `option` and closes it (open option rows collide with the
+ * `by.text` popup matchers). No-op when it already shows `option`. Omit
+ * `control` for pickers outside a scroll view — they are tapped in place.
  */
 export async function selectPickerOption(
   { pickerId, label, option }: PickerSelection,
-  { scrollViewId, ...scroll }: SettingsControlOptions,
+  control?: SettingsControlOptions,
 ) {
   const expected = `${label}: ${option}`;
 
-  if ((await getTopmostMatch(by.id(pickerId))).text === expected) {
+  const current = await getTopmostMatch(by.id(pickerId));
+  if ((current.text ?? current.label) === expected) {
     return;
   }
 
-  const control = { scrollViewId, ...scroll };
-  await scrollToAndTap(pickerId, control);
-  await scrollToAndTap(pickerOptionId(label, option), control);
-  await scrollToAndTap(pickerId, control);
+  const tap = async (id: string) => {
+    if (control) {
+      await scrollToAndTap(id, control);
+    } else {
+      await element(by.id(id)).tap();
+    }
+  };
 
-  await expect(element(by.id(pickerId))).toHaveText(expected);
+  await tap(pickerId);
+  await tap(pickerOptionId(label, option));
+  await tap(pickerId);
+
+  await expectPickerValue(pickerId, expected);
+}
+
+/** The value is an RN `Text`: `text` on Android, `label` on iOS. */
+async function expectPickerValue(pickerId: string, expected: string) {
+  if (device.getPlatform() === 'ios') {
+    await expect(element(by.id(pickerId))).toHaveLabel(expected);
+  } else {
+    await expect(element(by.id(pickerId))).toHaveText(expected);
+  }
 }
 
 /** `to` is the state expected afterwards — a swallowed tap fails here. Omit
  * `control` on screens whose switches sit outside any scroll view. */
+type SwitchToggle = {
+  switchId: string;
+  /** The switch's `label` prop. */
+  label: string;
+  /** The state expected after the tap. */
+  to: boolean;
+};
+
 export async function toggleSettingsSwitch(
-  { switchId, label, to }: { switchId: string; label: string; to: boolean },
+  { switchId, label, to }: SwitchToggle,
   control?: SettingsControlOptions,
 ) {
   if (control) {
@@ -234,6 +255,17 @@ export async function toggleSettingsSwitch(
   await element(by.id(switchId)).tap();
 
   await expect(element(by.text(`${label}: ${to}`))).toBeVisible();
+}
+
+/** Asserts the toolbar-menu screens' `Last clicked: <id>` line. */
+export async function expectLastClicked(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+) {
+  await rewindAndScrollUntilVisible('last-clicked-text', scrollViewId, scroll);
+  await expect(element(by.id('last-clicked-text'))).toHaveText(
+    `Last clicked: ${id}`,
+  );
 }
 
 type ElementAttributes = IosElementAttributes | AndroidElementAttributes;
@@ -262,11 +294,7 @@ function resolveMatcher({ by: matcher, value }: ElementMatcher) {
   }
 }
 
-/**
- * Attributes of a single element on either platform. Cast to
- * `IosElementAttributes` / `AndroidElementAttributes` at the call site for
- * platform-specific fields.
- */
+/** Attributes of exactly one element; throws on an ambiguous match. */
 export async function getElementAttributes(
   matcher: ElementMatcher,
 ): Promise<ElementAttributes> {
@@ -285,20 +313,21 @@ export async function getElementAttributes(
 
   return attrs as ElementAttributes;
 }
-/**
- * Coordinate-based tap on iOS, bypassing Detox's visibility checks so an
- * element obstructed by other UI layers can still be hit.
- */
+
+type Frame = ElementAttributes['frame'];
+
+/** Coordinate tap at (`xFraction`, 1/2) of `frame`, bypassing visibility checks. */
+async function tapWithinFrame({ x, y, width, height }: Frame, xFraction = 0.5) {
+  await device.tap({ x: x + width * xFraction, y: y + height / 2 });
+}
+
+/** Coordinate tap (iOS) — bypasses Detox's visibility check. */
 export async function forceTapByLabeliOS(testLabel: string) {
-  const elementAttributes = await getElementAttributes({
+  const { frame } = await getElementAttributes({
     by: 'label',
     value: testLabel,
   });
-  const { x, y, width, height } = elementAttributes.frame;
-  await device.tap({
-    x: x + width / 2,
-    y: y + height / 2,
-  });
+  await tapWithinFrame(frame);
 }
 
 export async function forceSelectTabByLabel(label: string) {
@@ -309,10 +338,37 @@ export async function forceSelectTabByLabel(label: string) {
   }
 }
 
+// ---------------------------------------------------------------------------
+// iOS 26 tab bar bottom accessory
+// ---------------------------------------------------------------------------
+
+/** The accessory host view; a single match is asserted by `getElementAttributes`. */
+export const getBottomAccessoryAttributes = () =>
+  getElementAttributes({
+    by: 'type',
+    value: CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
+  }) as Promise<IosElementAttributes>;
+
+/** The `UITabBar`; a single match is asserted by `getElementAttributes`. */
+export const getTabBarAttributes = () =>
+  getElementAttributes({
+    by: 'type',
+    value: CLASS_NAME_UI_TAB_BAR,
+  }) as Promise<IosElementAttributes>;
+
+/** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
+export async function expectBottomAccessoryAboveTabBar() {
+  const bottomAccessory = await getBottomAccessoryAttributes();
+  const tabBar = await getTabBarAttributes();
+  jestExpect(tabBar.frame.y).toBeGreaterThan(
+    bottomAccessory.frame.y + bottomAccessory.frame.height,
+  );
+}
+
 export async function dismissToast(message: string) {
   await waitFor(element(by.label(message)))
     .toBeVisible()
-    .withTimeout(3000);
+    .withTimeout(DEFAULT_TIMEOUT_MS);
   await element(by.label(message)).tap();
 }
 
@@ -338,9 +394,8 @@ type MatchOptions = {
 };
 
 /**
- * Every element matching `matcher`, normalizing `getAttributes()`'s single- and
- * multi-element shapes into one array ordered by view hierarchy (topmost
- * stacked screen last). Throws on no match, so a crash is not read as "found 0".
+ * All matches as one array (topmost stacked screen last). Throws on no match
+ * unless `orEmpty`, so a crashed app is not read as "found 0".
  */
 export async function getMatches(
   matcher: NativeMatcher,
@@ -373,22 +428,14 @@ export async function getTopmostMatch(
   return matches[matches.length - 1];
 }
 
-/**
- * Taps `matcher`'s last match — the topmost stacked screen's copy. Pass a
- * freshly built matcher: on Android `atIndex` rewrites it in place, so a reused
- * one stays pinned to the index tapped here.
- */
+/** Taps the last match (topmost stacked screen). Pass a fresh matcher: `atIndex` mutates it on Android. */
 export async function tapTopmost(matcher: NativeMatcher): Promise<void> {
   await element(matcher)
     .atIndex((await countMatches(matcher)) - 1)
     .tap();
 }
 
-/**
- * Only "nothing matched yet" / "not visible yet" are worth retrying. Anything
- * else — a crashed app, a lost session, a bad matcher — must surface as itself,
- * not as a settle timeout.
- */
+/** Only "no match yet" / "not visible yet" are worth retrying. */
 function isTransientMatchError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -398,15 +445,9 @@ function isTransientMatchError(error: unknown): boolean {
 }
 
 /**
- * Asserts the last match of `buildMatcher()` — the topmost stacked screen's
- * copy — is visible. Indexed because a bare `toBeVisible()` throws once several
- * screens are attached; polled because header chrome can lag the content.
- *
- * Pass a factory, not a matcher: on Android `atIndex` rewrites one in place, so
- * a reused matcher would pin later polls to the first attempt's index, where a
- * now-buried view still reads as visible and would pass falsely.
- *
- * Only for elements expected to be present — absence burns the full timeout.
+ * Polls until the last match of `buildMatcher()` (the topmost stacked screen's
+ * copy) is visible. Takes a factory: on Android `atIndex` mutates the matcher,
+ * so a reused one would stay pinned to the first poll's index.
  */
 export async function expectTopmostVisible(
   buildMatcher: () => NativeMatcher,
@@ -450,15 +491,12 @@ type WaitUntilOptions = {
 };
 
 /**
- * Polls `predicate` until it resolves `true`, or fails once `timeout` elapses.
- * Prefer Detox's `waitFor(...).withTimeout(...)`, which syncs with the app
- * instead of sampling it; this is for conditions it cannot express — notably
- * anything about the match *set*, since on Android `waitFor` retries natively
- * against a single view and a transient ambiguous match is terminal.
+ * Polls `predicate` until `true` or `timeout`. Prefer Detox's `waitFor`; use
+ * this only for conditions it cannot express, e.g. match counts.
  */
 export async function waitUntil(
   predicate: () => Promise<boolean>,
-  { timeout = 3000, interval = 100, message }: WaitUntilOptions,
+  { timeout = DEFAULT_TIMEOUT_MS, interval = 100, message }: WaitUntilOptions,
 ): Promise<void> {
   const deadline = Date.now() + timeout;
 
@@ -490,10 +528,13 @@ export const MENU_ANIMATION_TIMEOUT_MS = 5000;
 export const MENU_PRESENCE_TIMEOUT_MS = 250;
 
 /** The accessibility label AppCompat gives the overflow button. */
-const OVERFLOW_MENU_LABEL = 'More options';
+export const OVERFLOW_MENU_LABEL = 'More options';
 
-export const overflowMenu = () =>
-  element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW));
+/** The popup hosting the overflow menu (or, once opened, a submenu). */
+export const overflowMenuMatcher = (): NativeMatcher =>
+  by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW);
+
+export const overflowMenu = () => element(overflowMenuMatcher());
 
 /**
  * A multi-toggle group renders check boxes and a single-selection one radio
@@ -517,10 +558,47 @@ export function menuItemToggle(
 }
 
 /**
- * Asserts `title`'s row hosts a check box (a multi-toggle group) — the sibling
- * widget is asserted absent so a mismatched group type fails loudly instead of
- * matching nothing.
+ * The visible image view in `title`'s row — divider, submenu arrow or icon;
+ * they share one class and Detox cannot tell them apart by resource id.
  */
+export function menuItemImage(title: string): NativeMatcher {
+  return by
+    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
+    .withAncestor(menuItemRow(title));
+}
+
+/** `title` inside the focused popup (row title or submenu header). */
+export function overflowMenuText(title: string): NativeMatcher {
+  return by.text(title).withAncestor(overflowMenuMatcher());
+}
+
+/**
+ * A toolbar action button, matched by label in both forms; icon-only buttons
+ * have empty text, text buttons show `title`.
+ */
+export function actionMenuItem(title: string): NativeMatcher {
+  return by.label(title).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
+}
+
+/** Asserts the open popup lists `titles` top to bottom in this order. */
+export async function expectOverflowMenuOrder(
+  titles: readonly string[],
+): Promise<void> {
+  const rows: { title: string; top: number }[] = [];
+
+  for (const title of titles) {
+    const matches = await getMatches(overflowMenuText(title));
+    if (matches.length !== 1) {
+      throw new Error(`Expected a single menu row titled "${title}".`);
+    }
+    rows.push({ title, top: matches[0].frame.y });
+  }
+
+  const topToBottom = [...rows].sort((a, b) => a.top - b.top).map(r => r.title);
+  jestExpect(topToBottom).toEqual([...titles]);
+}
+
+/** Asserts `title`'s row hosts a check box (multi-toggle group), not a radio. */
 export async function expectCheckBox(title: string, checked: boolean) {
   await expect(
     element(menuItemToggle(title, CLASS_NAME_ANDROID_RADIO_BUTTON)),
@@ -571,10 +649,7 @@ export type OverflowMenuControl = {
   maxMenuDepth?: number;
 };
 
-/**
- * The helpers that depend on the screen behind the popup, bound to one spec's
- * scroll view.
- */
+/** Overflow-menu helpers bound to one spec's scroll view. */
 export function createOverflowMenuHelpers({
   scrollViewId,
   maxMenuDepth = 3,
@@ -647,5 +722,172 @@ export function createOverflowMenuHelpers({
     await closingMenuAfter(assertions);
   };
 
-  return { waitForScreen, closeMenuIfOpen, closingMenuAfter, withOverflowMenu };
+  const waitForMenuItem = async (title: string) => {
+    await waitFor(element(overflowMenuText(title)))
+      .toBeVisible()
+      .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
+  };
+
+  /** Taps `title` in the open popup and waits for the popup to go away. */
+  const tapMenuItem = async (title: string) => {
+    await waitForMenuItem(title);
+    await element(overflowMenuText(title)).tap();
+    await waitFor(element(overflowMenuText(title)))
+      .not.toExist()
+      .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
+    await waitForScreen();
+  };
+
+  return {
+    waitForScreen,
+    closeMenuIfOpen,
+    closingMenuAfter,
+    withOverflowMenu,
+    waitForMenuItem,
+    tapMenuItem,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// iOS Stack v5 header items (UIBarButtonItem)
+// ---------------------------------------------------------------------------
+
+export type HeaderItemOptions = {
+  /**
+   * Match the inner control (`_UIModernBarButton`) instead of the item
+   * container (`_UIButtonBarButton`). Both carry the title as their label.
+   */
+  control?: boolean;
+};
+
+/** A title-only header item, addressed by its visible title. */
+export function headerItem(
+  title: string,
+  { control = false }: HeaderItemOptions = {},
+) {
+  return element(
+    by
+      .type(
+        control
+          ? CLASS_NAME_UI_MODERN_BAR_BUTTON
+          : CLASS_NAME_UI_BUTTON_BAR_BUTTON,
+      )
+      .and(by.label(title)),
+  );
+}
+
+/** A header item's icon, by icon id (SF Symbol name or asset path). */
+export function barButtonIcon(iconId: string) {
+  return element(
+    by.id(iconId).withAncestor(by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON)),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// iOS context menu (UIMenu presented from a header item or the title)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detox's idle sync does not cover the menu's present/dismiss animation, so
+ * waits that straddle it must be explicit.
+ */
+export const CONTEXT_MENU_ANIMATION_TIMEOUT_MS = 2000;
+
+/** The list hosting the rows of the presented menu (or submenu). */
+export const contextMenu = () =>
+  element(by.type(CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW));
+
+export type MenuRowOptions = {
+  /**
+   * Restrict to selectable rows (those inside a `_UIContextMenuCell`). This
+   * excludes a submenu's pinned title/back row, which shares the label of the
+   * submenu's first entry when that item also has an `onPress`.
+   */
+  actionsOnly?: boolean;
+};
+
+/** Matcher for a row of a presented menu, addressed by its visible label. */
+export function menuRowMatcher(
+  title: string,
+  { actionsOnly = false }: MenuRowOptions = {},
+): NativeMatcher {
+  const row = by
+    .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
+    .and(by.label(title));
+  return actionsOnly
+    ? row.withAncestor(by.type(CLASS_NAME_UI_CONTEXT_MENU_CELL))
+    : row;
+}
+
+/** A row of a presented menu, addressed by its visible label. */
+export function menuRow(title: string, options?: MenuRowOptions) {
+  return element(menuRowMatcher(title, options));
+}
+
+/** A submenu's pinned title row — its own class, not a menu row. */
+export function submenuTitleRow(title: string) {
+  return element(
+    by
+      .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
+      .and(by.label(title))
+      .withAncestor(by.type(CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW)),
+  );
+}
+
+/** The checkmark of a checked toggle / singleSelection row. */
+export function checkmarkFor(title: string) {
+  return element(by.id('checkmark').withAncestor(menuRowMatcher(title)));
+}
+
+/** The submenu chevron; absent on inlined submenus. */
+export function chevronFor(title: string) {
+  return element(by.id('chevron.forward').withAncestor(menuRowMatcher(title)));
+}
+
+/** A menu row's icon by icon id; addressed by row title, since parent rows stay attached under a submenu. */
+export function menuRowIcon(iconId: string, title: string) {
+  return element(
+    by
+      .type(CLASS_NAME_UI_IMAGE_VIEW)
+      .and(by.id(iconId))
+      .withAncestor(menuRowMatcher(title)),
+  );
+}
+
+export type OpenContextMenuOptions = {
+  /** `longPress` for an item that also has an `onPress` — a tap fires that. */
+  gesture?: 'tap' | 'longPress';
+  timeout?: number;
+};
+
+/** Opens the menu attached to `anchor` and waits for it to present. */
+export async function openContextMenu(
+  anchor: Detox.NativeElement,
+  {
+    gesture = 'tap',
+    timeout = CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
+  }: OpenContextMenuOptions = {},
+) {
+  await waitFor(anchor).toBeVisible().withTimeout(timeout);
+  if (gesture === 'longPress') {
+    await anchor.longPress();
+  } else {
+    await anchor.tap();
+  }
+  await waitFor(contextMenu()).toBeVisible().withTimeout(timeout);
+}
+
+/**
+ * Dismisses the menu at any submenu depth by tapping UIKit's dismiss overlay
+ * near its leading edge (a tap on the menu itself only pops one level).
+ */
+export async function dismissContextMenu(
+  timeout = CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
+) {
+  const { frame } = await getElementAttributes({
+    by: 'type',
+    value: CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW,
+  });
+  await tapWithinFrame(frame, 0.1);
+  await waitFor(contextMenu()).not.toExist().withTimeout(timeout);
 }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -416,22 +416,27 @@ export const TOOLBAR_UPDATE_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 /**
  * Asserts `title`'s action button is up and renders `text`. Asserted
  * positively — on Android a negated matcher passes on a missing view.
+ * `timeoutMs` covers waits longer than a re-inflation, e.g. an image load.
  */
-async function expectActionItemText(title: string, text: string) {
+async function expectActionItemText(
+  title: string,
+  text: string,
+  timeoutMs = TOOLBAR_UPDATE_TIMEOUT_MS,
+) {
   await waitFor(element(actionMenuItem(title)))
     .toBeVisible()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+    .withTimeout(timeoutMs);
   await waitFor(element(actionMenuItem(title)))
     .toHaveText(text)
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+    .withTimeout(timeoutMs);
 }
 
 /**
  * Asserts `title` is promoted to the toolbar as an icon-only button, whose
  * text AppCompat clears. Which icon it is cannot be asserted through Detox.
  */
-export const expectIconActionItem = (title: string) =>
-  expectActionItemText(title, '');
+export const expectIconActionItem = (title: string, timeoutMs?: number) =>
+  expectActionItemText(title, '', timeoutMs);
 
 /**
  * Asserts `title` is promoted to the toolbar as a text button (no icon, or
@@ -654,7 +659,12 @@ export function createOverflowMenuHelpers({
         await closeMenuIfOpen();
       } catch (cleanupError) {
         // A throw from `finally` would replace the error that actually failed.
-        if (!assertionFailed) {
+        if (assertionFailed) {
+          console.warn(
+            'Cleanup failed after a failed assertion:',
+            cleanupError,
+          );
+        } else {
           throw cleanupError;
         }
       }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -1082,11 +1082,17 @@ export async function dismissNextToast(message: string) {
 }
 
 /**
- * Detox matches a regex against the *whole* string — without the trailing `.*`
- * this matches nothing and always passes.
+ * Asserts no toast is on screen. Passing `message` pins the check to the
+ * queue head (`1.`) — every caller here dismisses its own toasts first, so an
+ * unexpected one always lands there, same as `dismissNextToast`. Omitting it
+ * falls back to Detox matching a regex against the whole string, so any
+ * position and text counts as a toast; dropping that wildcard suffix would
+ * match nothing and always pass.
  */
-export async function expectNoToast() {
-  await expect(element(by.label(/\d+\. .*/))).not.toExist();
+export async function expectNoToast(message?: string) {
+  const matcher =
+    message === undefined ? by.label(/\d+\. .*/) : by.label(`1. ${message}`);
+  await expect(element(matcher)).not.toExist();
 }
 
 // ---------------------------------------------------------------------------
@@ -1100,6 +1106,9 @@ const ROUTE_KEY_TEST_ID = 'stack-route-key';
 /** The `Key: ...` label of the topmost screen. */
 const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
 
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
 /**
  * Matches the route key label of any screen on `routeName`. Keys are minted as
  * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
@@ -1107,9 +1116,6 @@ const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
  */
 const routeKeyPattern = (routeName: string) =>
   new RegExp(`^Key: r-${escapeRegExp(routeName)}-\\d+$`);
-
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
  * Waits for the `Name: <routeName>` label to be visible. Only where that

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -663,6 +663,9 @@ export const MENU_ANIMATION_TIMEOUT_MS = 5000;
 /** Probes an already-settled popup: by now it is either up or was never opened. */
 export const MENU_PRESENCE_TIMEOUT_MS = 250;
 
+/** Outlasts a popup's exit animation without paying the full animation timeout. */
+const MENU_DISMISS_PROBE_TIMEOUT_MS = 1000;
+
 /** The accessibility label AppCompat gives the overflow button. */
 export const OVERFLOW_MENU_LABEL = 'More options';
 
@@ -807,12 +810,16 @@ export function createOverflowMenuHelpers({
       .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
   };
 
-  /** `waitForScreen` reported rather than thrown — a stacked popup keeps it false. */
+  /** Reported rather than thrown — a stacked popup keeps it false. The short
+   * probe outlasts the exit animation without stalling stacked cleanup. */
   const isScreenAddressable = () =>
-    waitForScreen().then(
-      () => true,
-      () => false,
-    );
+    waitFor(element(by.id(scrollViewId)))
+      .toBeVisible()
+      .withTimeout(MENU_DISMISS_PROBE_TIMEOUT_MS)
+      .then(
+        () => true,
+        () => false,
+      );
 
   /**
    * Back only ever goes to an open popup: with no menu up the activity takes

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -31,7 +31,7 @@ import {
 const { getIOSVersionNumber } = require('../../scripts/e2e/ios-devices.js');
 
 /** Default for waits Detox's idle sync already mostly covers. */
-const DEFAULT_TIMEOUT_MS = 3000;
+export const DEFAULT_TIMEOUT_MS = 3000;
 
 export const describeIfiOS =
   device.getPlatform() === 'ios' ? describe : describe.skip;
@@ -208,8 +208,10 @@ export async function selectPickerOption(
 ) {
   const expected = `${label}: ${option}`;
 
-  const current = await getTopmostMatch(by.id(pickerId));
-  if ((current.text ?? current.label) === expected) {
+  // Already set. Asserted collapsed: one left open by an earlier failure would
+  // collide with later `by.text` matchers.
+  if (textOf(await getTopmostMatch(by.id(pickerId))) === expected) {
+    await expect(element(by.id(pickerOptionId(label, option)))).not.toExist();
     return;
   }
 
@@ -299,19 +301,21 @@ export async function forceSelectTabByLabel(label: string) {
 // iOS 26 tab bar bottom accessory
 // ---------------------------------------------------------------------------
 
-/** The accessory host view; a single match is asserted by `getSingleMatch`. */
-export const getBottomAccessoryAttributes = () =>
-  getSingleMatch(
-    by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY),
-    'the bottom accessory',
-  ) as Promise<IosElementAttributes>;
+/**
+ * The first match — UIKit can keep more than one host view / tab bar in the
+ * hierarchy (an accessory mid-transition, a sidebar and tab bar pair on iPad).
+ */
+async function getFirstMatch(matcher: NativeMatcher) {
+  return (await getMatches(matcher))[0] as IosElementAttributes;
+}
 
-/** The `UITabBar`; a single match is asserted by `getSingleMatch`. */
+/** The accessory host view. */
+export const getBottomAccessoryAttributes = () =>
+  getFirstMatch(by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY));
+
+/** The `UITabBar`. */
 export const getTabBarAttributes = () =>
-  getSingleMatch(
-    by.type(CLASS_NAME_UI_TAB_BAR),
-    'the UITabBar',
-  ) as Promise<IosElementAttributes>;
+  getFirstMatch(by.type(CLASS_NAME_UI_TAB_BAR));
 
 /** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
 export async function expectBottomAccessoryAboveTabBar() {
@@ -379,8 +383,7 @@ export async function countMatches(
 
 /**
  * Attributes of `matcher`'s only match; throws when it resolves to several.
- * A Detox matcher does not stringify, so pass `description` (e.g. the testID)
- * to name the target in that error.
+ * `description` names the target in that error — a matcher does not stringify.
  */
 export async function getSingleMatch(
   matcher: NativeMatcher,
@@ -408,10 +411,17 @@ export async function getTopmostMatch(
   return matches[matches.length - 1];
 }
 
-/** Trimmed text of the topmost screen's copy of `testID` (`''` when unset). */
+/**
+ * The value of an RN `Text`, which Detox reports as `text` on Android and as
+ * `label` on iOS (`''` when unset).
+ */
+export function textOf(attributes: ElementAttributes): string {
+  return (attributes.text ?? attributes.label ?? '').trim();
+}
+
+/** Text of the topmost screen's copy of `testID`. */
 export async function readTopmostText(testID: string): Promise<string> {
-  const topmost = await getTopmostMatch(by.id(testID));
-  return (topmost.text ?? topmost.label ?? '').trim();
+  return textOf(await getTopmostMatch(by.id(testID)));
 }
 
 /** Scrolls `id` into view and returns its text (`''` when unset). */
@@ -420,7 +430,7 @@ export async function readText(
   { scrollViewId, ...scroll }: SettingsControlOptions,
 ): Promise<string> {
   await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
-  return (await getSingleMatch(by.id(id), `id "${id}"`)).text ?? '';
+  return textOf(await getSingleMatch(by.id(id), `id "${id}"`));
 }
 
 /** Taps the last match (topmost stacked screen). Pass a fresh matcher: `atIndex` mutates it on Android. */
@@ -446,14 +456,15 @@ const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
  * so this pins the route, not the instance.
  */
 const routeKeyPattern = (routeName: string) =>
-  new RegExp(`^Key: r-${routeName}-\\d+$`);
+  new RegExp(`^Key: r-${escapeRegExp(routeName)}-\\d+$`);
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 /**
- * Waits until the topmost screen is `routeName` and returns its route key. The
- * key identifies the route *and* the instance, so one read settles continuity
- * (same key) or a push (new key). Polled rather than `waitFor(...)`: Detox
- * intersects a view only with its parents, never with an occluding sibling, so
- * `toBeVisible()` on a buried screen passes at once and would not gate a pop.
+ * Waits until the topmost screen is `routeName` and returns its route key,
+ * which pins the instance too (same key: preserved; new key: pushed). Polled:
+ * `toBeVisible()` passes on a buried screen, so `waitFor` would not gate a pop.
  */
 export async function waitForTopmostRoute(routeName: string): Promise<string> {
   const pattern = routeKeyPattern(routeName);
@@ -488,11 +499,12 @@ export async function expectTopmostButtons(titles: string[]): Promise<void> {
   }
 }
 
-/** Only "no match yet" / "not visible yet" are worth retrying. */
+/** Only "no match yet" (Espresso / iOS wording) and "not visible yet" retry. */
 function isTransientMatchError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
     message.includes('No views in hierarchy found matching') ||
+    message.includes('No elements found') ||
     message.includes('not visible')
   );
 }
@@ -510,8 +522,6 @@ export async function expectTopmostVisible(
 
   await waitUntil(
     async () => {
-      // Fresh per attempt: `countMatches` reads it before `atIndex` mutates it,
-      // and it is discarded before the next poll.
       const matcher = buildMatcher();
       try {
         const count = await countMatches(matcher);
@@ -568,24 +578,10 @@ export async function waitUntil(
 }
 
 // ---------------------------------------------------------------------------
-// Android toolbar overflow menu (Stack v5 header)
-// ---------------------------------------------------------------------------
-
-/**
- * Detox's idle sync does not cover popup window animations, so waits that
- * straddle the overflow menu opening or dismissing must be explicit.
- */
-export const MENU_ANIMATION_TIMEOUT_MS = 5000;
-
-/** Probes an already-settled popup: by now it is either up or was never opened. */
-export const MENU_PRESENCE_TIMEOUT_MS = 250;
-
-// ---------------------------------------------------------------------------
 // Android Stack v5 header (toolbar) matchers
 // ---------------------------------------------------------------------------
 //
-// Factories, built fresh per call: on Android `atIndex` rewrites a matcher in
-// place (see `tapTopmost`), so a shared one would stay pinned to an index.
+// Factories: on Android `atIndex` rewrites a matcher in place (see `tapTopmost`).
 
 /**
  * The Stack v5 header's toolbar. Scoped to `MaterialToolbar` so it never
@@ -604,11 +600,9 @@ export const stackV5AppBar = (): NativeMatcher =>
   by.type(CLASS_NAME_ANDROID_APP_BAR_LAYOUT).withDescendant(stackV5Toolbar());
 
 /**
- * The header's back chevron — the toolbar's navigation icon. A covered screen
- * keeps its toolbar but loses its navigation icon, so while a headered screen
- * is on top this resolves to that screen's chevron alone. Absence is not
- * reliable: under a headerless top screen the covered screen's chevron is
- * still there and still reads visible.
+ * The header's back chevron. A covered screen keeps its toolbar but loses its
+ * chevron, so under a headered top screen this is that screen's alone; under a
+ * headerless one the covered screen's chevron is still there and visible.
  */
 export const stackV5BackButton = (): NativeMatcher =>
   by
@@ -626,32 +620,31 @@ export const stackV5HeaderTitle = (title: string): NativeMatcher =>
 export const TOOLBAR_UPDATE_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 
 /**
- * Asserts `title` is promoted to the toolbar as an icon-only button. Asserted
- * positively through the cleared text — on Android a negated matcher passes on
- * a missing view. Which icon it is cannot be asserted through Detox.
+ * Asserts `title`'s action button is up and renders `text`. Asserted
+ * positively — on Android a negated matcher passes on a missing view.
  */
-export async function expectIconActionItem(title: string) {
+async function expectActionItemText(title: string, text: string) {
   await waitFor(element(actionMenuItem(title)))
     .toBeVisible()
     .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
   await waitFor(element(actionMenuItem(title)))
-    .toHaveText('')
+    .toHaveText(text)
     .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
 }
 
 /**
- * Asserts `title` is promoted to the toolbar with its title as text — no icon
- * set, or WITH_TEXT put the title beside the icon. Whether an icon sits next
- * to the text is not assertable: it is a compound drawable, not a view.
+ * Asserts `title` is promoted to the toolbar as an icon-only button, whose
+ * text AppCompat clears. Which icon it is cannot be asserted through Detox.
  */
-export async function expectTextActionItem(title: string) {
-  await waitFor(element(actionMenuItem(title)))
-    .toBeVisible()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
-  await waitFor(element(actionMenuItem(title)))
-    .toHaveText(title)
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
-}
+export const expectIconActionItem = (title: string) =>
+  expectActionItemText(title, '');
+
+/**
+ * Asserts `title` is promoted to the toolbar as a text button (no icon, or
+ * WITH_TEXT). An icon beside the text is a compound drawable — not assertable.
+ */
+export const expectTextActionItem = (title: string) =>
+  expectActionItemText(title, title);
 
 /** Asserts `title` is not promoted: the button is in neither form. */
 export async function expectNoActionItem(title: string) {
@@ -663,6 +656,15 @@ export async function expectNoActionItem(title: string) {
 // ---------------------------------------------------------------------------
 // Android toolbar overflow menu (Stack v5 header)
 // ---------------------------------------------------------------------------
+
+/**
+ * Detox's idle sync does not cover popup window animations, so waits that
+ * straddle the overflow menu opening or dismissing must be explicit.
+ */
+export const MENU_ANIMATION_TIMEOUT_MS = 5000;
+
+/** Probes an already-settled popup: by now it is either up or was never opened. */
+export const MENU_PRESENCE_TIMEOUT_MS = 250;
 
 /** The accessibility label AppCompat gives the overflow button. */
 export const OVERFLOW_MENU_LABEL = 'More options';
@@ -710,6 +712,16 @@ export function overflowMenuText(title: string): NativeMatcher {
 }
 
 /**
+ * Any row of the focused popup — the only handle on an entry with no title.
+ * Built per call: `atIndex` rewrites the matcher it is given on Android.
+ */
+export function overflowMenuRow(): NativeMatcher {
+  return by
+    .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
+    .withAncestor(overflowMenuMatcher());
+}
+
+/**
  * A toolbar action button, matched by label in both forms; icon-only buttons
  * have empty text, text buttons show `title`.
  */
@@ -724,15 +736,15 @@ export async function expectOverflowMenuOrder(
   const rows: { title: string; top: number }[] = [];
 
   for (const title of titles) {
-    const matches = await getMatches(overflowMenuText(title));
-    if (matches.length !== 1) {
-      throw new Error(`Expected a single menu row titled "${title}".`);
-    }
-    rows.push({ title, top: matches[0].frame.y });
+    const { frame } = await getSingleMatch(
+      overflowMenuText(title),
+      `menu row "${title}"`,
+    );
+    rows.push({ title, top: frame.y });
   }
 
-  const topToBottom = [...rows].sort((a, b) => a.top - b.top).map(r => r.title);
-  jestExpect(topToBottom).toEqual([...titles]);
+  rows.sort((a, b) => a.top - b.top);
+  jestExpect(rows.map(row => row.title)).toEqual(titles);
 }
 
 /** Asserts `title`'s row hosts a check box (multi-toggle group), not a radio. */
@@ -791,16 +803,19 @@ export function createOverflowMenuHelpers({
   scrollViewId,
   maxMenuDepth = 3,
 }: OverflowMenuControl) {
-  /**
-   * Detox searches one window: while a popup holds focus nothing behind it is
-   * in the hierarchy, so the popup going away is not enough — the screen
-   * itself has to become addressable again.
-   */
+  /** Detox searches the focused window only: the screen itself must be back. */
   const waitForScreen = async () => {
     await waitFor(element(by.id(scrollViewId)))
       .toBeVisible()
       .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
   };
+
+  /** `waitForScreen` reported rather than thrown — a stacked popup keeps it false. */
+  const isScreenAddressable = () =>
+    waitForScreen().then(
+      () => true,
+      () => false,
+    );
 
   /**
    * Back only ever goes to an open popup: with no menu up the activity takes
@@ -818,6 +833,12 @@ export function createOverflowMenuHelpers({
       }
       await device.pressBack();
       pressCount++;
+
+      // A popup lingers while animating out and would read as a second menu;
+      // the screen coming back settles it. If it does not, a parent popup is up.
+      if (await isScreenAddressable()) {
+        return;
+      }
     }
 
     if (pressCount > 0) {
@@ -825,11 +846,7 @@ export function createOverflowMenuHelpers({
     }
   };
 
-  /**
-   * Closes the menu even on failure: a leaked popup is never a local problem —
-   * every later matcher would resolve against the popup window instead of the
-   * activity, failing the rest of the suite on views that are plainly there.
-   */
+  /** Closes the menu even on failure — a leaked popup fails every later case. */
   const closingMenuAfter = async (assertions: () => Promise<void>) => {
     let assertionFailed = false;
 
@@ -930,6 +947,13 @@ export function barButtonIcon(iconId: string) {
  */
 export const CONTEXT_MENU_ANIMATION_TIMEOUT_MS = 2000;
 
+/**
+ * Tap point on the dismiss overlay, as a fraction of its width: the leading
+ * edge is clear of a trailing- or title-anchored platter (a platter tap only
+ * pops one level).
+ */
+const CONTEXT_MENU_DISMISS_X_FRACTION = 0.1;
+
 /** The list hosting the rows of the presented menu (or submenu). */
 export const contextMenu = () =>
   element(by.type(CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW));
@@ -981,7 +1005,7 @@ export function chevronFor(title: string) {
   return element(by.id('chevron.forward').withAncestor(menuRowMatcher(title)));
 }
 
-/** A menu row's icon by icon id; addressed by row title, since parent rows stay attached under a submenu. */
+/** A row's icon by id, scoped to its row: parent rows stay attached under a submenu. */
 export function menuRowIcon(iconId: string, title: string) {
   return element(
     by
@@ -1026,7 +1050,7 @@ export async function dismissContextMenu(
       by.type(CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW),
       'the context menu platter',
     ),
-    0.1,
+    CONTEXT_MENU_DISMISS_X_FRACTION,
   );
   await waitFor(contextMenu()).not.toExist().withTimeout(timeout);
 }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -8,9 +8,12 @@ import {
 import isVersionEqualOrHigherThan from './helpers/isVersionEqualOrHigherThan';
 import {
   CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
+  CLASS_NAME_ANDROID_APP_BAR_LAYOUT,
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
   CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
   CLASS_NAME_ANDROID_CHECK_BOX,
   CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
+  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
   CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
   CLASS_NAME_ANDROID_RADIO_BUTTON,
   CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
@@ -270,50 +273,6 @@ export async function expectLastClicked(
 
 type ElementAttributes = IosElementAttributes | AndroidElementAttributes;
 
-type ElementMatcher = {
-  /** Which matcher to resolve the element by. */
-  by: 'label' | 'id' | 'type';
-  /** The label text, testID, or native type name to match. */
-  value: string;
-  /** Disambiguate when the matcher resolves to multiple elements. */
-  index?: number;
-};
-
-function resolveMatcher({ by: matcher, value }: ElementMatcher) {
-  switch (matcher) {
-    case 'label':
-      return by.label(value);
-    case 'id':
-      return by.id(value);
-    case 'type':
-      return by.type(value);
-    default: {
-      const _exhaustive: never = matcher;
-      throw new Error(`Unsupported matcher: ${_exhaustive}`);
-    }
-  }
-}
-
-/** Attributes of exactly one element; throws on an ambiguous match. */
-export async function getElementAttributes(
-  matcher: ElementMatcher,
-): Promise<ElementAttributes> {
-  const target = element(resolveMatcher(matcher));
-  const attrs = await (matcher.index === undefined
-    ? target
-    : target.atIndex(matcher.index)
-  ).getAttributes();
-
-  if ('elements' in attrs) {
-    throw new Error(
-      `Multiple elements (${attrs.elements.length}) found for ${matcher.by}: "${matcher.value}". ` +
-        `Pass an \`index\` to disambiguate.`,
-    );
-  }
-
-  return attrs as ElementAttributes;
-}
-
 type Frame = ElementAttributes['frame'];
 
 /** Coordinate tap at (`xFraction`, 1/2) of `frame`, bypassing visibility checks. */
@@ -323,11 +282,7 @@ async function tapWithinFrame({ x, y, width, height }: Frame, xFraction = 0.5) {
 
 /** Coordinate tap (iOS) — bypasses Detox's visibility check. */
 export async function forceTapByLabeliOS(testLabel: string) {
-  const { frame } = await getElementAttributes({
-    by: 'label',
-    value: testLabel,
-  });
-  await tapWithinFrame(frame);
+  await tapWithinFrame(await getFrame(by.label(testLabel)));
 }
 
 export async function forceSelectTabByLabel(label: string) {
@@ -342,19 +297,17 @@ export async function forceSelectTabByLabel(label: string) {
 // iOS 26 tab bar bottom accessory
 // ---------------------------------------------------------------------------
 
-/** The accessory host view; a single match is asserted by `getElementAttributes`. */
+/** The accessory host view; a single match is asserted by `getSingleMatch`. */
 export const getBottomAccessoryAttributes = () =>
-  getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
-  }) as Promise<IosElementAttributes>;
+  getSingleMatch(
+    by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY),
+  ) as Promise<IosElementAttributes>;
 
-/** The `UITabBar`; a single match is asserted by `getElementAttributes`. */
+/** The `UITabBar`; a single match is asserted by `getSingleMatch`. */
 export const getTabBarAttributes = () =>
-  getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_UI_TAB_BAR,
-  }) as Promise<IosElementAttributes>;
+  getSingleMatch(
+    by.type(CLASS_NAME_UI_TAB_BAR),
+  ) as Promise<IosElementAttributes>;
 
 /** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
 export async function expectBottomAccessoryAboveTabBar() {
@@ -420,6 +373,23 @@ export async function countMatches(
   return (await getMatches(matcher, options)).length;
 }
 
+/** Attributes of `matcher`'s only match; throws when it resolves to several. */
+export async function getSingleMatch(
+  matcher: NativeMatcher,
+): Promise<ElementAttributes> {
+  const matches = await getMatches(matcher);
+  if (matches.length > 1) {
+    throw new Error(
+      `Matcher resolved to ${matches.length} elements, expected exactly one.`,
+    );
+  }
+  return matches[0];
+}
+
+export async function getFrame(matcher: NativeMatcher) {
+  return (await getSingleMatch(matcher)).frame;
+}
+
 /** Attributes of `matcher`'s last match — the topmost stacked screen's copy. */
 export async function getTopmostMatch(
   matcher: NativeMatcher,
@@ -428,11 +398,84 @@ export async function getTopmostMatch(
   return matches[matches.length - 1];
 }
 
+/** Trimmed text of the topmost screen's copy of `testID` (`''` when unset). */
+export async function readTopmostText(testID: string): Promise<string> {
+  const topmost = await getTopmostMatch(by.id(testID));
+  return (topmost.text ?? topmost.label ?? '').trim();
+}
+
+/** Scrolls `id` into view and returns its text (`''` when unset). */
+export async function readText(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+): Promise<string> {
+  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
+  return (await getSingleMatch(by.id(id))).text ?? '';
+}
+
 /** Taps the last match (topmost stacked screen). Pass a fresh matcher: `atIndex` mutates it on Android. */
 export async function tapTopmost(matcher: NativeMatcher): Promise<void> {
   await element(matcher)
     .atIndex((await countMatches(matcher)) - 1)
     .tap();
+}
+
+// ---------------------------------------------------------------------------
+// Stack v5 test screens: route information (Android, covered screens attached)
+// ---------------------------------------------------------------------------
+
+/** @see apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx */
+const ROUTE_KEY_TEST_ID = 'stack-route-key';
+
+/** The `Key: ...` label of the topmost screen. */
+const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
+
+/**
+ * Matches the route key label of any screen on `routeName`. Keys are minted as
+ * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
+ * so this pins the route, not the instance.
+ */
+const routeKeyPattern = (routeName: string) =>
+  new RegExp(`^Key: r-${routeName}-\\d+$`);
+
+/**
+ * Waits until the topmost screen is `routeName` and returns its route key. The
+ * key identifies the route *and* the instance, so one read settles continuity
+ * (same key) or a push (new key). Polled rather than `waitFor(...)`: Detox
+ * intersects a view only with its parents, never with an occluding sibling, so
+ * `toBeVisible()` on a buried screen passes at once and would not gate a pop.
+ */
+export async function waitForTopmostRoute(routeName: string): Promise<string> {
+  const pattern = routeKeyPattern(routeName);
+  let lastSeen = '<never read>';
+
+  await waitUntil(
+    async () => {
+      lastSeen = await readTopmostRouteKey();
+      return pattern.test(lastSeen);
+    },
+    {
+      message: () =>
+        `the topmost route to be "${routeName}"; topmost key was "${lastSeen}"`,
+    },
+  );
+
+  return lastSeen;
+}
+
+/**
+ * Taps a Push/Pop/Toggle button on the topmost stacked screen. React Native's
+ * core `<Button>` uppercases its `title` on Android, so pass the rendered text.
+ */
+export async function tapTopmostButton(title: string): Promise<void> {
+  await tapTopmost(by.text(title));
+}
+
+/** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
+export async function expectTopmostButtons(titles: string[]): Promise<void> {
+  for (const title of titles) {
+    await expectTopmostVisible(() => by.text(title));
+  }
 }
 
 /** Only "no match yet" / "not visible yet" are worth retrying. */
@@ -526,6 +569,90 @@ export const MENU_ANIMATION_TIMEOUT_MS = 5000;
 
 /** Probes an already-settled popup: by now it is either up or was never opened. */
 export const MENU_PRESENCE_TIMEOUT_MS = 250;
+
+// ---------------------------------------------------------------------------
+// Android Stack v5 header (toolbar) matchers
+// ---------------------------------------------------------------------------
+//
+// Factories, built fresh per call: on Android `atIndex` rewrites a matcher in
+// place (see `tapTopmost`), so a shared one would stay pinned to an index.
+
+/**
+ * The Stack v5 header's toolbar. Scoped to `MaterialToolbar` so it never
+ * matches the example app's own legacy header, a `CustomToolbar` — which
+ * extends `Toolbar` but not `MaterialToolbar`.
+ */
+export const stackV5Toolbar = (): NativeMatcher =>
+  by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
+
+/**
+ * The Stack v5 header's app bar. Every stacked screen keeps its own
+ * `AppBarLayout`, so the bare class matches several; only the Stack v5 header
+ * wraps a `MaterialToolbar`.
+ */
+export const stackV5AppBar = (): NativeMatcher =>
+  by.type(CLASS_NAME_ANDROID_APP_BAR_LAYOUT).withDescendant(stackV5Toolbar());
+
+/**
+ * The header's back chevron — the toolbar's navigation icon. A covered screen
+ * keeps its toolbar but loses its navigation icon, so while a headered screen
+ * is on top this resolves to that screen's chevron alone. Absence is not
+ * reliable: under a headerless top screen the covered screen's chevron is
+ * still there and still reads visible.
+ */
+export const stackV5BackButton = (): NativeMatcher =>
+  by
+    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
+    .withAncestor(stackV5Toolbar());
+
+/** A native header title, which renders as a `MaterialToolbar` child. */
+export const stackV5HeaderTitle = (title: string): NativeMatcher =>
+  by.text(title).withAncestor(stackV5Toolbar());
+
+/**
+ * A `showAsAction` change re-inflates the action menu, and a rotation does it
+ * from a configuration change, so the toolbar can lag an assertion.
+ */
+export const TOOLBAR_UPDATE_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
+
+/**
+ * Asserts `title` is promoted to the toolbar as an icon-only button. Asserted
+ * positively through the cleared text — on Android a negated matcher passes on
+ * a missing view. Which icon it is cannot be asserted through Detox.
+ */
+export async function expectIconActionItem(title: string) {
+  await waitFor(element(actionMenuItem(title)))
+    .toBeVisible()
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+  await waitFor(element(actionMenuItem(title)))
+    .toHaveText('')
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+}
+
+/**
+ * Asserts `title` is promoted to the toolbar with its title as text — no icon
+ * set, or WITH_TEXT put the title beside the icon. Whether an icon sits next
+ * to the text is not assertable: it is a compound drawable, not a view.
+ */
+export async function expectTextActionItem(title: string) {
+  await waitFor(element(actionMenuItem(title)))
+    .toBeVisible()
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+  await waitFor(element(actionMenuItem(title)))
+    .toHaveText(title)
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+}
+
+/** Asserts `title` is not promoted: the button is in neither form. */
+export async function expectNoActionItem(title: string) {
+  await waitFor(element(actionMenuItem(title)))
+    .not.toExist()
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
+}
+
+// ---------------------------------------------------------------------------
+// Android toolbar overflow menu (Stack v5 header)
+// ---------------------------------------------------------------------------
 
 /** The accessibility label AppCompat gives the overflow button. */
 export const OVERFLOW_MENU_LABEL = 'More options';
@@ -884,10 +1011,9 @@ export async function openContextMenu(
 export async function dismissContextMenu(
   timeout = CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
 ) {
-  const { frame } = await getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW,
-  });
-  await tapWithinFrame(frame, 0.1);
+  await tapWithinFrame(
+    await getFrame(by.type(CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW)),
+    0.1,
+  );
   await waitFor(contextMenu()).not.toExist().withTimeout(timeout);
 }

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -24,6 +24,7 @@ import {
   CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
   CLASS_NAME_UI_IMAGE_VIEW,
+  CLASS_NAME_UI_LABEL,
   CLASS_NAME_UI_MODERN_BAR_BUTTON,
   CLASS_NAME_UI_TAB_BAR,
 } from './native-class-names';
@@ -68,7 +69,8 @@ export const describeIfiPadOS26 =
 export type ScrollOptions = {
   /** Pixels per step. Smaller steps avoid overshooting a short row. */
   pixels?: number;
-  /** Swipe start, as a fraction of height. `NaN` leaves it to Detox. */
+  /** Swipe start, as a fraction of height. Keep it inside the view: on
+   * Android a `NaN`/0 start lands in the status bar and opens the shade. */
   startPercentage?: number;
   /** Scroll direction; `whileElement` only ever scrolls one way. */
   direction?: 'up' | 'down';
@@ -934,6 +936,11 @@ export function headerItem(
   );
 }
 
+/** The header title label. */
+export function headerTitle(title: string): NativeMatcher {
+  return by.type(CLASS_NAME_UI_LABEL).and(by.text(title));
+}
+
 /** A header item's icon, by icon id (SF Symbol name or asset path). */
 export function barButtonIcon(iconId: string) {
   return element(
@@ -1039,6 +1046,18 @@ export async function openContextMenu(
   } else {
     await anchor.tap();
   }
+  await waitFor(contextMenu()).toBeVisible().withTimeout(timeout);
+}
+
+/**
+ * Opens the menu attached to the header title. UIKit's title control fails
+ * Detox's visibility threshold, so the label is tapped by coordinates.
+ */
+export async function openHeaderTitleMenu(
+  title: string,
+  timeout = CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
+) {
+  await tapWithinFrame(await getFrame(headerTitle(title)));
   await waitFor(contextMenu()).toBeVisible().withTimeout(timeout);
 }
 

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -473,7 +473,7 @@ const MENU_DISMISS_PROBE_TIMEOUT_MS = 1000;
 export const OVERFLOW_MENU_LABEL = 'More options';
 
 /** The popup hosting the overflow menu (or, once opened, a submenu). */
-export const overflowMenuMatcher = (): NativeMatcher =>
+const overflowMenuMatcher = (): NativeMatcher =>
   by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW);
 
 export const overflowMenu = () => element(overflowMenuMatcher());

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -74,15 +74,8 @@ export type ScrollOptions = {
   direction?: 'up' | 'down';
 };
 
-/** A `testID`, or any matcher for targets that carry no `testID`. */
-export type ScrollTarget = string | NativeMatcher;
-
-function toMatcher(target: ScrollTarget): NativeMatcher {
-  return typeof target === 'string' ? by.id(target) : target;
-}
-
 export async function scrollUntilVisible(
-  target: ScrollTarget,
+  id: string,
   scrollViewId: string,
   {
     pixels = 600,
@@ -90,20 +83,24 @@ export async function scrollUntilVisible(
     direction = 'down',
   }: ScrollOptions = {},
 ) {
-  await waitFor(element(toMatcher(target)))
+  await waitFor(element(by.id(id)))
     .toBeVisible()
     .whileElement(by.id(scrollViewId))
     .scroll(pixels, direction, Number.NaN, startPercentage);
 }
 
-/** Rewinds to the top first — `whileElement` only scrolls one way. */
+/**
+ * Rewinds to the top first — `whileElement` only scrolls one way. Down only:
+ * rewinding to the top makes an upward scan pointless, so `direction` is
+ * rejected at the type level.
+ */
 export async function rewindAndScrollUntilVisible(
-  target: ScrollTarget,
+  id: string,
   scrollViewId: string,
-  options: ScrollOptions = {},
+  options: Omit<ScrollOptions, 'direction'> = {},
 ) {
   await element(by.id(scrollViewId)).scrollTo('top');
-  await scrollUntilVisible(target, scrollViewId, options);
+  await scrollUntilVisible(id, scrollViewId, options);
 }
 
 export async function selectIssueTestScreen(screenName: string) {

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -450,6 +450,18 @@ const ROUTE_KEY_TEST_ID = 'stack-route-key';
 const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
 
 /**
+ * Waits for the `Name: <routeName>` label to be visible. Only where that
+ * label is unique in the hierarchy — iOS (covered screens are detached) or an
+ * Android stack that never holds two screens of one route; otherwise use
+ * `waitForTopmostRoute`, which reads the topmost copy.
+ */
+export async function waitForRouteName(routeName: string): Promise<void> {
+  await waitFor(element(by.text(`Name: ${routeName}`)))
+    .toBeVisible()
+    .withTimeout(DEFAULT_TIMEOUT_MS);
+}
+
+/**
  * Matches the route key label of any screen on `routeName`. Keys are minted as
  * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
  * so this pins the route, not the instance.

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -282,7 +282,9 @@ async function tapWithinFrame({ x, y, width, height }: Frame, xFraction = 0.5) {
 
 /** Coordinate tap (iOS) — bypasses Detox's visibility check. */
 export async function forceTapByLabeliOS(testLabel: string) {
-  await tapWithinFrame(await getFrame(by.label(testLabel)));
+  await tapWithinFrame(
+    await getFrame(by.label(testLabel), `label "${testLabel}"`),
+  );
 }
 
 export async function forceSelectTabByLabel(label: string) {
@@ -301,12 +303,14 @@ export async function forceSelectTabByLabel(label: string) {
 export const getBottomAccessoryAttributes = () =>
   getSingleMatch(
     by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY),
+    'the bottom accessory',
   ) as Promise<IosElementAttributes>;
 
 /** The `UITabBar`; a single match is asserted by `getSingleMatch`. */
 export const getTabBarAttributes = () =>
   getSingleMatch(
     by.type(CLASS_NAME_UI_TAB_BAR),
+    'the UITabBar',
   ) as Promise<IosElementAttributes>;
 
 /** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
@@ -373,21 +377,27 @@ export async function countMatches(
   return (await getMatches(matcher, options)).length;
 }
 
-/** Attributes of `matcher`'s only match; throws when it resolves to several. */
+/**
+ * Attributes of `matcher`'s only match; throws when it resolves to several.
+ * A Detox matcher does not stringify, so pass `description` (e.g. the testID)
+ * to name the target in that error.
+ */
 export async function getSingleMatch(
   matcher: NativeMatcher,
+  description = 'matcher',
 ): Promise<ElementAttributes> {
   const matches = await getMatches(matcher);
   if (matches.length > 1) {
     throw new Error(
-      `Matcher resolved to ${matches.length} elements, expected exactly one.`,
+      `${description} resolved to ${matches.length} elements, expected exactly one. ` +
+        'Narrow the matcher, or the view hierarchy changed.',
     );
   }
   return matches[0];
 }
 
-export async function getFrame(matcher: NativeMatcher) {
-  return (await getSingleMatch(matcher)).frame;
+export async function getFrame(matcher: NativeMatcher, description?: string) {
+  return (await getSingleMatch(matcher, description)).frame;
 }
 
 /** Attributes of `matcher`'s last match — the topmost stacked screen's copy. */
@@ -410,7 +420,7 @@ export async function readText(
   { scrollViewId, ...scroll }: SettingsControlOptions,
 ): Promise<string> {
   await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
-  return (await getSingleMatch(by.id(id))).text ?? '';
+  return (await getSingleMatch(by.id(id), `id "${id}"`)).text ?? '';
 }
 
 /** Taps the last match (topmost stacked screen). Pass a fresh matcher: `atIndex` mutates it on Android. */
@@ -1012,7 +1022,10 @@ export async function dismissContextMenu(
   timeout = CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
 ) {
   await tapWithinFrame(
-    await getFrame(by.type(CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW)),
+    await getFrame(
+      by.type(CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW),
+      'the context menu platter',
+    ),
     0.1,
   );
   await waitFor(contextMenu()).not.toExist().withTimeout(timeout);

--- a/FabricExample/e2e/e2e-utils.ts
+++ b/FabricExample/e2e/e2e-utils.ts
@@ -31,8 +31,10 @@ import {
 
 const { getIOSVersionNumber } = require('../../scripts/e2e/ios-devices.js');
 
-/** Default for waits Detox's idle sync already mostly covers. */
-export const DEFAULT_TIMEOUT_MS = 3000;
+// ---------------------------------------------------------------------------
+// Platform and OS-version gates
+// → structure PR: framework/platform.ts
+// ---------------------------------------------------------------------------
 
 export const describeIfiOS =
   device.getPlatform() === 'ios' ? describe : describe.skip;
@@ -66,284 +68,56 @@ export const describeIfiOS26 = isIOSVersionAtLeast('26.0')
 export const describeIfiPadOS26 =
   isIPadTarget && isIOSVersionAtLeast('26.0') ? describe : describe.skip;
 
-export type ScrollOptions = {
-  /** Pixels per step. Smaller steps avoid overshooting a short row. */
-  pixels?: number;
-  /** Swipe start, as a fraction of height. Keep it inside the view: on
-   * Android a `NaN`/0 start lands in the status bar and opens the shade. */
-  startPercentage?: number;
-  /** Scroll direction; `whileElement` only ever scrolls one way. */
-  direction?: 'up' | 'down';
-};
+// ---------------------------------------------------------------------------
+// Generic polling
+// → structure PR: framework/wait.ts
+// ---------------------------------------------------------------------------
 
-export async function scrollUntilVisible(
-  id: string,
-  scrollViewId: string,
-  {
-    pixels = 600,
-    startPercentage = 0.85,
-    direction = 'down',
-  }: ScrollOptions = {},
-) {
-  await waitFor(element(by.id(id)))
-    .toBeVisible()
-    .whileElement(by.id(scrollViewId))
-    .scroll(pixels, direction, Number.NaN, startPercentage);
-}
+/** Default for waits Detox's idle sync already mostly covers. */
+export const DEFAULT_TIMEOUT_MS = 3000;
 
-/**
- * Rewinds to the top first — `whileElement` only scrolls one way. Down only:
- * rewinding to the top makes an upward scan pointless, so `direction` is
- * rejected at the type level.
- */
-export async function rewindAndScrollUntilVisible(
-  id: string,
-  scrollViewId: string,
-  options: Omit<ScrollOptions, 'direction'> = {},
-) {
-  await element(by.id(scrollViewId)).scrollTo('top');
-  await scrollUntilVisible(id, scrollViewId, options);
-}
-
-export async function selectIssueTestScreen(screenName: string) {
-  await scrollUntilVisible(
-    'root-screen-issue-tests',
-    'root-screen-examples-scrollview',
-  );
-  await element(by.id('root-screen-issue-tests')).tap();
-
-  await waitFor(element(by.id('issue-tests-scrollview'))).toBeVisible();
-
-  if (device.getPlatform() === 'android') {
-    await element(by.label('Search')).tap();
-
-    // Only way found to reach the search input: matching by type
-    // (androidx.appcompat.widget.SearchView.SearchAutoComplete) fails even
-    // though it shows up in Detox's view hierarchy.
-    await element(by.text('')).replaceText(screenName);
-  } else if (device.getPlatform() === 'ios') {
-    await element(by.traits(['searchField'])).typeText(screenName);
-  }
-
-  await expect(element(by.id(`issue-tests-${screenName}`))).toBeVisible();
-  await element(by.id(`issue-tests-${screenName}`)).tap();
-}
-
-/** Root → `section` list → `scenarioGroup` list → `screenKey`. */
-async function selectTestsScreen(
-  section: 'single-feature-tests' | 'component-integration-tests',
-  scenarioGroup: string,
-  screenKey: string,
-) {
-  const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
-  const sectionScrollView = `${section}-scrollview`;
-  const groupScrollView = `${scenarioGroupId}-scenarios-scrollview`;
-
-  await scrollToAndTapInList(
-    `root-screen-${section}`,
-    'root-screen-examples-scrollview',
-  );
-  await waitFor(element(by.id(sectionScrollView)))
-    .toBeVisible()
-    .withTimeout(DEFAULT_TIMEOUT_MS);
-
-  await scrollToAndTapInList(
-    `${section}-${scenarioGroupId}`,
-    sectionScrollView,
-  );
-  await waitFor(element(by.id(groupScrollView)))
-    .toBeVisible()
-    .withTimeout(DEFAULT_TIMEOUT_MS);
-
-  await scrollToAndTapInList(screenKey, groupScrollView);
-}
-
-async function scrollToAndTapInList(id: string, scrollViewId: string) {
-  await scrollUntilVisible(id, scrollViewId);
-  await element(by.id(id)).tap();
-}
-
-export const selectSingleFeatureTestsScreen = (
-  scenarioGroup: string,
-  screenKey: string,
-) => selectTestsScreen('single-feature-tests', scenarioGroup, screenKey);
-
-export const selectComponentIntegrationTestsScreen = (
-  scenarioGroup: string,
-  screenKey: string,
-) => selectTestsScreen('component-integration-tests', scenarioGroup, screenKey);
-
-/** @see apps/src/shared/SettingsPicker.tsx — derives option `testID`s. */
-export function pickerOptionId(pickerLabel: string, option: string): string {
-  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
-}
-
-export type SettingsControlOptions = ScrollOptions & { scrollViewId: string };
-
-/** Rewinds, scrolls `id` into view and taps it. */
-export async function scrollToAndTap(
-  id: string,
-  { scrollViewId, ...scroll }: SettingsControlOptions,
-) {
-  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
-  await element(by.id(id)).tap();
-}
-
-type PickerSelection = {
-  pickerId: string;
-  /** The picker's `label` prop — option `testID`s are derived from it. */
-  label: string;
-  option: string;
+type WaitUntilOptions = {
+  /** How long to keep polling before failing, in milliseconds. */
+  timeout?: number;
+  /** Delay between two `predicate` calls, in milliseconds. */
+  interval?: number;
+  /** What was awaited, appended to the timeout error. A function can build it
+   * from whatever the last `predicate` call observed. */
+  message: string | (() => string);
 };
 
 /**
- * Sets a picker to `option` and closes it (open option rows collide with the
- * `by.text` popup matchers). No-op when it already shows `option`. Omit
- * `control` for pickers outside a scroll view — they are tapped in place.
+ * Polls `predicate` until `true` or `timeout`. Prefer Detox's `waitFor`; use
+ * this only for conditions it cannot express, e.g. match counts.
  */
-export async function selectPickerOption(
-  { pickerId, label, option }: PickerSelection,
-  control?: SettingsControlOptions,
-) {
-  const expected = `${label}: ${option}`;
+export async function waitUntil(
+  predicate: () => Promise<boolean>,
+  { timeout = DEFAULT_TIMEOUT_MS, interval = 100, message }: WaitUntilOptions,
+): Promise<void> {
+  const deadline = Date.now() + timeout;
 
-  // Already set. Asserted collapsed: one left open by an earlier failure would
-  // collide with later `by.text` matchers.
-  if (textOf(await getTopmostMatch(by.id(pickerId))) === expected) {
-    await expect(element(by.id(pickerOptionId(label, option)))).not.toExist();
-    return;
-  }
-
-  const tap = async (id: string) => {
-    if (control) {
-      await scrollToAndTap(id, control);
-    } else {
-      await element(by.id(id)).tap();
+  while (Date.now() <= deadline) {
+    if (await predicate()) {
+      return;
     }
-  };
-
-  await tap(pickerId);
-  await tap(pickerOptionId(label, option));
-  await tap(pickerId);
-
-  await expectPickerValue(pickerId, expected);
-}
-
-/** The value is an RN `Text`: `text` on Android, `label` on iOS. */
-async function expectPickerValue(pickerId: string, expected: string) {
-  if (device.getPlatform() === 'ios') {
-    await expect(element(by.id(pickerId))).toHaveLabel(expected);
-  } else {
-    await expect(element(by.id(pickerId))).toHaveText(expected);
+    await new Promise(resolve => setTimeout(resolve, interval));
   }
-}
 
-/** `to` is the state expected afterwards — a swallowed tap fails here. Omit
- * `control` on screens whose switches sit outside any scroll view. */
-type SwitchToggle = {
-  switchId: string;
-  /** The switch's `label` prop. */
-  label: string;
-  /** The state expected after the tap. */
-  to: boolean;
-};
-
-export async function toggleSettingsSwitch(
-  { switchId, label, to }: SwitchToggle,
-  control?: SettingsControlOptions,
-) {
-  if (control) {
-    const { scrollViewId, ...scroll } = control;
-    await rewindAndScrollUntilVisible(switchId, scrollViewId, scroll);
-  }
-  await element(by.id(switchId)).tap();
-
-  await expect(element(by.text(`${label}: ${to}`))).toBeVisible();
-}
-
-/** Asserts the toolbar-menu screens' `Last clicked: <id>` line. */
-export async function expectLastClicked(
-  id: string,
-  { scrollViewId, ...scroll }: SettingsControlOptions,
-) {
-  await rewindAndScrollUntilVisible('last-clicked-text', scrollViewId, scroll);
-  await expect(element(by.id('last-clicked-text'))).toHaveText(
-    `Last clicked: ${id}`,
+  throw new Error(
+    `waitUntil timed out after ${timeout}ms: ${
+      typeof message === 'function' ? message() : message
+    }`,
   );
 }
+
+// ---------------------------------------------------------------------------
+// Element matches and attributes
+// → structure PR: framework/matchers.ts
+// ---------------------------------------------------------------------------
 
 type ElementAttributes = IosElementAttributes | AndroidElementAttributes;
 
 type Frame = ElementAttributes['frame'];
-
-/** Coordinate tap at (`xFraction`, 1/2) of `frame`, bypassing visibility checks. */
-async function tapWithinFrame({ x, y, width, height }: Frame, xFraction = 0.5) {
-  await device.tap({ x: x + width * xFraction, y: y + height / 2 });
-}
-
-/** Coordinate tap (iOS) — bypasses Detox's visibility check. */
-export async function forceTapByLabeliOS(testLabel: string) {
-  await tapWithinFrame(
-    await getFrame(by.label(testLabel), `label "${testLabel}"`),
-  );
-}
-
-export async function forceSelectTabByLabel(label: string) {
-  if (device.getPlatform() === 'ios') {
-    await forceTapByLabeliOS(label);
-  } else {
-    await element(by.label(label)).tap();
-  }
-}
-
-// ---------------------------------------------------------------------------
-// iOS 26 tab bar bottom accessory
-// ---------------------------------------------------------------------------
-
-/**
- * The first match — UIKit can keep more than one host view / tab bar in the
- * hierarchy (an accessory mid-transition, a sidebar and tab bar pair on iPad).
- */
-async function getFirstMatch(matcher: NativeMatcher) {
-  return (await getMatches(matcher))[0] as IosElementAttributes;
-}
-
-/** The accessory host view. */
-export const getBottomAccessoryAttributes = () =>
-  getFirstMatch(by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY));
-
-/** The `UITabBar`. */
-export const getTabBarAttributes = () =>
-  getFirstMatch(by.type(CLASS_NAME_UI_TAB_BAR));
-
-/** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
-export async function expectBottomAccessoryAboveTabBar() {
-  const bottomAccessory = await getBottomAccessoryAttributes();
-  const tabBar = await getTabBarAttributes();
-  jestExpect(tabBar.frame.y).toBeGreaterThan(
-    bottomAccessory.frame.y + bottomAccessory.frame.height,
-  );
-}
-
-export async function dismissToast(message: string) {
-  await waitFor(element(by.label(message)))
-    .toBeVisible()
-    .withTimeout(DEFAULT_TIMEOUT_MS);
-  await element(by.label(message)).tap();
-}
-
-/** Dismisses the head of the toast queue — always `1.` if each is dismissed. */
-export async function dismissNextToast(message: string) {
-  await dismissToast(`1. ${message}`);
-}
-
-/**
- * Detox matches a regex against the *whole* string — without the trailing `.*`
- * this matches nothing and always passes.
- */
-export async function expectNoToast() {
-  await expect(element(by.label(/\d+\. .*/))).not.toExist();
-}
 
 type MatchOptions = {
   /**
@@ -423,13 +197,60 @@ export async function readTopmostText(testID: string): Promise<string> {
   return textOf(await getTopmostMatch(by.id(testID)));
 }
 
-/** Scrolls `id` into view and returns its text (`''` when unset). */
-export async function readText(
+// ---------------------------------------------------------------------------
+// Scrolling and tapping
+// → structure PR: framework/gestures.ts
+// ---------------------------------------------------------------------------
+
+export type ScrollOptions = {
+  /** Pixels per step. Smaller steps avoid overshooting a short row. */
+  pixels?: number;
+  /** Swipe start, as a fraction of height. Keep it inside the view: on
+   * Android a `NaN`/0 start lands in the status bar and opens the shade. */
+  startPercentage?: number;
+  /** Scroll direction; `whileElement` only ever scrolls one way. */
+  direction?: 'up' | 'down';
+};
+
+export async function scrollUntilVisible(
   id: string,
-  { scrollViewId, ...scroll }: SettingsControlOptions,
-): Promise<string> {
-  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
-  return textOf(await getSingleMatch(by.id(id), `id "${id}"`));
+  scrollViewId: string,
+  {
+    pixels = 600,
+    startPercentage = 0.85,
+    direction = 'down',
+  }: ScrollOptions = {},
+) {
+  await waitFor(element(by.id(id)))
+    .toBeVisible()
+    .whileElement(by.id(scrollViewId))
+    .scroll(pixels, direction, Number.NaN, startPercentage);
+}
+
+/**
+ * Rewinds to the top first — `whileElement` only scrolls one way. Down only:
+ * rewinding to the top makes an upward scan pointless, so `direction` is
+ * rejected at the type level.
+ */
+export async function rewindAndScrollUntilVisible(
+  id: string,
+  scrollViewId: string,
+  options: Omit<ScrollOptions, 'direction'> = {},
+) {
+  await element(by.id(scrollViewId)).scrollTo('top');
+  await scrollUntilVisible(id, scrollViewId, options);
+}
+
+/** Coordinate tap at (`xFraction`, 1/2) of `frame`, bypassing visibility checks. */
+async function tapWithinFrame({ x, y, width, height }: Frame, xFraction = 0.5) {
+  await device.tap({ x: x + width * xFraction, y: y + height / 2 });
+}
+
+/** Coordinate tap (iOS) — bypasses Detox's visibility check. */
+export async function forceTapByLabeliOS(testLabel: string) {
+  await tapWithinFrame(
+    await getFrame(by.label(testLabel), `label "${testLabel}"`),
+  );
 }
 
 /** Taps the last match (topmost stacked screen). Pass a fresh matcher: `atIndex` mutates it on Android. */
@@ -437,62 +258,6 @@ export async function tapTopmost(matcher: NativeMatcher): Promise<void> {
   await element(matcher)
     .atIndex((await countMatches(matcher)) - 1)
     .tap();
-}
-
-// ---------------------------------------------------------------------------
-// Stack v5 test screens: route information (Android, covered screens attached)
-// ---------------------------------------------------------------------------
-
-/** @see apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx */
-const ROUTE_KEY_TEST_ID = 'stack-route-key';
-
-/** The `Key: ...` label of the topmost screen. */
-const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
-
-/**
- * Waits for the `Name: <routeName>` label to be visible. Only where that
- * label is unique in the hierarchy — iOS (covered screens are detached) or an
- * Android stack that never holds two screens of one route; otherwise use
- * `waitForTopmostRoute`, which reads the topmost copy.
- */
-export async function waitForRouteName(routeName: string): Promise<void> {
-  await waitFor(element(by.text(`Name: ${routeName}`)))
-    .toBeVisible()
-    .withTimeout(DEFAULT_TIMEOUT_MS);
-}
-
-/**
- * Matches the route key label of any screen on `routeName`. Keys are minted as
- * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
- * so this pins the route, not the instance.
- */
-const routeKeyPattern = (routeName: string) =>
-  new RegExp(`^Key: r-${escapeRegExp(routeName)}-\\d+$`);
-
-const escapeRegExp = (value: string) =>
-  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-
-/**
- * Waits until the topmost screen is `routeName` and returns its route key,
- * which pins the instance too (same key: preserved; new key: pushed). Polled:
- * `toBeVisible()` passes on a buried screen, so `waitFor` would not gate a pop.
- */
-export async function waitForTopmostRoute(routeName: string): Promise<string> {
-  const pattern = routeKeyPattern(routeName);
-  let lastSeen = '<never read>';
-
-  await waitUntil(
-    async () => {
-      lastSeen = await readTopmostRouteKey();
-      return pattern.test(lastSeen);
-    },
-    {
-      message: () =>
-        `the topmost route to be "${routeName}"; topmost key was "${lastSeen}"`,
-    },
-  );
-
-  return lastSeen;
 }
 
 /**
@@ -503,12 +268,10 @@ export async function tapTopmostButton(title: string): Promise<void> {
   await tapTopmost(by.text(title));
 }
 
-/** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
-export async function expectTopmostButtons(titles: string[]): Promise<void> {
-  for (const title of titles) {
-    await expectTopmostVisible(() => by.text(title));
-  }
-}
+// ---------------------------------------------------------------------------
+// Shared assertions
+// → structure PR: framework/assertions.ts
+// ---------------------------------------------------------------------------
 
 /** Only "no match yet" (Espresso / iOS wording) and "not visible yet" retry. */
 function isTransientMatchError(error: unknown): boolean {
@@ -554,45 +317,57 @@ export async function expectTopmostVisible(
   );
 }
 
-type WaitUntilOptions = {
-  /** How long to keep polling before failing, in milliseconds. */
-  timeout?: number;
-  /** Delay between two `predicate` calls, in milliseconds. */
-  interval?: number;
-  /** What was awaited, appended to the timeout error. A function can build it
-   * from whatever the last `predicate` call observed. */
-  message: string | (() => string);
-};
+/** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
+export async function expectTopmostButtons(titles: string[]): Promise<void> {
+  for (const title of titles) {
+    await expectTopmostVisible(() => by.text(title));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Tab bar (incl. the iOS 26 bottom accessory)
+// → structure PR: framework/tab-bar.ts
+// ---------------------------------------------------------------------------
+
+export async function forceSelectTabByLabel(label: string) {
+  if (device.getPlatform() === 'ios') {
+    await forceTapByLabeliOS(label);
+  } else {
+    await element(by.label(label)).tap();
+  }
+}
 
 /**
- * Polls `predicate` until `true` or `timeout`. Prefer Detox's `waitFor`; use
- * this only for conditions it cannot express, e.g. match counts.
+ * The first match — UIKit can keep more than one host view / tab bar in the
+ * hierarchy (an accessory mid-transition, a sidebar and tab bar pair on iPad).
  */
-export async function waitUntil(
-  predicate: () => Promise<boolean>,
-  { timeout = DEFAULT_TIMEOUT_MS, interval = 100, message }: WaitUntilOptions,
-): Promise<void> {
-  const deadline = Date.now() + timeout;
+async function getFirstMatch(matcher: NativeMatcher) {
+  return (await getMatches(matcher))[0] as IosElementAttributes;
+}
 
-  while (Date.now() <= deadline) {
-    if (await predicate()) {
-      return;
-    }
-    await new Promise(resolve => setTimeout(resolve, interval));
-  }
+/** The accessory host view. */
+export const getBottomAccessoryAttributes = () =>
+  getFirstMatch(by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY));
 
-  throw new Error(
-    `waitUntil timed out after ${timeout}ms: ${
-      typeof message === 'function' ? message() : message
-    }`,
+/** The `UITabBar`. */
+export const getTabBarAttributes = () =>
+  getFirstMatch(by.type(CLASS_NAME_UI_TAB_BAR));
+
+/** Asserts the accessory sits above the tab bar (iPhone "extended" layout). */
+export async function expectBottomAccessoryAboveTabBar() {
+  const bottomAccessory = await getBottomAccessoryAttributes();
+  const tabBar = await getTabBarAttributes();
+  jestExpect(tabBar.frame.y).toBeGreaterThan(
+    bottomAccessory.frame.y + bottomAccessory.frame.height,
   );
 }
 
 // ---------------------------------------------------------------------------
-// Android Stack v5 header (toolbar) matchers
-// ---------------------------------------------------------------------------
+// Android Stack v5 header (toolbar): matchers and action items
+// → structure PR: framework/stack-header-android.ts
 //
 // Factories: on Android `atIndex` rewrites a matcher in place (see `tapTopmost`).
+// ---------------------------------------------------------------------------
 
 /**
  * The Stack v5 header's toolbar. Scoped to `MaterialToolbar` so it never
@@ -623,6 +398,14 @@ export const stackV5BackButton = (): NativeMatcher =>
 /** A native header title, which renders as a `MaterialToolbar` child. */
 export const stackV5HeaderTitle = (title: string): NativeMatcher =>
   by.text(title).withAncestor(stackV5Toolbar());
+
+/**
+ * A toolbar action button, matched by label in both forms; icon-only buttons
+ * have empty text, text buttons show `title`.
+ */
+export function actionMenuItem(title: string): NativeMatcher {
+  return by.label(title).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
+}
 
 /**
  * A `showAsAction` change re-inflates the action menu, and a rotation does it
@@ -666,6 +449,7 @@ export async function expectNoActionItem(title: string) {
 
 // ---------------------------------------------------------------------------
 // Android toolbar overflow menu (Stack v5 header)
+// → structure PR: framework/toolbar-menu-android.ts
 // ---------------------------------------------------------------------------
 
 /**
@@ -733,14 +517,6 @@ export function overflowMenuRow(): NativeMatcher {
   return by
     .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
     .withAncestor(overflowMenuMatcher());
-}
-
-/**
- * A toolbar action button, matched by label in both forms; icon-only buttons
- * have empty text, text buttons show `title`.
- */
-export function actionMenuItem(title: string): NativeMatcher {
-  return by.label(title).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
 }
 
 /** Asserts the open popup lists `titles` top to bottom in this order. */
@@ -922,6 +698,7 @@ export function createOverflowMenuHelpers({
 
 // ---------------------------------------------------------------------------
 // iOS Stack v5 header items (UIBarButtonItem)
+// → structure PR: framework/context-menu-ios.ts (or its own header-items-ios.ts)
 // ---------------------------------------------------------------------------
 
 export type HeaderItemOptions = {
@@ -962,6 +739,7 @@ export function barButtonIcon(iconId: string) {
 
 // ---------------------------------------------------------------------------
 // iOS context menu (UIMenu presented from a header item or the title)
+// → structure PR: framework/context-menu-ios.ts
 // ---------------------------------------------------------------------------
 
 /**
@@ -1088,4 +866,272 @@ export async function dismissContextMenu(
     CONTEXT_MENU_DISMISS_X_FRACTION,
   );
   await waitFor(contextMenu()).not.toExist().withTimeout(timeout);
+}
+
+// ---------------------------------------------------------------------------
+// Example app navigation to test screens
+// → structure PR: app/test-screen-navigation.ts
+// ---------------------------------------------------------------------------
+
+export async function selectIssueTestScreen(screenName: string) {
+  await scrollUntilVisible(
+    'root-screen-issue-tests',
+    'root-screen-examples-scrollview',
+  );
+  await element(by.id('root-screen-issue-tests')).tap();
+
+  await waitFor(element(by.id('issue-tests-scrollview'))).toBeVisible();
+
+  if (device.getPlatform() === 'android') {
+    await element(by.label('Search')).tap();
+
+    // Only way found to reach the search input: matching by type
+    // (androidx.appcompat.widget.SearchView.SearchAutoComplete) fails even
+    // though it shows up in Detox's view hierarchy.
+    await element(by.text('')).replaceText(screenName);
+  } else if (device.getPlatform() === 'ios') {
+    await element(by.traits(['searchField'])).typeText(screenName);
+  }
+
+  await expect(element(by.id(`issue-tests-${screenName}`))).toBeVisible();
+  await element(by.id(`issue-tests-${screenName}`)).tap();
+}
+
+/** Root → `section` list → `scenarioGroup` list → `screenKey`. */
+async function selectTestsScreen(
+  section: 'single-feature-tests' | 'component-integration-tests',
+  scenarioGroup: string,
+  screenKey: string,
+) {
+  const scenarioGroupId = scenarioGroup.replace(/\s/g, '');
+  const sectionScrollView = `${section}-scrollview`;
+  const groupScrollView = `${scenarioGroupId}-scenarios-scrollview`;
+
+  await scrollToAndTapInList(
+    `root-screen-${section}`,
+    'root-screen-examples-scrollview',
+  );
+  await waitFor(element(by.id(sectionScrollView)))
+    .toBeVisible()
+    .withTimeout(DEFAULT_TIMEOUT_MS);
+
+  await scrollToAndTapInList(
+    `${section}-${scenarioGroupId}`,
+    sectionScrollView,
+  );
+  await waitFor(element(by.id(groupScrollView)))
+    .toBeVisible()
+    .withTimeout(DEFAULT_TIMEOUT_MS);
+
+  await scrollToAndTapInList(screenKey, groupScrollView);
+}
+
+async function scrollToAndTapInList(id: string, scrollViewId: string) {
+  await scrollUntilVisible(id, scrollViewId);
+  await element(by.id(id)).tap();
+}
+
+export const selectSingleFeatureTestsScreen = (
+  scenarioGroup: string,
+  screenKey: string,
+) => selectTestsScreen('single-feature-tests', scenarioGroup, screenKey);
+
+export const selectComponentIntegrationTestsScreen = (
+  scenarioGroup: string,
+  screenKey: string,
+) => selectTestsScreen('component-integration-tests', scenarioGroup, screenKey);
+
+// ---------------------------------------------------------------------------
+// Test-screen settings controls and readouts
+// → structure PR: app/settings-controls.ts
+// ---------------------------------------------------------------------------
+
+/** @see apps/src/shared/SettingsPicker.tsx — derives option `testID`s. */
+export function pickerOptionId(pickerLabel: string, option: string): string {
+  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
+}
+
+export type SettingsControlOptions = ScrollOptions & { scrollViewId: string };
+
+/** Rewinds, scrolls `id` into view and taps it. */
+export async function scrollToAndTap(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+) {
+  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
+  await element(by.id(id)).tap();
+}
+
+type PickerSelection = {
+  pickerId: string;
+  /** The picker's `label` prop — option `testID`s are derived from it. */
+  label: string;
+  option: string;
+};
+
+/**
+ * Sets a picker to `option` and closes it (open option rows collide with the
+ * `by.text` popup matchers). No-op when it already shows `option`. Omit
+ * `control` for pickers outside a scroll view — they are tapped in place.
+ */
+export async function selectPickerOption(
+  { pickerId, label, option }: PickerSelection,
+  control?: SettingsControlOptions,
+) {
+  const expected = `${label}: ${option}`;
+
+  // Already set. Asserted collapsed: one left open by an earlier failure would
+  // collide with later `by.text` matchers.
+  if (textOf(await getTopmostMatch(by.id(pickerId))) === expected) {
+    await expect(element(by.id(pickerOptionId(label, option)))).not.toExist();
+    return;
+  }
+
+  const tap = async (id: string) => {
+    if (control) {
+      await scrollToAndTap(id, control);
+    } else {
+      await element(by.id(id)).tap();
+    }
+  };
+
+  await tap(pickerId);
+  await tap(pickerOptionId(label, option));
+  await tap(pickerId);
+
+  await expectPickerValue(pickerId, expected);
+}
+
+/** The value is an RN `Text`: `text` on Android, `label` on iOS. */
+async function expectPickerValue(pickerId: string, expected: string) {
+  if (device.getPlatform() === 'ios') {
+    await expect(element(by.id(pickerId))).toHaveLabel(expected);
+  } else {
+    await expect(element(by.id(pickerId))).toHaveText(expected);
+  }
+}
+
+/** `to` is the state expected afterwards — a swallowed tap fails here. Omit
+ * `control` on screens whose switches sit outside any scroll view. */
+type SwitchToggle = {
+  switchId: string;
+  /** The switch's `label` prop. */
+  label: string;
+  /** The state expected after the tap. */
+  to: boolean;
+};
+
+export async function toggleSettingsSwitch(
+  { switchId, label, to }: SwitchToggle,
+  control?: SettingsControlOptions,
+) {
+  if (control) {
+    const { scrollViewId, ...scroll } = control;
+    await rewindAndScrollUntilVisible(switchId, scrollViewId, scroll);
+  }
+  await element(by.id(switchId)).tap();
+
+  await expect(element(by.text(`${label}: ${to}`))).toBeVisible();
+}
+
+/** Scrolls `id` into view and returns its text (`''` when unset). */
+export async function readText(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+): Promise<string> {
+  await rewindAndScrollUntilVisible(id, scrollViewId, scroll);
+  return textOf(await getSingleMatch(by.id(id), `id "${id}"`));
+}
+
+/** Asserts the toolbar-menu screens' `Last clicked: <id>` line. */
+export async function expectLastClicked(
+  id: string,
+  { scrollViewId, ...scroll }: SettingsControlOptions,
+) {
+  await rewindAndScrollUntilVisible('last-clicked-text', scrollViewId, scroll);
+  await expect(element(by.id('last-clicked-text'))).toHaveText(
+    `Last clicked: ${id}`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Toast queue
+// → structure PR: app/toast.ts
+// ---------------------------------------------------------------------------
+
+export async function dismissToast(message: string) {
+  await waitFor(element(by.label(message)))
+    .toBeVisible()
+    .withTimeout(DEFAULT_TIMEOUT_MS);
+  await element(by.label(message)).tap();
+}
+
+/** Dismisses the head of the toast queue — always `1.` if each is dismissed. */
+export async function dismissNextToast(message: string) {
+  await dismissToast(`1. ${message}`);
+}
+
+/**
+ * Detox matches a regex against the *whole* string — without the trailing `.*`
+ * this matches nothing and always passes.
+ */
+export async function expectNoToast() {
+  await expect(element(by.label(/\d+\. .*/))).not.toExist();
+}
+
+// ---------------------------------------------------------------------------
+// Stack v5 test screens: route information
+// → structure PR: app/stack-route.ts (not in the guide yet)
+// ---------------------------------------------------------------------------
+
+/** @see apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx */
+const ROUTE_KEY_TEST_ID = 'stack-route-key';
+
+/** The `Key: ...` label of the topmost screen. */
+const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
+
+/**
+ * Matches the route key label of any screen on `routeName`. Keys are minted as
+ * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
+ * so this pins the route, not the instance.
+ */
+const routeKeyPattern = (routeName: string) =>
+  new RegExp(`^Key: r-${escapeRegExp(routeName)}-\\d+$`);
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+/**
+ * Waits for the `Name: <routeName>` label to be visible. Only where that
+ * label is unique in the hierarchy — iOS (covered screens are detached) or an
+ * Android stack that never holds two screens of one route; otherwise use
+ * `waitForTopmostRoute`, which reads the topmost copy.
+ */
+export async function waitForRouteName(routeName: string): Promise<void> {
+  await waitFor(element(by.text(`Name: ${routeName}`)))
+    .toBeVisible()
+    .withTimeout(DEFAULT_TIMEOUT_MS);
+}
+
+/**
+ * Waits until the topmost screen is `routeName` and returns its route key,
+ * which pins the instance too (same key: preserved; new key: pushed). Polled:
+ * `toBeVisible()` passes on a buried screen, so `waitFor` would not gate a pop.
+ */
+export async function waitForTopmostRoute(routeName: string): Promise<string> {
+  const pattern = routeKeyPattern(routeName);
+  let lastSeen = '<never read>';
+
+  await waitUntil(
+    async () => {
+      lastSeen = await readTopmostRouteKey();
+      return pattern.test(lastSeen);
+    },
+    {
+      message: () =>
+        `the topmost route to be "${routeName}"; topmost key was "${lastSeen}"`,
+    },
+  );
+
+  return lastSeen;
 }

--- a/FabricExample/e2e/elements/back-button.ts
+++ b/FabricExample/e2e/elements/back-button.ts
@@ -1,14 +1,18 @@
 import { device, by } from 'detox';
 import type { NativeMatcher } from 'detox/detox';
 import {
+  DEFAULT_TIMEOUT_MS,
   expectTopmostVisible,
   isIOSVersionAtLeast,
-  stackV5BackButton,
   tapTopmost,
 } from '../e2e-utils';
-import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../native-class-names';
+import {
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
+  CLASS_NAME_ANDROID_TOOLBAR,
+  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
+} from '../native-class-names';
 
-const BACK_BUTTON_TIMEOUT_MS = 3000;
+const BACK_BUTTON_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 
 /** UIKit's `BackButton` id; ambiguous on iOS 26, so narrowed to the container. */
 const iosBackButtonMatcher = (): NativeMatcher =>
@@ -16,16 +20,28 @@ const iosBackButtonMatcher = (): NativeMatcher =>
     ? by.id('BackButton').and(by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON))
     : by.id('BackButton');
 
+/**
+ * The toolbar's navigation icon, for the legacy (`CustomToolbar`) and Stack v5
+ * (`MaterialToolbar`) headers alike — unlike `stackV5BackButton`.
+ */
+const androidBackButtonMatcher = (): NativeMatcher =>
+  by
+    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
+    .withAncestor(by.type(CLASS_NAME_ANDROID_TOOLBAR));
+
 function backButtonMatcher(): NativeMatcher {
   const platform = device.getPlatform();
   if (platform === 'ios') {
     return iosBackButtonMatcher();
   } else if (platform === 'android') {
-    return stackV5BackButton();
+    return androidBackButtonMatcher();
   } else throw new Error(`Platform "${platform}" not supported`);
 }
 
-/** Waits for, then taps, the topmost screen's header back button. */
+/**
+ * Waits for, then taps, the topmost screen's header back button. With several
+ * headers attached (a nested stack), the last match is tapped.
+ */
 export async function tapBarBackButton() {
   await expectTopmostVisible(backButtonMatcher, {
     timeout: BACK_BUTTON_TIMEOUT_MS,

--- a/FabricExample/e2e/elements/back-button.ts
+++ b/FabricExample/e2e/elements/back-button.ts
@@ -1,36 +1,43 @@
-import { device, element, by } from 'detox';
-import isVersionEqualOrHigherThan from '../helpers/isVersionEqualOrHigherThan';
-import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../native-class-names';
+import { device, by } from 'detox';
+import type { NativeMatcher } from 'detox/detox';
+import {
+  expectTopmostVisible,
+  isIOSVersionAtLeast,
+  tapTopmost,
+} from '../e2e-utils';
+import {
+  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
+  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
+  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
+} from '../native-class-names';
 
-const { getIOSVersionNumber } = require('../../../scripts/e2e/ios-devices.js');
+const BACK_BUTTON_TIMEOUT_MS = 3000;
 
-const backButtonElement = element(by.id('BackButton'));
+/** UIKit's `BackButton` id; ambiguous on iOS 26, so narrowed to the container. */
+const iosBackButtonMatcher = (): NativeMatcher =>
+  isIOSVersionAtLeast('26.0')
+    ? by.id('BackButton').and(by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON))
+    : by.id('BackButton');
 
-export async function tapBarBackButton() {
+/** Stack v5 header only — the v4 `CustomToolbar` is not a `MaterialToolbar`. */
+const androidBackButtonMatcher = (): NativeMatcher =>
+  by
+    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
+    .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
+
+function backButtonMatcher(): NativeMatcher {
   const platform = device.getPlatform();
   if (platform === 'ios') {
-    return (await getIOSBackButton()).tap();
+    return iosBackButtonMatcher();
   } else if (platform === 'android') {
-    return backButtonElement.tap();
+    return androidBackButtonMatcher();
   } else throw new Error(`Platform "${platform}" not supported`);
 }
 
-async function getIOSBackButton() {
-  const iosVersion = getIOSVersionNumber();
-  if (isVersionEqualOrHigherThan(iosVersion, '26.0')) {
-    const elementsByAttributes =
-      (await backButtonElement.getAttributes()) as unknown as {
-        elements: { className: string }[];
-      };
-    const elements = elementsByAttributes.elements;
-    if (Array.isArray(elements)) {
-      const uiBarButtonIndex = elements.findIndex(
-        elem => elem.className === CLASS_NAME_UI_BUTTON_BAR_BUTTON,
-      );
-      if (uiBarButtonIndex !== -1) {
-        return backButtonElement.atIndex(uiBarButtonIndex);
-      }
-    }
-  }
-  return backButtonElement;
+/** Waits for, then taps, the topmost screen's header back button. */
+export async function tapBarBackButton() {
+  await expectTopmostVisible(backButtonMatcher, {
+    timeout: BACK_BUTTON_TIMEOUT_MS,
+  });
+  await tapTopmost(backButtonMatcher());
 }

--- a/FabricExample/e2e/elements/back-button.ts
+++ b/FabricExample/e2e/elements/back-button.ts
@@ -3,13 +3,10 @@ import type { NativeMatcher } from 'detox/detox';
 import {
   expectTopmostVisible,
   isIOSVersionAtLeast,
+  stackV5BackButton,
   tapTopmost,
 } from '../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
-  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
-  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
-} from '../native-class-names';
+import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../native-class-names';
 
 const BACK_BUTTON_TIMEOUT_MS = 3000;
 
@@ -19,18 +16,12 @@ const iosBackButtonMatcher = (): NativeMatcher =>
     ? by.id('BackButton').and(by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON))
     : by.id('BackButton');
 
-/** Stack v5 header only — the v4 `CustomToolbar` is not a `MaterialToolbar`. */
-const androidBackButtonMatcher = (): NativeMatcher =>
-  by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
-    .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
-
 function backButtonMatcher(): NativeMatcher {
   const platform = device.getPlatform();
   if (platform === 'ios') {
     return iosBackButtonMatcher();
   } else if (platform === 'android') {
-    return androidBackButtonMatcher();
+    return stackV5BackButton();
   } else throw new Error(`Platform "${platform}" not supported`);
 }
 

--- a/FabricExample/e2e/elements/back-button.ts
+++ b/FabricExample/e2e/elements/back-button.ts
@@ -1,7 +1,6 @@
 import { device, by } from 'detox';
 import type { NativeMatcher } from 'detox/detox';
 import {
-  DEFAULT_TIMEOUT_MS,
   expectTopmostVisible,
   isIOSVersionAtLeast,
   tapTopmost,
@@ -11,8 +10,6 @@ import {
   CLASS_NAME_ANDROID_TOOLBAR,
   CLASS_NAME_UI_BUTTON_BAR_BUTTON,
 } from '../native-class-names';
-
-const BACK_BUTTON_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 
 /** UIKit's `BackButton` id; ambiguous on iOS 26, so narrowed to the container. */
 const iosBackButtonMatcher = (): NativeMatcher =>
@@ -43,8 +40,6 @@ function backButtonMatcher(): NativeMatcher {
  * headers attached (a nested stack), the last match is tapped.
  */
 export async function tapBarBackButton() {
-  await expectTopmostVisible(backButtonMatcher, {
-    timeout: BACK_BUTTON_TIMEOUT_MS,
-  });
+  await expectTopmostVisible(backButtonMatcher);
   await tapTopmost(backButtonMatcher());
 }

--- a/FabricExample/e2e/helpers/isVersionEqualOrHigherThan.ts
+++ b/FabricExample/e2e/helpers/isVersionEqualOrHigherThan.ts
@@ -24,10 +24,10 @@ function assertSupportedVersionString(
 
 function compareVersions(
   version: MajorVersion | MajorMinorVersion,
-  versionToCompare: MajorVersion | MajorMinorVersion,
+  minimumVersion: MajorVersion | MajorMinorVersion,
 ) {
   const [majorA, minorA = '0'] = version.split('.').map(Number);
-  const [majorB, minorB = '0'] = versionToCompare.split('.').map(Number);
+  const [majorB, minorB = '0'] = minimumVersion.split('.').map(Number);
   if (majorA !== majorB) {
     return majorA - majorB;
   } else {
@@ -35,12 +35,13 @@ function compareVersions(
   }
 }
 
+/** `true` when `version` is at least `minimumVersion`. */
 export default function isVersionEqualOrHigherThan(
-  first: string,
-  second: string,
+  version: string,
+  minimumVersion: string,
 ) {
-  assertSupportedVersionString(first);
-  assertSupportedVersionString(second);
+  assertSupportedVersionString(version);
+  assertSupportedVersionString(minimumVersion);
 
-  return compareVersions(first, second) >= 0;
+  return compareVersions(version, minimumVersion) >= 0;
 }

--- a/FabricExample/e2e/helpers/isVersionEqualOrHigherThan.ts
+++ b/FabricExample/e2e/helpers/isVersionEqualOrHigherThan.ts
@@ -24,10 +24,10 @@ function assertSupportedVersionString(
 
 function compareVersions(
   version: MajorVersion | MajorMinorVersion,
-  minimumVersion: MajorVersion | MajorMinorVersion,
+  versionToCompare: MajorVersion | MajorMinorVersion,
 ) {
   const [majorA, minorA = '0'] = version.split('.').map(Number);
-  const [majorB, minorB = '0'] = minimumVersion.split('.').map(Number);
+  const [majorB, minorB = '0'] = versionToCompare.split('.').map(Number);
   if (majorA !== majorB) {
     return majorA - majorB;
   } else {

--- a/FabricExample/e2e/issue-tests/Test758.e2e.ts
+++ b/FabricExample/e2e/issue-tests/Test758.e2e.ts
@@ -1,13 +1,13 @@
 import { device, expect, element, by } from 'detox';
-import { describeIfiOS, selectIssueTestScreen } from '../e2e-utils';
-import isVersionEqualOrHigherThan from '../helpers/isVersionEqualOrHigherThan';
-
-const { getIOSVersionNumber } = require('../../../scripts/e2e/ios-devices.js');
+import {
+  describeIfiOS,
+  isIOSVersionAtLeast,
+  selectIssueTestScreen,
+} from '../e2e-utils';
 
 // On iOS 26+ cancel button does not contain any text.
 function getSearchBarCloseButton() {
-  const iosVersion = getIOSVersionNumber();
-  if (isVersionEqualOrHigherThan(iosVersion, '26.0')) {
+  if (isIOSVersionAtLeast('26.0')) {
     return element(by.label('Close').and(by.traits(['button'])));
   } else {
     return element(by.text('Cancel text'));

--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -55,6 +55,9 @@ export const CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW =
 
 export const CLASS_NAME_UI_CONTEXT_MENU_VIEW = '_UIContextMenuView';
 export const CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW = '_UIContextMenuListView';
+/** UIKit's full-screen "Dismiss context menu" overlay behind the platter. */
+export const CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW =
+  '_UIContextMenuPlatterTransitionView';
 export const CLASS_NAME_UI_CONTEXT_MENU_CELL = '_UIContextMenuCell';
 export const CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW =
   '_UIContextMenuCellContentView';

--- a/FabricExample/e2e/native-class-names.ts
+++ b/FabricExample/e2e/native-class-names.ts
@@ -80,6 +80,9 @@ export const CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON =
   'androidx.appcompat.widget.AppCompatImageButton';
 export const CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW =
   'androidx.appcompat.widget.MenuPopupWindow$MenuDropDownListView';
+// Matches every toolbar (`by.type` uses `isAssignableFrom`): the legacy
+// `CustomToolbar` and the Stack v5 `MaterialToolbar` alike.
+export const CLASS_NAME_ANDROID_TOOLBAR = 'androidx.appcompat.widget.Toolbar';
 export const CLASS_NAME_ANDROID_MATERIAL_TOOLBAR =
   'com.google.android.material.appbar.MaterialToolbar';
 // Detox resolves `by.type` with `isAssignableFrom`, so this also matches the

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-back-button-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-back-button-android.e2e.ts
@@ -41,7 +41,7 @@ async function expectNoBackButton() {
 // settle race would otherwise read as "the back button is missing". The count
 // names the ambiguity a second stacked toolbar's icon would cause.
 async function expectSingleVisibleBackButton() {
-  await waitFor(element(stackV5BackButton())).toBeVisible().withTimeout(3000);
+  await expectTopmostVisible(stackV5BackButton);
   jestExpect(await countMatches(stackV5BackButton())).toBe(1);
 }
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-back-button-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-back-button-android.e2e.ts
@@ -3,13 +3,13 @@ import { device, expect, element, by, waitFor } from 'detox';
 import {
   countMatches,
   describeIfAndroid,
+  expectTopmostVisible,
+  pickerOptionId,
   selectSingleFeatureTestsScreen,
+  stackV5BackButton,
+  stackV5Toolbar,
   tapTopmost,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
-  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
-} from '../../native-class-names';
 
 // Icon identity and tint colors are not assertable through Detox — see
 // `scenario.md` next to the test screen for the manual-only steps.
@@ -20,19 +20,12 @@ const PUSH_ANOTHER = 'PUSH ANOTHER';
 
 const BACK_BUTTON_HIDDEN_SWITCH = 'back-button-hidden-switch';
 
-// Scoped to the toolbar the Stack v5 (gamma) header builds — the legacy v4
-// header uses `CustomToolbar`, which extends `Toolbar` but not
-// `MaterialToolbar`.
-const backButtonMatcher = by
-  .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
-  .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
-
 // Option ids are `SettingsPicker`'s own `<label>-<item>`, lowercased. The
 // second tap on the picker closes it, so its options do not push later
 // controls off-screen.
-async function selectOption(pickerId: string, optionId: string) {
+async function selectOption(pickerId: string, label: string, option: string) {
   await tapTopmost(by.id(pickerId));
-  await tapTopmost(by.id(optionId));
+  await tapTopmost(by.id(pickerOptionId(label, option)));
   await tapTopmost(by.id(pickerId));
 }
 
@@ -40,18 +33,16 @@ async function selectOption(pickerId: string, optionId: string) {
 // exist". The toolbar is asserted first, otherwise a header that never
 // rendered would pass too. Each screen builds its own toolbar, hence the index.
 async function expectNoBackButton() {
-  const toolbarMatcher = by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
-  const count = await countMatches(toolbarMatcher);
-  await expect(element(toolbarMatcher).atIndex(count - 1)).toBeVisible();
-  await expect(element(backButtonMatcher)).not.toExist();
+  await expectTopmostVisible(stackV5Toolbar);
+  await expect(element(stackV5BackButton())).not.toExist();
 }
 
 // The icon can lag the pushed screen's content, so wait before counting — a
 // settle race would otherwise read as "the back button is missing". The count
 // names the ambiguity a second stacked toolbar's icon would cause.
 async function expectSingleVisibleBackButton() {
-  await waitFor(element(backButtonMatcher)).toBeVisible().withTimeout(3000);
-  jestExpect(await countMatches(backButtonMatcher)).toBe(1);
+  await waitFor(element(stackV5BackButton())).toBeVisible().withTimeout(3000);
+  jestExpect(await countMatches(stackV5BackButton())).toBe(1);
 }
 
 async function openScreen() {
@@ -97,8 +88,8 @@ describeIfAndroid('Stack v5: back button configured before the push', () => {
   beforeAll(openScreen);
 
   it('should keep the root screen back-button-free with an icon and tint set', async () => {
-    await selectOption('icon-picker', 'icon-imagesource');
-    await selectOption('tint-color-normal-picker', 'tintcolornormal-purple');
+    await selectOption('icon-picker', 'icon', 'imageSource');
+    await selectOption('tint-color-normal-picker', 'tintColorNormal', 'purple');
     await expectNoBackButton();
   });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
@@ -2,13 +2,13 @@ import { device, expect, element, by } from 'detox';
 import {
   barButtonIcon,
   describeIfiOS,
+  headerTitle,
   menuRowIcon,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
-  CLASS_NAME_UI_LABEL,
 } from '../../native-class-names';
 
 // Number of rows in the header item menu that render an icon:
@@ -64,9 +64,7 @@ describeIfiOS('Stack Header Icon (iOS)', () => {
   });
 
   it('should display the header with a star sfSymbol icon on the trailing item', async () => {
-    await expect(
-      element(by.type(CLASS_NAME_UI_LABEL).and(by.text('Header Icons'))),
-    ).toExist();
+    await expect(element(headerTitle('Header Icons'))).toExist();
     await expect(barButtonIcon(ICON_IDS.sfSymbol)).toBeVisible();
   });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
@@ -4,17 +4,13 @@ import {
   CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
   CLASS_NAME_UI_LABEL,
-  CLASS_NAME_UI_MODERN_BAR_BUTTON,
 } from '../../native-class-names';
+import { menuRowIcon } from '../../e2e-utils';
+import { barButtonIcon } from '../../e2e-utils';
 
 // Number of rows in the header item menu that render an icon:
 // Toggle 1, Toggle 2, Toggle 3 and Submenu.
 const MENU_ROW_COUNT = 4;
-
-// The icon of the header bar button item, addressed by its icon id (SF Symbol
-// name or asset path).
-const barButtonIcon = (iconId: string) =>
-  element(by.id(iconId).withAncestor(by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON)));
 
 // `imageSource` and `templateSource` ids are the bundled paths of the `require`d
 // asset files — renaming or moving those assets requires updating them here.
@@ -27,7 +23,7 @@ const ICON_IDS = {
 
 // The icon of a single menu row, addressed by its icon id and its position in
 // the menu.
-const menuRowIcon = (iconId: string, index: number) =>
+const menuRowIconAt = (iconId: string, index: number) =>
   element(
     by
       .id(iconId)
@@ -40,32 +36,20 @@ const expectAllMenuRowIconsToBeVisible = async (
   rowCount: number = MENU_ROW_COUNT,
 ) => {
   for (let index = 0; index < rowCount; index++) {
-    await expect(menuRowIcon(iconId, index)).toBeVisible();
+    await expect(menuRowIconAt(iconId, index)).toBeVisible();
   }
 };
 
 // Titles of the rows inside the nested submenu.
 const SUBMENU_ROWS = ['Sub Toggle 1', 'Sub Toggle 2', 'Sub Toggle 3'] as const;
 
-// The icon of a single submenu row, addressed by its icon id and the row's own
-// title rather than by position: the parent menu's cells use the same class and
-// stay in the hierarchy while the submenu is open, so an index-based matcher
-// would happily match a parent row instead.
-const submenuRowIcon = (iconId: string, rowTitle: string) =>
-  element(
-    by
-      .id(iconId)
-      .withAncestor(
-        by
-          .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-          .and(by.label(rowTitle)),
-      ),
-  );
-
-// Asserts that every submenu row renders the icon carrying `iconId`.
+// Asserts that every submenu row renders the icon carrying `iconId`. Rows are
+// addressed by title rather than by position: the parent menu's cells stay in
+// the hierarchy while the submenu is open, so an index-based matcher would
+// happily match a parent row instead.
 const expectAllSubmenuRowIconsToBeVisible = async (iconId: string) => {
   for (const rowTitle of SUBMENU_ROWS) {
-    await expect(submenuRowIcon(iconId, rowTitle)).toBeVisible();
+    await expect(menuRowIcon(iconId, rowTitle)).toBeVisible();
   }
 };
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-icon-ios.e2e.ts
@@ -1,12 +1,15 @@
 import { device, expect, element, by } from 'detox';
-import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
+import {
+  barButtonIcon,
+  describeIfiOS,
+  menuRowIcon,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
 import {
   CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
   CLASS_NAME_UI_LABEL,
 } from '../../native-class-names';
-import { menuRowIcon } from '../../e2e-utils';
-import { barButtonIcon } from '../../e2e-utils';
 
 // Number of rows in the header item menu that render an icon:
 // Toggle 1, Toggle 2, Toggle 3 and Submenu.
@@ -43,10 +46,8 @@ const expectAllMenuRowIconsToBeVisible = async (
 // Titles of the rows inside the nested submenu.
 const SUBMENU_ROWS = ['Sub Toggle 1', 'Sub Toggle 2', 'Sub Toggle 3'] as const;
 
-// Asserts that every submenu row renders the icon carrying `iconId`. Rows are
-// addressed by title rather than by position: the parent menu's cells stay in
-// the hierarchy while the submenu is open, so an index-based matcher would
-// happily match a parent row instead.
+// Asserts every submenu row renders `iconId`. Addressed by title, not index:
+// the parent menu's cells stay attached while the submenu is open.
 const expectAllSubmenuRowIconsToBeVisible = async (iconId: string) => {
   for (const rowTitle of SUBMENU_ROWS) {
     await expect(menuRowIcon(iconId, rowTitle)).toBeVisible();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -9,17 +9,9 @@ import {
 } from '../../e2e-utils';
 import {
   CLASS_NAME_UI_LABEL,
-  CLASS_NAME_UI_MODERN_BAR_BUTTON,
   CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW,
 } from '../../native-class-names';
-
-// The icon of the header bar button item, addressed by its icon id (SF Symbol
-// name or asset path).
-function barButtonIcon(sfSymbolName: string) {
-  return element(
-    by.id(sfSymbolName).withAncestor(by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON)),
-  );
-}
+import { barButtonIcon } from '../../e2e-utils';
 
 // Every SF Symbol the test screen cycles through (SYMBOL_CYCLES in the test
 // screen's index.tsx).

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -2,6 +2,7 @@ import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
 import { IosElementAttributes } from 'detox/detox';
 import {
+  barButtonIcon,
   describeIfiOS26,
   getMatches,
   selectSingleFeatureTestsScreen,
@@ -11,7 +12,6 @@ import {
   CLASS_NAME_UI_LABEL,
   CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW,
 } from '../../native-class-names';
-import { barButtonIcon } from '../../e2e-utils';
 
 // Every SF Symbol the test screen cycles through (SYMBOL_CYCLES in the test
 // screen's index.tsx).

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios.e2e.ts
@@ -4,14 +4,12 @@ import { IosElementAttributes } from 'detox/detox';
 import {
   barButtonIcon,
   describeIfiOS26,
+  headerTitle,
   getMatches,
   selectSingleFeatureTestsScreen,
   toggleSettingsSwitch,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_UI_LABEL,
-  CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW,
-} from '../../native-class-names';
+import { CLASS_NAME_UI_NAVIGATION_BAR_PLATTER_VIEW } from '../../native-class-names';
 
 // Every SF Symbol the test screen cycles through (SYMBOL_CYCLES in the test
 // screen's index.tsx).
@@ -39,7 +37,7 @@ async function expectExactBarButtonSymbols(expected: string[]) {
 }
 
 async function waitForScreen(routeName: 'One' | 'Two' | 'Three') {
-  await waitFor(element(by.type(CLASS_NAME_UI_LABEL).and(by.text(routeName))))
+  await waitFor(element(headerTitle(routeName)))
     .toExist()
     .withTimeout(3000);
 }
@@ -54,7 +52,7 @@ async function pushNext() {
 // is asserted to confirm where the pop landed.
 async function popBackFrom(routeName: 'Two' | 'Three') {
   await element(by.text('Go back')).tap();
-  await waitFor(element(by.type(CLASS_NAME_UI_LABEL).and(by.text(routeName))))
+  await waitFor(element(headerTitle(routeName)))
     .not.toExist()
     .withTimeout(3000);
   await waitForScreen(routeName === 'Three' ? 'Two' : 'One');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
@@ -2,79 +2,52 @@ import { device, expect, element, by } from 'detox';
 import {
   describeIfiOS,
   dismissToast,
+  scrollToAndTap,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
-  CLASS_NAME_UI_LABEL,
-  CLASS_NAME_UI_MODERN_BAR_BUTTON,
-  CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW,
-  CLASS_NAME_UI_CONTEXT_MENU_CELL,
-  CLASS_NAME_UI_IMAGE_VIEW,
-} from '../../native-class-names';
+import { CLASS_NAME_UI_LABEL } from '../../native-class-names';
 import { IosElementAttributes } from 'detox/detox';
+import {
+  checkmarkFor,
+  contextMenu,
+  dismissContextMenu,
+  menuRow,
+  menuRowIcon,
+  openContextMenu,
+} from '../../e2e-utils';
+import { headerItem } from '../../e2e-utils';
 
 const SCROLLVIEW_ID = 'header-menu-scrollview';
 
-const menuOneBarButton = element(
-  by.type(CLASS_NAME_UI_MODERN_BAR_BUTTON).and(by.label('Menu 1')),
-);
+const menuOneBarButton = headerItem('Menu 1', { control: true });
 
 const headerTitle = element(
   by.type(CLASS_NAME_UI_LABEL).and(by.text('Header Menu')),
 );
 
-const contextMenu = element(by.type(CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW));
-
-function menuCell(itemLabel: string) {
-  return by
-    .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-    .and(by.label(itemLabel));
-}
-
-function checkmarkFor(itemLabel: string) {
-  return element(by.id('checkmark').withAncestor(menuCell(itemLabel)));
-}
-
-/** A menu row's SF Symbol, whose identifier is the symbol name. */
-function iconFor(iconId: string, itemLabel: string) {
-  return element(
-    by
-      .type(CLASS_NAME_UI_IMAGE_VIEW)
-      .and(by.id(iconId))
-      .withAncestor(menuCell(itemLabel)),
-  );
-}
-
-async function scrollTo(matcher: Detox.NativeMatcher) {
-  await waitFor(element(matcher))
-    .toBeVisible()
-    .whileElement(by.id(SCROLLVIEW_ID))
-    .scroll(200, 'down');
-}
+// Small steps keep a short picker row from being scrolled past; the Detox
+// default start point is kept.
+const SCROLL = {
+  scrollViewId: SCROLLVIEW_ID,
+  pixels: 200,
+  startPercentage: NaN,
+};
 
 /**
- * Opens the picker, taps the option, closes it again. Option ids
- * (`<label>-<option>`) repeat across both sections, so only one picker may be
- * open at a time.
+ * Option ids (`<label>-<option>`) repeat across both sections, so only one
+ * picker may be open at a time — `selectPickerOption` closes it again.
  */
-async function selectPickerOption(pickerId: string, optionId: string) {
-  await scrollTo(by.id(pickerId));
-  await element(by.id(pickerId)).tap();
-  await scrollTo(by.id(optionId));
-  await element(by.id(optionId)).tap();
-  await element(by.id(pickerId)).tap();
+async function setPicker(pickerId: string, label: string, option: string) {
+  await selectPickerOption({ pickerId, label, option }, SCROLL);
 }
 
 async function tapSendButton(buttonId: string) {
-  await scrollTo(by.id(buttonId));
-  await element(by.id(buttonId)).tap();
+  await scrollToAndTap(buttonId, SCROLL);
 }
 
 async function openMenuOne() {
-  await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-  await menuOneBarButton.tap();
-  await waitFor(contextMenu).toBeVisible().withTimeout(2000);
+  await openContextMenu(menuOneBarButton);
 }
 
 /**
@@ -86,21 +59,7 @@ async function openTitleMenu() {
     (await headerTitle.getAttributes()) as IosElementAttributes;
   const { x, y, width, height } = titleAttributes.frame;
   await device.tap({ x: x + width / 2, y: y + height / 2 });
-  await waitFor(contextMenu).toBeVisible().withTimeout(2000);
-}
-
-/**
- * Taps the dimming layer to dismiss the menu. The menu is anchored to the
- * trailing bar button, so a point near the left edge never lands on it.
- */
-async function dismissMenu() {
-  const textAttributes = (await element(
-    by.text('setMenuOptions (Menu 1)'),
-  ).getAttributes()) as IosElementAttributes;
-  const x = textAttributes.frame.x;
-  const y = textAttributes.frame.y + textAttributes.frame.height / 2;
-  await device.tap({ x, y });
-  await waitFor(contextMenu).not.toExist().withTimeout(2000);
+  await waitFor(contextMenu()).toBeVisible().withTimeout(2000);
 }
 
 describeIfiOS('Stack Header Menu (iOS)', () => {
@@ -127,7 +86,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await expect(element(by.text('Toggle 1-3'))).toBeVisible();
       await expect(element(by.text('Submenu with Radio'))).toBeVisible();
 
-      await dismissMenu();
+      await dismissContextMenu();
     });
 
     it('should dismiss the menu and emit toast after tapping the action item "Action 1-1"', async () => {
@@ -135,7 +94,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Action 1-1')).tap();
       await dismissToast('1. Clicked Action 1-1');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
     });
   });
 
@@ -145,10 +104,9 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Toggle 1-1')).tap();
       await dismissToast('1. Selected "toggle-1-1"');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
 
-      await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-      await menuOneBarButton.tap();
+      await openMenuOne();
 
       await expect(checkmarkFor('Toggle 1-1')).toBeVisible();
     });
@@ -157,10 +115,9 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Toggle 1-3')).tap();
       await dismissToast('1. Selected "toggle-1-1", "toggle-1-3"');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
 
-      await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-      await menuOneBarButton.tap();
+      await openMenuOne();
 
       await expect(checkmarkFor('Toggle 1-1')).toBeVisible();
       await expect(checkmarkFor('Toggle 1-3')).toBeVisible();
@@ -170,10 +127,9 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Toggle 1-1')).tap();
       await dismissToast('1. Selected "toggle-1-3"');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
 
-      await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-      await menuOneBarButton.tap();
+      await openMenuOne();
 
       await expect(checkmarkFor('Toggle 1-1')).not.toExist();
       await expect(checkmarkFor('Toggle 1-3')).toBeVisible();
@@ -192,10 +148,9 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await waitFor(
         element(by.label('1. Selected unique "radio-1-1"')),
       ).not.toBeVisible();
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
 
-      await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-      await menuOneBarButton.tap();
+      await openMenuOne();
       await element(by.text('Submenu with Radio')).tap();
 
       await expect(checkmarkFor('Radio 1-1')).toBeVisible();
@@ -206,9 +161,8 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Radio 1-2')).tap();
       await dismissToast('1. Selected unique "radio-1-2"');
 
-      await expect(contextMenu).not.toExist();
-      await waitFor(menuOneBarButton).toBeVisible().withTimeout(2000);
-      await menuOneBarButton.tap();
+      await expect(contextMenu()).not.toExist();
+      await openMenuOne();
       await element(by.text('Submenu with Radio')).tap();
 
       await expect(checkmarkFor('Radio 1-1')).not.toExist();
@@ -221,7 +175,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
 
   describe('title menu', () => {
     it('should open a menu with both title actions when the header title is tapped', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
 
       await openTitleMenu();
 
@@ -233,7 +187,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Title Action 1')).tap();
       await dismissToast('1. Clicked "Title Action 1"');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
     });
 
     it('should dismiss the title menu and emit a toast after tapping "Title Action 2"', async () => {
@@ -241,7 +195,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
       await element(by.text('Title Action 2')).tap();
       await dismissToast('1. Clicked "Title Action 2"');
 
-      await expect(contextMenu).not.toExist();
+      await expect(contextMenu()).not.toExist();
     });
   });
 });
@@ -258,10 +212,7 @@ describeIfiOS(
     });
 
     it('should rename the targeted menu item', async () => {
-      await selectPickerOption(
-        'menu-item-options-title-picker',
-        'title-new title',
-      );
+      await setPicker('menu-item-options-title-picker', 'title', 'New Title');
       await tapSendButton('send-menu-item-options-button');
 
       await openMenuOne();
@@ -271,42 +222,31 @@ describeIfiOS(
     });
 
     it('should add an icon to the renamed item while keeping its title', async () => {
-      await expect(iconFor('star.fill', 'New Title')).not.toExist();
-      await dismissMenu();
+      await expect(menuRowIcon('star.fill', 'New Title')).not.toExist();
+      await dismissContextMenu();
 
-      await selectPickerOption(
-        'menu-item-options-title-picker',
-        'title-no change',
-      );
-      await selectPickerOption(
-        'menu-item-options-icon-picker',
-        'icon-star.fill',
-      );
+      await setPicker('menu-item-options-title-picker', 'title', 'no change');
+      await setPicker('menu-item-options-icon-picker', 'icon', 'star.fill');
       await tapSendButton('send-menu-item-options-button');
 
       await openMenuOne();
 
-      await expect(
-        element(
-          by
-            .label('New Title')
-            .and(by.type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW))
-            .withAncestor(by.type(CLASS_NAME_UI_CONTEXT_MENU_CELL)),
-        ),
-      ).toBeVisible();
-      await expect(iconFor('star.fill', 'New Title')).toBeVisible();
+      await expect(menuRow('New Title', { actionsOnly: true })).toBeVisible();
+      await expect(menuRowIcon('star.fill', 'New Title')).toBeVisible();
     });
 
     it('should check Toggle 1-1 and emit a selection toast when toggleState is set to true', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
 
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-target-id-picker',
-        'target-id-toggle-1-1',
+        'target id',
+        'toggle-1-1',
       );
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-toggle-state-picker',
-        'togglestate-true',
+        'toggleState',
+        'true',
       );
       await tapSendButton('send-menu-item-options-button');
 
@@ -318,15 +258,17 @@ describeIfiOS(
     });
 
     it('should keep Radio 1-1 selected when deselecting it in a singleSelection submenu', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
 
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-target-id-picker',
-        'target-id-radio-1-1',
+        'target id',
+        'radio-1-1',
       );
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-toggle-state-picker',
-        'togglestate-false',
+        'toggleState',
+        'false',
       );
       await tapSendButton('send-menu-item-options-button');
 
@@ -337,15 +279,17 @@ describeIfiOS(
     });
 
     it('should move the singleSelection checkmark from Radio 1-1 to Radio 1-2', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
 
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-target-id-picker',
-        'target-id-radio-1-2',
+        'target id',
+        'radio-1-2',
       );
-      await selectPickerOption(
+      await setPicker(
         'menu-item-options-toggle-state-picker',
-        'togglestate-true',
+        'toggleState',
+        'true',
       );
       await tapSendButton('send-menu-item-options-button');
 
@@ -373,7 +317,7 @@ describeIfiOS('Stack Header Menu (iOS): setMenuOptions view command', () => {
   });
 
   it('should rename the targeted submenu', async () => {
-    await selectPickerOption('menu-options-title-picker', 'title-new title');
+    await setPicker('menu-options-title-picker', 'title', 'New Title');
     await tapSendButton('send-menu-options-button');
 
     await openMenuOne();
@@ -383,18 +327,18 @@ describeIfiOS('Stack Header Menu (iOS): setMenuOptions view command', () => {
   });
 
   it('should add an icon to the renamed submenu while keeping its title', async () => {
-    await expect(iconFor('bell.fill', 'New Title')).not.toExist();
-    await dismissMenu();
+    await expect(menuRowIcon('bell.fill', 'New Title')).not.toExist();
+    await dismissContextMenu();
 
-    await selectPickerOption('menu-options-title-picker', 'title-no change');
-    await selectPickerOption('menu-options-icon-picker', 'icon-bell.fill');
+    await setPicker('menu-options-title-picker', 'title', 'no change');
+    await setPicker('menu-options-icon-picker', 'icon', 'bell.fill');
     await tapSendButton('send-menu-options-button');
 
     await openMenuOne();
 
     await expect(element(by.text('New Title'))).toBeVisible();
-    await expect(iconFor('bell.fill', 'New Title')).toBeVisible();
+    await expect(menuRowIcon('bell.fill', 'New Title')).toBeVisible();
 
-    await dismissMenu();
+    await dismissContextMenu();
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
@@ -1,29 +1,30 @@
 import { device, expect, element, by } from 'detox';
 import {
+  checkmarkFor,
+  CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
+  contextMenu,
   describeIfiOS,
+  dismissContextMenu,
   dismissToast,
+  forceTapByLabeliOS,
+  headerItem,
+  menuRow,
+  menuRowIcon,
+  openContextMenu,
   scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import { CLASS_NAME_UI_LABEL } from '../../native-class-names';
-import { IosElementAttributes } from 'detox/detox';
-import {
-  checkmarkFor,
-  contextMenu,
-  dismissContextMenu,
-  menuRow,
-  menuRowIcon,
-  openContextMenu,
-} from '../../e2e-utils';
-import { headerItem } from '../../e2e-utils';
 
 const SCROLLVIEW_ID = 'header-menu-scrollview';
 
 const menuOneBarButton = headerItem('Menu 1', { control: true });
 
+const HEADER_TITLE = 'Header Menu';
+
 const headerTitle = element(
-  by.type(CLASS_NAME_UI_LABEL).and(by.text('Header Menu')),
+  by.type(CLASS_NAME_UI_LABEL).and(by.text(HEADER_TITLE)),
 );
 
 // Small steps keep a short picker row from being scrolled past; the Detox
@@ -55,11 +56,10 @@ async function openMenuOne() {
  * visibility threshold, so the title label is tapped by coordinates.
  */
 async function openTitleMenu() {
-  const titleAttributes =
-    (await headerTitle.getAttributes()) as IosElementAttributes;
-  const { x, y, width, height } = titleAttributes.frame;
-  await device.tap({ x: x + width / 2, y: y + height / 2 });
-  await waitFor(contextMenu()).toBeVisible().withTimeout(2000);
+  await forceTapByLabeliOS(HEADER_TITLE);
+  await waitFor(contextMenu())
+    .toBeVisible()
+    .withTimeout(CONTEXT_MENU_ANIMATION_TIMEOUT_MS);
 }
 
 describeIfiOS('Stack Header Menu (iOS)', () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-ios.e2e.ts
@@ -1,21 +1,20 @@
 import { device, expect, element, by } from 'detox';
 import {
   checkmarkFor,
-  CONTEXT_MENU_ANIMATION_TIMEOUT_MS,
   contextMenu,
   describeIfiOS,
   dismissContextMenu,
   dismissToast,
-  forceTapByLabeliOS,
+  headerTitle,
   headerItem,
   menuRow,
   menuRowIcon,
   openContextMenu,
+  openHeaderTitleMenu,
   scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import { CLASS_NAME_UI_LABEL } from '../../native-class-names';
 
 const SCROLLVIEW_ID = 'header-menu-scrollview';
 
@@ -23,16 +22,12 @@ const menuOneBarButton = headerItem('Menu 1', { control: true });
 
 const HEADER_TITLE = 'Header Menu';
 
-const headerTitle = element(
-  by.type(CLASS_NAME_UI_LABEL).and(by.text(HEADER_TITLE)),
-);
+const headerTitleLabel = element(headerTitle(HEADER_TITLE));
 
-// Small steps keep a short picker row from being scrolled past; the Detox
-// default start point is kept.
+// Small steps keep a short picker row from being scrolled past.
 const SCROLL = {
   scrollViewId: SCROLLVIEW_ID,
   pixels: 200,
-  startPercentage: NaN,
 };
 
 /**
@@ -51,17 +46,6 @@ async function openMenuOne() {
   await openContextMenu(menuOneBarButton);
 }
 
-/**
- * Opens the title menu. The control UIKit wraps the title in fails Detox's
- * visibility threshold, so the title label is tapped by coordinates.
- */
-async function openTitleMenu() {
-  await forceTapByLabeliOS(HEADER_TITLE);
-  await waitFor(contextMenu())
-    .toBeVisible()
-    .withTimeout(CONTEXT_MENU_ANIMATION_TIMEOUT_MS);
-}
-
 describeIfiOS('Stack Header Menu (iOS)', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -72,7 +56,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
   });
 
   it('should display the header with a trailing item exposing a real menu', async () => {
-    await expect(headerTitle).toExist();
+    await expect(headerTitleLabel).toExist();
     await expect(menuOneBarButton).toBeVisible();
   });
 
@@ -177,7 +161,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
     it('should open a menu with both title actions when the header title is tapped', async () => {
       await dismissContextMenu();
 
-      await openTitleMenu();
+      await openHeaderTitleMenu(HEADER_TITLE);
 
       await expect(element(by.text('Title Action 1'))).toBeVisible();
       await expect(element(by.text('Title Action 2'))).toBeVisible();
@@ -191,7 +175,7 @@ describeIfiOS('Stack Header Menu (iOS)', () => {
     });
 
     it('should dismiss the title menu and emit a toast after tapping "Title Action 2"', async () => {
-      await openTitleMenu();
+      await openHeaderTitleMenu(HEADER_TITLE);
       await element(by.text('Title Action 2')).tap();
       await dismissToast('1. Clicked "Title Action 2"');
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
@@ -1,5 +1,13 @@
 import { device, expect, element, by } from 'detox';
-import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
+import {
+  chevronFor,
+  describeIfiOS,
+  dismissContextMenu,
+  headerItem,
+  menuRow,
+  openContextMenu,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
 import { expect as jestExpect } from '@jest/globals';
 import {
   CLASS_NAME_UI_CONTEXT_MENU_HEADER_VIEW,
@@ -7,13 +15,6 @@ import {
   CLASS_NAME_UI_IMAGE_VIEW,
   CLASS_NAME_UI_LABEL,
 } from '../../native-class-names';
-import {
-  chevronFor,
-  dismissContextMenu,
-  menuRow,
-  openContextMenu,
-} from '../../e2e-utils';
-import { headerItem } from '../../e2e-utils';
 import { IosElementAttributes } from 'detox/detox';
 
 /**

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
@@ -2,6 +2,7 @@ import { device, expect, element, by } from 'detox';
 import {
   chevronFor,
   describeIfiOS,
+  headerTitle,
   dismissContextMenu,
   headerItem,
   menuRow,
@@ -13,7 +14,6 @@ import {
   CLASS_NAME_UI_CONTEXT_MENU_HEADER_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
   CLASS_NAME_UI_IMAGE_VIEW,
-  CLASS_NAME_UI_LABEL,
 } from '../../native-class-names';
 import { IosElementAttributes } from 'detox/detox';
 
@@ -60,9 +60,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
   });
 
   it('should display the header with Options and Palette trailing items', async () => {
-    await expect(
-      element(by.type(CLASS_NAME_UI_LABEL).and(by.text('Menu Options'))),
-    ).toExist();
+    await expect(element(headerTitle('Menu Options'))).toExist();
     await expect(optionsMenuButton).toBeVisible();
     await expect(paletteMenuButton).toBeVisible();
   });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-menu-options-ios.e2e.ts
@@ -1,20 +1,19 @@
 import { device, expect, element, by } from 'detox';
-import {
-  describeIfiOS,
-  getElementAttributes,
-  selectSingleFeatureTestsScreen,
-} from '../../e2e-utils';
+import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
 import { expect as jestExpect } from '@jest/globals';
 import {
-  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
-  CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_HEADER_VIEW,
-  CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW,
   CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
-  CLASS_NAME_UI_CONTEXT_MENU_VIEW,
   CLASS_NAME_UI_IMAGE_VIEW,
   CLASS_NAME_UI_LABEL,
 } from '../../native-class-names';
+import {
+  chevronFor,
+  dismissContextMenu,
+  menuRow,
+  openContextMenu,
+} from '../../e2e-utils';
+import { headerItem } from '../../e2e-utils';
 import { IosElementAttributes } from 'detox/detox';
 
 /**
@@ -23,40 +22,8 @@ import { IosElementAttributes } from 'detox/detox';
  * a row's chevron tells a collapsed submenu from an inlined one; and icon
  * frames tell a horizontal palette from a vertical list.
  */
-const contextMenu = element(by.type(CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW));
-
-const optionsMenuButton = element(
-  by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON).and(by.label('Options')),
-);
-const paletteMenuButton = element(
-  by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON).and(by.label('Palette')),
-);
-
-/** A row of a presented menu, matched by its visible label. */
-function menuRow(itemLabel: string) {
-  return element(
-    by
-      .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-      .and(by.label(itemLabel)),
-  );
-}
-
-/**
- * UIKit's disclosure indicator, drawn only on rows that open a submenu. Its
- * absence marks an inlined submenu; the title alone cannot, since an inlined
- * submenu may keep its title as a section header (see Text Style).
- */
-function chevronFor(itemLabel: string) {
-  return element(
-    by
-      .id('chevron.forward')
-      .withAncestor(
-        by
-          .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-          .and(by.label(itemLabel)),
-      ),
-  );
-}
+const optionsMenuButton = headerItem('Options');
+const paletteMenuButton = headerItem('Palette');
 
 /** The palette submenu title's chevron — its own class, not a menu row. */
 const paletteTitleChevron = element(
@@ -74,27 +41,6 @@ function paletteIcon(iconId: string) {
 async function getPaletteIconTopY(iconId: string) {
   const attrs = await paletteIcon(iconId).getAttributes();
   return (attrs as IosElementAttributes).frame.y;
-}
-
-/**
- * Dismisses the presented context menu without selecting any item.
- *
- * The platter is anchored under the header's trailing items, so it covers the
- * centre of this full-width text: a centre tap hits the menu and only pops one
- * submenu level, while a tap near the leading edge is clear of it and closes
- * the menu at any depth. The label is just body text underneath, used to locate
- * that point — it has nothing to do with the displayInline prop.
- */
-async function dismissMenu() {
-  const { frame } = await getElementAttributes({
-    by: 'id',
-    value: 'text-display-inline',
-  });
-  await device.tap({
-    x: frame.x + frame.width / 10,
-    y: frame.y + frame.height / 2,
-  });
-  await waitFor(contextMenu).not.toExist();
 }
 
 /** Taps a toggle and asserts the label it settles on. */
@@ -131,7 +77,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('shows Copy, Paste, Share, Sort By, Delete at the top level', async () => {
-      await optionsMenuButton.tap();
+      await openContextMenu(optionsMenuButton);
       await expect(element(by.text('Copy'))).toBeVisible();
       await expect(element(by.text('Paste'))).toBeVisible();
       await expect(element(by.text('Share'))).toBeVisible();
@@ -159,7 +105,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('dismisses the Sort By and Rating submenus without selecting an item', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
       await expect(
         element(by.id('toggle-display-inline-rating')),
       ).toBeVisible();
@@ -173,7 +119,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('still shows the same top-level items after inlining Rating', async () => {
-      await optionsMenuButton.tap();
+      await openContextMenu(optionsMenuButton);
       await expect(element(by.text('Copy'))).toBeVisible();
       await expect(element(by.text('Paste'))).toBeVisible();
       await expect(element(by.text('Share'))).toBeVisible();
@@ -195,7 +141,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('dismisses the Sort By submenu with Rating inlined', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
       await expect(
         element(by.id('toggle-display-inline-rating')),
       ).toBeVisible();
@@ -213,7 +159,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('inlines Name, Date, Size, Rating alongside Copy, Paste, Share, Delete at the top level', async () => {
-      await optionsMenuButton.tap();
+      await openContextMenu(optionsMenuButton);
       await expect(element(by.text('Copy'))).toBeVisible();
       await expect(element(by.text('Paste'))).toBeVisible();
       await expect(element(by.text('Share'))).toBeVisible();
@@ -235,7 +181,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('dismisses the top-level menu with Sort By inlined', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
       await expect(
         element(by.id('toggle-display-inline-rating')),
       ).toBeVisible();
@@ -249,7 +195,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('fully flattens every item into a single top-level list when both displayInline flags are true', async () => {
-      await optionsMenuButton.tap();
+      await openContextMenu(optionsMenuButton);
       await expect(element(by.text('Copy'))).toBeVisible();
       await expect(element(by.text('Paste'))).toBeVisible();
       await expect(element(by.text('Share'))).toBeVisible();
@@ -265,7 +211,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
       await expect(chevronFor('Rating')).not.toExist();
       await expect(chevronFor('Sort By')).not.toExist();
 
-      await dismissMenu();
+      await dismissContextMenu();
     });
   });
 
@@ -280,7 +226,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('shows Text Style and Reset Formatting at the top level', async () => {
-      await paletteMenuButton.tap();
+      await openContextMenu(paletteMenuButton);
       await expect(element(by.text('Text Style'))).toBeVisible();
       await expect(chevronFor('Text Style')).toBeVisible();
       await expect(element(by.text('Reset Formatting'))).toBeVisible();
@@ -300,7 +246,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('dismisses the Text Style submenu', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
       await expect(element(by.id('toggle-display-as-palette'))).toBeVisible();
     });
 
@@ -312,7 +258,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('still shows Text Style as a collapsed submenu at the top level', async () => {
-      await paletteMenuButton.tap();
+      await openContextMenu(paletteMenuButton);
       await expect(element(by.text('Text Style'))).toBeVisible();
       await expect(chevronFor('Text Style')).toBeVisible();
       await expect(element(by.text('Reset Formatting'))).toBeVisible();
@@ -342,7 +288,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('dismisses the palette submenu', async () => {
-      await dismissMenu();
+      await dismissContextMenu();
       await expect(element(by.id('toggle-display-as-palette'))).toBeVisible();
     });
 
@@ -354,7 +300,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
     });
 
     it('inlines Bold, Italic, Underline, Strikethrough alongside Reset Formatting at the top level', async () => {
-      await paletteMenuButton.tap();
+      await openContextMenu(paletteMenuButton);
       await expect(element(by.text('Bold'))).not.toBeVisible();
       await expect(element(by.text('Italic'))).not.toBeVisible();
       await expect(element(by.text('Underline'))).not.toBeVisible();
@@ -381,7 +327,7 @@ describeIfiOS('Stack Header Menu Options (iOS)', () => {
         ),
       ).toBeVisible();
 
-      await dismissMenu();
+      await dismissContextMenu();
     });
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios.e2e.ts
@@ -1,30 +1,12 @@
-import { device, expect, element, by, waitFor } from 'detox';
+import { device, expect, element, by } from 'detox';
 import {
   describeIfiOS,
   dismissToast,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
-  CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
-} from '../../native-class-names';
-
-function textItem(label: string) {
-  return element(by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON).and(by.label(label)));
-}
-
-// A checked toggle/singleSelection row inside the presented native UIMenu.
-function checkmarkFor(itemLabel: string) {
-  return element(
-    by
-      .id('checkmark')
-      .withAncestor(
-        by
-          .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-          .and(by.label(itemLabel)),
-      ),
-  );
-}
+import { checkmarkFor, openContextMenu } from '../../e2e-utils';
+import { headerItem as textItem } from '../../e2e-utils';
 
 // `SettingsPicker` derives its option testIDs from the label only, not the item
 // index (`title-foo`, `menu-single`, …), so those IDs are duplicated across
@@ -32,20 +14,22 @@ function checkmarkFor(itemLabel: string) {
 // single picker, taps the option, and closes it again before the next call -
 // i.e. at most one picker is expanded at any time. Keep that invariant.
 async function setTitle(itemIndex: number, variant: 'foo' | 'bar') {
-  const pickerId = `title-picker-${itemIndex}`;
-  await element(by.id(pickerId)).tap();
-  await element(by.id(`title-${variant}`)).tap();
-  await element(by.id(pickerId)).tap();
+  await selectPickerOption({
+    pickerId: `title-picker-${itemIndex}`,
+    label: 'Title',
+    option: variant,
+  });
 }
 
 async function setMenuMode(
   itemIndex: number,
   mode: 'none' | 'single' | 'multi',
 ) {
-  const pickerId = `menu-picker-${itemIndex}`;
-  await element(by.id(pickerId)).tap();
-  await element(by.id(`menu-${mode}`)).tap();
-  await element(by.id(pickerId)).tap();
+  await selectPickerOption({
+    pickerId: `menu-picker-${itemIndex}`,
+    label: 'Menu',
+    option: mode,
+  });
 }
 
 describeIfiOS('Stack Header Selective Updates (iOS)', () => {
@@ -78,7 +62,7 @@ describeIfiOS('Stack Header Selective Updates (iOS)', () => {
 
   describe('opening Item 1 menu by long press with singleSelection', () => {
     it('should select Option-0-B via the menu and emit the selection toast', async () => {
-      await textItem('Bar 1').longPress();
+      await openContextMenu(textItem('Bar 1'), { gesture: 'longPress' });
       await expect(checkmarkFor('Option-0-A')).toBeVisible();
 
       await element(by.text('Option-0-B')).tap();
@@ -87,7 +71,7 @@ describeIfiOS('Stack Header Selective Updates (iOS)', () => {
     });
 
     it('should show only Option-0-B checked when the menu is reopened', async () => {
-      await textItem('Bar 1').longPress();
+      await openContextMenu(textItem('Bar 1'), { gesture: 'longPress' });
 
       await expect(checkmarkFor('Option-0-B')).toBeVisible();
       await expect(checkmarkFor('Option-0-A')).not.toExist();
@@ -98,14 +82,14 @@ describeIfiOS('Stack Header Selective Updates (iOS)', () => {
   it('should default to Option-0-A, add Option-0-B to the multi selection, emit a combined toast, and keep both checked on reopen', async () => {
     await setMenuMode(0, 'multi');
 
-    await textItem('Bar 1').longPress();
+    await openContextMenu(textItem('Bar 1'), { gesture: 'longPress' });
     await expect(checkmarkFor('Option-0-A')).toBeVisible();
 
     await element(by.text('Option-0-B')).tap();
     await dismissToast('1. Pressed Item 1');
     await dismissToast('1. Item 1 [multi]: "Option-0-A", "Option-0-B"');
 
-    await textItem('Bar 1').longPress();
+    await openContextMenu(textItem('Bar 1'), { gesture: 'longPress' });
     await expect(checkmarkFor('Option-0-A')).toBeVisible();
     await expect(checkmarkFor('Option-0-B')).toBeVisible();
     await dismissToast('1. Pressed Item 1');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-selective-updates-ios.e2e.ts
@@ -1,12 +1,13 @@
 import { device, expect, element, by } from 'detox';
 import {
+  checkmarkFor,
   describeIfiOS,
   dismissToast,
+  headerItem as textItem,
+  openContextMenu,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import { checkmarkFor, openContextMenu } from '../../e2e-utils';
-import { headerItem as textItem } from '../../e2e-utils';
 
 // `SettingsPicker` derives its option testIDs from the label only, not the item
 // index (`title-foo`, `menu-single`, …), so those IDs are duplicated across

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios.e2e.ts
@@ -1,25 +1,23 @@
 import { device, expect, element, by } from 'detox';
 import {
+  chevronFor,
   describeIfiOS,
   describeIfiOS26,
-  dismissToast,
-  selectSingleFeatureTestsScreen,
-} from '../../e2e-utils';
-import {
-  chevronFor,
   dismissContextMenu,
-  menuRow as anyMenuRow,
+  dismissToast,
+  headerItem,
+  menuRow,
   openContextMenu,
+  selectSingleFeatureTestsScreen,
   submenuTitleRow,
 } from '../../e2e-utils';
-import { headerItem } from '../../e2e-utils';
 
 /**
  * A selectable row of the presented menu. A submenu's pinned title/back row
  * shares the label of the submenu's first entry when that item also has an
  * `onPress`, so only action rows are matched here.
  */
-const menuRow = (title: string) => anyMenuRow(title, { actionsOnly: true });
+const actionRow = (title: string) => menuRow(title, { actionsOnly: true });
 
 /** UIKit's automatic identifier for the iOS 26 toolbar overflow ("More") item. */
 const overflowButton = element(by.id('OverflowBarButtonItem'));
@@ -50,8 +48,8 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
   it('should open a native menu with two actions on a single tap of Menu 1, which has no onPress', async () => {
     await openContextMenu(headerItem('Menu 1'));
 
-    await expect(menuRow('Action 1-1')).toBeVisible();
-    await expect(menuRow('Action 1-2')).toBeVisible();
+    await expect(actionRow('Action 1-1')).toBeVisible();
+    await expect(actionRow('Action 1-2')).toBeVisible();
 
     await dismissContextMenu();
   });
@@ -64,8 +62,8 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
     // to leave a clean state for the following tests.
     await openContextMenu(headerItem('Item 0'), { gesture: 'longPress' });
 
-    await expect(menuRow('Action 0-1')).toBeVisible();
-    await expect(menuRow('Action 0-2')).toBeVisible();
+    await expect(actionRow('Action 0-1')).toBeVisible();
+    await expect(actionRow('Action 0-2')).toBeVisible();
     await dismissContextMenu();
   });
 
@@ -86,30 +84,30 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
     it('should list Item 0 and Menu 1 as entries when opening the overflow menu', async () => {
       await openContextMenu(overflowButton);
 
-      await expect(menuRow('Item 0')).toBeVisible();
-      await expect(menuRow('Menu 1')).toBeVisible();
+      await expect(actionRow('Item 0')).toBeVisible();
+      await expect(actionRow('Menu 1')).toBeVisible();
       await expect(chevronFor('Item 0')).toBeVisible();
       await expect(chevronFor('Menu 1')).toBeVisible();
     });
 
     it("should open a 3-row submenu (Item 0, Action 0-1, Action 0-2) for the overflow's Item 0 entry, and fire the onPress toast when tapping its own row", async () => {
-      await menuRow('Item 0').tap();
+      await actionRow('Item 0').tap();
 
-      await expect(menuRow('Item 0').atIndex(1)).toBeVisible();
+      await expect(actionRow('Item 0').atIndex(1)).toBeVisible();
       await expect(submenuTitleRow('Item 0')).toBeVisible();
-      await expect(menuRow('Action 0-1')).toBeVisible();
-      await expect(menuRow('Action 0-2')).toBeVisible();
+      await expect(actionRow('Action 0-1')).toBeVisible();
+      await expect(actionRow('Action 0-2')).toBeVisible();
 
-      await menuRow('Item 0').atIndex(1).tap();
+      await actionRow('Item 0').atIndex(1).tap();
       await dismissToast('1. onPress Item 0');
     });
 
     it("should open a 2-row submenu (Action 1-1, Action 1-2) for the overflow's Menu 1 entry, which has no onPress", async () => {
       await openContextMenu(overflowButton);
-      await menuRow('Menu 1').tap();
+      await actionRow('Menu 1').tap();
 
-      await expect(menuRow('Action 1-1')).toBeVisible();
-      await expect(menuRow('Action 1-2')).toBeVisible();
+      await expect(actionRow('Action 1-1')).toBeVisible();
+      await expect(actionRow('Action 1-2')).toBeVisible();
 
       await dismissContextMenu();
     });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-header-subview-onpress-ios.e2e.ts
@@ -1,84 +1,31 @@
-import { device, expect, element, by, waitFor } from 'detox';
+import { device, expect, element, by } from 'detox';
 import {
   describeIfiOS,
+  describeIfiOS26,
   dismissToast,
-  getElementAttributes,
-  isIOSVersionAtLeast,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import {
-  CLASS_NAME_UI_BUTTON_BAR_BUTTON,
-  CLASS_NAME_UI_CONTEXT_MENU_CELL,
-  CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW,
-  CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW,
-  CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW,
-} from '../../native-class-names';
+  chevronFor,
+  dismissContextMenu,
+  menuRow as anyMenuRow,
+  openContextMenu,
+  submenuTitleRow,
+} from '../../e2e-utils';
+import { headerItem } from '../../e2e-utils';
 
 /**
- * The iOS 26 toolbar overflow ("More") button only appears once the header
- * runs out of room for trailing items. Scenario steps 5-8 are scoped to
- * iPhone (iOS 26) and don't apply on iOS 18.
+ * A selectable row of the presented menu. A submenu's pinned title/back row
+ * shares the label of the submenu's first entry when that item also has an
+ * `onPress`, so only action rows are matched here.
  */
-const describeIfIOS26 = isIOSVersionAtLeast('26.0') ? describe : describe.skip;
+const menuRow = (title: string) => anyMenuRow(title, { actionsOnly: true });
 
-/** A title-only trailing header button item, addressed by its visible title.
- * With or without an attached `menu`, this resolves to `_UIButtonBarButton`. */
-function headerItem(title: string) {
-  return element(by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON).and(by.label(title)));
-}
-
-const contextMenu = element(by.type(CLASS_NAME_UI_CONTEXT_MENU_LIST_VIEW));
-
-/**
- * A selectable row inside a presented native UIMenu (a header-item menu, or on
- * iOS 26 the toolbar overflow menu and its submenus), addressed by its title.
- * The `_UIContextMenuCell` ancestor excludes a submenu's pinned title/back row,
- * which shares the label of the submenu's first entry when that item also has
- * an `onPress`.
- */
-function menuRow(title: string) {
-  return element(
-    by
-      .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-      .and(by.label(title))
-      .withAncestor(by.type(CLASS_NAME_UI_CONTEXT_MENU_CELL)),
-  );
-}
-
+/** UIKit's automatic identifier for the iOS 26 toolbar overflow ("More") item. */
 const overflowButton = element(by.id('OverflowBarButtonItem'));
-
-/**
- * Dismisses any presented native UIMenu (header-item, or on iOS 26 the overflow
- * menu and its submenus) by tapping UIKit's full-screen "Dismiss context menu"
- * element, which every context menu exposes regardless of its anchor - so no
- * off-menu coordinate has to be computed.
- */
-async function dismissMenu() {
-  const { frame } = await getElementAttributes({
-    by: 'type',
-    value: '_UIContextMenuPlatterTransitionView',
-  });
-  await device.tap({
-    x: frame.x + frame.width / 2,
-    y: frame.y + frame.height / 2,
-  });
-  await waitFor(contextMenu).not.toExist();
-}
 
 async function toggleItemsCount() {
   await element(by.id('toggle-items-count-button')).tap();
-}
-
-function chevronFor(itemLabel: string) {
-  return element(
-    by
-      .id('chevron.forward')
-      .withAncestor(
-        by
-          .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-          .and(by.label(itemLabel)),
-      ),
-  );
 }
 
 describeIfiOS('Stack Header Subview onPress (iOS)', () => {
@@ -101,12 +48,12 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
   });
 
   it('should open a native menu with two actions on a single tap of Menu 1, which has no onPress', async () => {
-    await headerItem('Menu 1').tap();
+    await openContextMenu(headerItem('Menu 1'));
 
     await expect(menuRow('Action 1-1')).toBeVisible();
     await expect(menuRow('Action 1-2')).toBeVisible();
 
-    await dismissMenu();
+    await dismissContextMenu();
   });
 
   it("should require a long press (not a tap) to open Item 0's own menu, since a tap fires onPress instead", async () => {
@@ -115,14 +62,14 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
     // toast. The scenario expects only the native menu to appear on a real long
     // press, so we assert the menu opened and dismiss it (rather than the toast)
     // to leave a clean state for the following tests.
-    await headerItem('Item 0').longPress();
+    await openContextMenu(headerItem('Item 0'), { gesture: 'longPress' });
 
     await expect(menuRow('Action 0-1')).toBeVisible();
     await expect(menuRow('Action 0-2')).toBeVisible();
-    await dismissMenu();
+    await dismissContextMenu();
   });
 
-  describeIfIOS26('iOS 26 toolbar overflow ("More") menu', () => {
+  describeIfiOS26('iOS 26 toolbar overflow ("More") menu', () => {
     it('should move Item 0 and Menu 1 into the overflow button once 5 items are configured', async () => {
       await toggleItemsCount(); // 2 -> 3
       await toggleItemsCount(); // 3 -> 4
@@ -137,7 +84,7 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
     });
 
     it('should list Item 0 and Menu 1 as entries when opening the overflow menu', async () => {
-      await overflowButton.tap();
+      await openContextMenu(overflowButton);
 
       await expect(menuRow('Item 0')).toBeVisible();
       await expect(menuRow('Menu 1')).toBeVisible();
@@ -149,16 +96,7 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
       await menuRow('Item 0').tap();
 
       await expect(menuRow('Item 0').atIndex(1)).toBeVisible();
-      await expect(
-        element(
-          by
-            .type(CLASS_NAME_UI_CONTEXT_MENU_CELL_CONTENT_VIEW)
-            .and(by.label('Item 0'))
-            .withAncestor(
-              by.type(CLASS_NAME_UI_CONTEXT_MENU_SUBMENU_TITLE_VIEW),
-            ),
-        ),
-      ).toBeVisible();
+      await expect(submenuTitleRow('Item 0')).toBeVisible();
       await expect(menuRow('Action 0-1')).toBeVisible();
       await expect(menuRow('Action 0-2')).toBeVisible();
 
@@ -167,13 +105,13 @@ describeIfiOS('Stack Header Subview onPress (iOS)', () => {
     });
 
     it("should open a 2-row submenu (Action 1-1, Action 1-2) for the overflow's Menu 1 entry, which has no onPress", async () => {
-      await overflowButton.tap();
+      await openContextMenu(overflowButton);
       await menuRow('Menu 1').tap();
 
       await expect(menuRow('Action 1-1')).toBeVisible();
       await expect(menuRow('Action 1-2')).toBeVisible();
 
-      await dismissMenu();
+      await dismissContextMenu();
     });
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
@@ -1,10 +1,11 @@
-import { device, element, by, waitFor } from 'detox';
+import { device, element, by } from 'detox';
 import {
   describeIfAndroid,
   describeIfiOS,
   selectSingleFeatureTestsScreen,
   dismissToast,
   tapTopmostButton,
+  waitForRouteName,
 } from '../../e2e-utils';
 import { tapBarBackButton } from '../../elements/back-button';
 import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../../native-class-names';
@@ -39,12 +40,6 @@ import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../../native-class-names';
  *   scenario.
  */
 
-async function waitForRoute(routeName: string): Promise<void> {
-  await waitFor(element(by.text(`Name: ${routeName}`)))
-    .toBeVisible()
-    .withTimeout(3000);
-}
-
 describeIfiOS('Stack v5: lifecycle events', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -55,7 +50,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   });
 
   it('should show Home and fire onWillAppear + onDidAppear on launch', async () => {
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('2. Home: onDidAppear');
     await dismissToast('1. Home: onWillAppear');
   });
@@ -63,7 +58,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the push event set when pushing A over Home', async () => {
     await element(by.text('Push A')).tap();
 
-    await waitForRoute('A');
+    await waitForRouteName('A');
     await dismissToast('4. A: onDidAppear');
     await dismissToast('3. Home: onDidDisappear');
     await dismissToast('2. A: onWillAppear');
@@ -73,7 +68,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the pop event set when popping A via the native header back button', async () => {
     await tapBarBackButton();
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('4. Home: onDidAppear');
     await dismissToast('3. A: onDidDisappear');
     await dismissToast('2. Home: onWillAppear');
@@ -82,7 +77,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
   it('should fire the identical pop event set when popping A via native back gesture', async () => {
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     await dismissToast('4. A: onDidAppear');
     await dismissToast('3. Home: onDidDisappear');
     await dismissToast('2. A: onWillAppear');
@@ -90,7 +85,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await element(by.id('screenA-layout-view')).swipe('right');
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('4. Home: onDidAppear');
     await dismissToast('3. A: onDidDisappear');
     await dismissToast('2. Home: onWillAppear');
@@ -99,7 +94,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
   it('should fire the identical pop event set when popping A via the Pop button', async () => {
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     await dismissToast('4. A: onDidAppear');
     await dismissToast('3. Home: onDidDisappear');
     await dismissToast('2. A: onWillAppear');
@@ -107,7 +102,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await element(by.text('Pop')).tap();
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('4. Home: onDidAppear');
     await dismissToast('3. A: onDidDisappear');
     await dismissToast('2. Home: onWillAppear');
@@ -117,7 +112,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the duplicated container + initial-screen push event set when pushing NestedStack', async () => {
     await element(by.text('Push NestedStack')).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('6. NestedHome: onDidAppear');
     await dismissToast('5. NestedStack: onDidAppear');
     await dismissToast('4. Home: onDidDisappear');
@@ -129,7 +124,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the inner push event set when pushing NestedA inside the nested stack', async () => {
     await element(by.text('Push NestedA')).tap();
 
-    await waitForRoute('NestedA');
+    await waitForRouteName('NestedA');
     await dismissToast('4. NestedA: onDidAppear');
     await dismissToast('3. NestedHome: onDidDisappear');
     await dismissToast('2. NestedA: onWillAppear');
@@ -141,7 +136,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
       by.type(CLASS_NAME_UI_BUTTON_BAR_BUTTON).withAncestor(by.id('NestedA')),
     ).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('4. NestedHome: onDidAppear');
     await dismissToast('3. NestedA: onDidDisappear');
     await dismissToast('2. NestedHome: onWillAppear');
@@ -150,7 +145,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
   it('should fire the identical inner pop event set when popping NestedA via native back gesture', async () => {
     await element(by.text('Push NestedA')).tap();
-    await waitForRoute('NestedA');
+    await waitForRouteName('NestedA');
     await dismissToast('4. NestedA: onDidAppear');
     await dismissToast('3. NestedHome: onDidDisappear');
     await dismissToast('2. NestedA: onWillAppear');
@@ -158,7 +153,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await element(by.id('nested-screenA-layout-view')).swipe('right');
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('4. NestedHome: onDidAppear');
     await dismissToast('3. NestedA: onDidDisappear');
     await dismissToast('2. NestedHome: onWillAppear');
@@ -167,7 +162,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
   it('should fire the identical inner pop event set when popping NestedA via the Pop button', async () => {
     await element(by.text('Push NestedA')).tap();
-    await waitForRoute('NestedA');
+    await waitForRouteName('NestedA');
     await dismissToast('4. NestedA: onDidAppear');
     await dismissToast('3. NestedHome: onDidDisappear');
     await dismissToast('2. NestedA: onWillAppear');
@@ -175,7 +170,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await element(by.text('Pop')).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('4. NestedHome: onDidAppear');
     await dismissToast('3. NestedA: onDidDisappear');
     await dismissToast('2. NestedHome: onWillAppear');
@@ -190,7 +185,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
     // event set.
     await element(by.id('nested-home-screen-layout-view')).swipe('right');
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('6. Home: onDidAppear');
     await dismissToast('5. NestedHome: onDidDisappear');
     await dismissToast('4. NestedStack: onDidDisappear');
@@ -202,7 +197,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the identical container-pop event set when popping the container from NestedHome via the NestedStack header back button', async () => {
     await element(by.text('Push NestedStack')).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('6. NestedHome: onDidAppear');
     await dismissToast('5. NestedStack: onDidAppear');
     await dismissToast('4. Home: onDidDisappear');
@@ -212,7 +207,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await tapBarBackButton();
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('6. Home: onDidAppear');
     await dismissToast('5. NestedHome: onDidDisappear');
     await dismissToast('4. NestedStack: onDidDisappear');
@@ -224,7 +219,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should fire the identical container-pop event set when the Pop button on the nested root bubbles to a container pop', async () => {
     await element(by.text('Push NestedStack')).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('6. NestedHome: onDidAppear');
     await dismissToast('5. NestedStack: onDidAppear');
     await dismissToast('4. Home: onDidDisappear');
@@ -234,7 +229,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
 
     await element(by.text('Pop')).tap();
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('6. Home: onDidAppear');
     await dismissToast('5. NestedHome: onDidDisappear');
     await dismissToast('4. NestedStack: onDidDisappear');
@@ -246,7 +241,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
   it('should pop the whole NestedStack container from NestedA to Home in one step via the outer NestedStack header back button (skipping NestedHome)', async () => {
     await element(by.text('Push NestedStack')).tap();
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('6. NestedHome: onDidAppear');
     await dismissToast('5. NestedStack: onDidAppear');
     await dismissToast('4. Home: onDidDisappear');
@@ -255,7 +250,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
     await dismissToast('1. Home: onWillDisappear');
 
     await element(by.text('Push NestedA')).tap();
-    await waitForRoute('NestedA');
+    await waitForRouteName('NestedA');
     await dismissToast('4. NestedA: onDidAppear');
     await dismissToast('3. NestedHome: onDidDisappear');
     await dismissToast('2. NestedA: onWillAppear');
@@ -267,7 +262,7 @@ describeIfiOS('Stack v5: lifecycle events', () => {
         .withAncestor(by.id('NestedStack')),
     ).tap();
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('6. Home: onDidAppear');
     await dismissToast('5. NestedA: onDidDisappear');
     await dismissToast('4. NestedStack: onDidDisappear');
@@ -294,7 +289,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   });
 
   it('should show Home and fire onWillAppear + onDidAppear on launch', async () => {
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('2. Home: onDidAppear');
     await dismissToast('1. Home: onWillAppear');
   });
@@ -302,7 +297,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   it('should fire the push events (onWillAppear + onDidAppear) for A only when pushing A over Home', async () => {
     await tapTopmostButton(PUSH_A);
 
-    await waitForRoute('A');
+    await waitForRouteName('A');
     await dismissToast('2. A: onDidAppear');
     await dismissToast('1. A: onWillAppear');
   });
@@ -310,7 +305,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   it('should fire the pop events (onWillDisappear + onDidDisappear) for A only when popping A via the Pop button', async () => {
     await tapTopmostButton(POP);
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('2. A: onDidDisappear');
     await dismissToast('1. A: onWillDisappear');
   });
@@ -318,7 +313,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   it('should fire duplicated push events (onWillAppear + onDidAppear) for both the NestedStack container and its initial NestedHome screen when pushing NestedStack', async () => {
     await tapTopmostButton(PUSH_NESTED_STACK);
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('4. NestedHome: onDidAppear');
     await dismissToast('3. NestedStack: onDidAppear');
     await dismissToast('2. NestedHome: onWillAppear');
@@ -328,7 +323,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   it('should fire the push events (onWillAppear + onDidAppear) for the inner NestedA screen only when pushing NestedA inside the nested stack', async () => {
     await tapTopmostButton(PUSH_NESTED_A);
 
-    await waitForRoute('NestedA');
+    await waitForRouteName('NestedA');
     await dismissToast('2. NestedA: onDidAppear');
     await dismissToast('1. NestedA: onWillAppear');
   });
@@ -336,7 +331,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   it('should fire the pop events (onWillDisappear + onDidDisappear) for the inner NestedA screen only when popping NestedA via the Pop button', async () => {
     await tapTopmostButton(POP);
 
-    await waitForRoute('NestedHome');
+    await waitForRouteName('NestedHome');
     await dismissToast('2. NestedA: onDidDisappear');
     await dismissToast('1. NestedA: onWillDisappear');
   });
@@ -347,7 +342,7 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
     // screen within it.
     await tapTopmostButton(POP);
 
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     await dismissToast('4. NestedStack: onDidDisappear');
     await dismissToast('3. NestedHome: onDidDisappear');
     await dismissToast('2. NestedStack: onWillDisappear');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
@@ -1,5 +1,4 @@
 import { device, element, by, waitFor } from 'detox';
-import { IosElementAttributes, AndroidElementAttributes } from 'detox/detox';
 import {
   describeIfAndroid,
   describeIfiOS,
@@ -39,8 +38,6 @@ import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../../native-class-names';
  *   iOS and manually on Android via the direct launch documented in the
  *   scenario.
  */
-
-type AnyAttributes = IosElementAttributes | AndroidElementAttributes;
 
 async function waitForRoute(routeName: string): Promise<void> {
   await waitFor(element(by.text(`Name: ${routeName}`)))

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lifecycle-events.e2e.ts
@@ -4,7 +4,7 @@ import {
   describeIfiOS,
   selectSingleFeatureTestsScreen,
   dismissToast,
-  tapTopmost,
+  tapTopmostButton,
 } from '../../e2e-utils';
 import { tapBarBackButton } from '../../elements/back-button';
 import { CLASS_NAME_UI_BUTTON_BAR_BUTTON } from '../../native-class-names';
@@ -284,11 +284,6 @@ describeIfAndroid('Stack v5: lifecycle events', () => {
   const PUSH_NESTED_STACK = 'PUSH NESTEDSTACK';
   const PUSH_NESTED_A = 'PUSH NESTEDA';
   const POP = 'POP';
-
-  /** Taps a Push/Pop button on the topmost stacked screen. */
-  async function tapTopmostButton(title: string): Promise<void> {
-    await tapTopmost(by.text(title));
-  }
 
   beforeAll(async () => {
     await device.reloadReactNative();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -5,6 +5,7 @@ import {
   countMatches,
   DEFAULT_TIMEOUT_MS,
   describeIfAndroid,
+  expectTopmostVisible,
   getFrame,
   getSingleMatch,
   scrollUntilVisible,
@@ -195,7 +196,7 @@ async function selectLiftOnScroll(value: TriState) {
 }
 
 async function expectHeaderAttached() {
-  await waitFor(element(stackV5Toolbar())).toBeVisible().withTimeout(3000);
+  await expectTopmostVisible(stackV5Toolbar);
   await expect(element(by.text(HEADER_TITLE))).toBeVisible();
   jestExpect(await countMatches(stackV5AppBar())).toBe(1);
 }

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -4,16 +4,14 @@ import type { AndroidElementAttributes } from 'detox/detox';
 import {
   countMatches,
   describeIfAndroid,
-  getElementAttributes,
-  getMatches,
+  getFrame,
+  getSingleMatch,
   scrollUntilVisible,
   selectSingleFeatureTestsScreen,
+  stackV5AppBar,
+  stackV5Toolbar,
   waitUntil,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_BAR_LAYOUT,
-  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
-} from '../../native-class-names';
 import type { TriState } from '@apps/tests/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android';
 
 /**
@@ -41,36 +39,10 @@ const LIFT_PICKER = 'liftonscroll-picker';
 // lifted state has to be polled rather than read once.
 const LIFT_TIMEOUT_MS = 3000;
 
-// The legacy headers of the outer navigator build `CustomToolbar`, which extends
-// `Toolbar` but not `MaterialToolbar`, so this stays scoped to the Stack v5
-// header under test.
-const toolbar = by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
+const appBarAttributes = () =>
+  getSingleMatch(stackV5AppBar()) as Promise<AndroidElementAttributes>;
 
-// Every screen the outer navigator has stacked keeps its own `AppBarLayout` in
-// the hierarchy, so the bare class matches several. Only the Stack v5 header
-// wraps a `MaterialToolbar`.
-const appBar = by
-  .type(CLASS_NAME_ANDROID_APP_BAR_LAYOUT)
-  .withDescendant(toolbar);
-
-async function appBarAttributes(): Promise<AndroidElementAttributes> {
-  const matches = await getMatches(appBar);
-
-  // Guards against reading a sibling screen's app bar if the scoping above ever
-  // stops being unique.
-  jestExpect(matches).toHaveLength(1);
-
-  return matches[0] as AndroidElementAttributes;
-}
-
-async function contentFrame() {
-  const attributes = (await getElementAttributes({
-    by: 'id',
-    value: SCROLL_VIEW,
-  })) as AndroidElementAttributes;
-
-  return attributes.frame;
-}
+const contentFrame = () => getFrame(by.id(SCROLL_VIEW));
 
 async function appBarElevation(): Promise<number> {
   return (await appBarAttributes()).elevation;
@@ -219,9 +191,9 @@ async function selectLiftOnScroll(value: TriState) {
 }
 
 async function expectHeaderAttached() {
-  await waitFor(element(toolbar)).toBeVisible().withTimeout(3000);
+  await waitFor(element(stackV5Toolbar())).toBeVisible().withTimeout(3000);
   await expect(element(by.text(HEADER_TITLE))).toBeVisible();
-  jestExpect(await countMatches(appBar)).toBe(1);
+  jestExpect(await countMatches(stackV5AppBar())).toBe(1);
 }
 
 // A hidden or detached header is removed from the hierarchy, so its absence is
@@ -231,8 +203,8 @@ async function expectHeaderDetached() {
   await waitFor(element(by.id(SCROLL_VIEW)))
     .toBeVisible()
     .withTimeout(3000);
-  await expect(element(appBar)).not.toExist();
-  await expect(element(toolbar)).not.toExist();
+  await expect(element(stackV5AppBar())).not.toExist();
+  await expect(element(stackV5Toolbar())).not.toExist();
   // Implied by the toolbar being gone — the title is one of its children — but
   // asserted anyway: it is the part a reader of `scenario.md` actually checks
   // ("there is no header"), and it keeps holding if the title ever stops being

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -40,9 +40,12 @@ const LIFT_PICKER = 'liftonscroll-picker';
 const LIFT_TIMEOUT_MS = 3000;
 
 const appBarAttributes = () =>
-  getSingleMatch(stackV5AppBar()) as Promise<AndroidElementAttributes>;
+  getSingleMatch(
+    stackV5AppBar(),
+    'the Stack v5 app bar',
+  ) as Promise<AndroidElementAttributes>;
 
-const contentFrame = () => getFrame(by.id(SCROLL_VIEW));
+const contentFrame = () => getFrame(by.id(SCROLL_VIEW), SCROLL_VIEW);
 
 async function appBarElevation(): Promise<number> {
   return (await appBarAttributes()).elevation;

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-lift-on-scroll-android.e2e.ts
@@ -3,6 +3,7 @@ import { device, expect, element, by, waitFor } from 'detox';
 import type { AndroidElementAttributes } from 'detox/detox';
 import {
   countMatches,
+  DEFAULT_TIMEOUT_MS,
   describeIfAndroid,
   getFrame,
   getSingleMatch,
@@ -37,7 +38,7 @@ const LIFT_PICKER = 'liftonscroll-picker';
 
 // Espresso's idle sync does not cover the app bar's elevation animation, so the
 // lifted state has to be polled rather than read once.
-const LIFT_TIMEOUT_MS = 3000;
+const LIFT_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 
 const appBarAttributes = () =>
   getSingleMatch(

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
@@ -1,20 +1,19 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
-import { NativeMatcher } from 'detox/detox';
 import {
   describeIfAndroid,
   dismissNextToast,
   expectNoToast,
+  expectTopmostButtons,
   expectTopmostVisible,
-  getTopmostMatch,
+  readTopmostText,
   selectSingleFeatureTestsScreen,
+  stackV5BackButton,
+  stackV5HeaderTitle,
   tapTopmost,
-  waitUntil,
+  tapTopmostButton,
+  waitForTopmostRoute,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
-  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
-} from '../../native-class-names';
 
 /**
  * Stack v5 `preventNativeDismiss` — a nested stack inside another stack. See
@@ -28,43 +27,10 @@ import {
  * back press would navigate out of the example app's own navigation.
  */
 
-// Matchers are built fresh on each call, never shared: on Android `atIndex`
-// rewrites a matcher in place (see `tapTopmost`).
-
-/**
- * The Stack v5 header's toolbar. Scoped to `MaterialToolbar` so it never
- * matches the example app's own v4 header, a `CustomToolbar` — which extends
- * `Toolbar` but not `MaterialToolbar`.
- */
-const stackV5ToolbarMatcher = (): NativeMatcher =>
-  by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR);
-
-/**
- * The header's back chevron. A covered screen keeps its toolbar but loses its
- * navigation icon, so while a headered screen is on top this resolves to that
- * screen's chevron alone. Absence is not reliable: under a headerless top
- * screen the covered screen's chevron is still there and still reads visible.
- */
-const stackV5BackButtonMatcher = (): NativeMatcher =>
-  by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
-    .withAncestor(stackV5ToolbarMatcher());
-
-/** A native header title, which renders as a `MaterialToolbar` child. */
-const stackV5HeaderTitleMatcher = (title: string): NativeMatcher =>
-  by.text(title).withAncestor(stackV5ToolbarMatcher());
-
 /** Taps the back chevron of the topmost headered screen. */
 async function tapStackV5BackButton(): Promise<void> {
-  await tapTopmost(stackV5BackButtonMatcher());
+  await tapTopmost(stackV5BackButton());
 }
-
-// Covered screens stay attached on Android, so the widget matchers below
-// resolve to one element per stacked screen. Every read is normalized to the
-// last match: the topmost screen of the innermost stack.
-
-/** @see apps/src/tests/shared/components/stack-v5/StackRouteInformation.tsx */
-const ROUTE_KEY_TEST_ID = 'stack-route-key';
 
 /** Rendered by the `preventNativeDismiss` test screens' own info label. */
 const PREVENT_NATIVE_DISMISS_TEST_ID = 'prevent-native-dismiss-info';
@@ -88,61 +54,9 @@ const TOGGLE_PREVENT_NATIVE_DISMISS_LABEL = buttonLabel(
   'Toggle Prevent Native Dismiss',
 );
 
-async function readTopmostText(testID: string): Promise<string> {
-  const top = await getTopmostMatch(by.id(testID));
-  return (top.text ?? top.label ?? '').trim();
-}
-
-/** The `Key: ...` label of the topmost screen. */
-const readTopmostRouteKey = () => readTopmostText(ROUTE_KEY_TEST_ID);
-
 /** The `Prevent native dismiss: ...` label of the topmost screen. */
 const readTopmostPreventNativeDismissInfo = () =>
   readTopmostText(PREVENT_NATIVE_DISMISS_TEST_ID);
-
-/**
- * Matches the route key label of any screen on `routeName`. Keys are minted as
- * `r-<routeName>-<id>` with an increasing id (`generateRouteKeyForRouteName`),
- * so this pins the route, not the instance.
- */
-const routeKeyPattern = (routeName: string) =>
-  new RegExp(`^Key: r-${routeName}-\\d+$`);
-
-/**
- * Waits until the topmost screen is `routeName` and returns its route key. The
- * key identifies the route *and* the instance, so one read settles continuity
- * (same key) or a push (new key). Polled rather than `waitFor(...)`, which
- * passes at once on a buried screen and so would not gate a pop.
- */
-async function waitForTopmostRoute(routeName: string): Promise<string> {
-  const pattern = routeKeyPattern(routeName);
-  let lastSeen = '<never read>';
-
-  await waitUntil(
-    async () => {
-      lastSeen = await readTopmostRouteKey();
-      return pattern.test(lastSeen);
-    },
-    {
-      message: () =>
-        `the topmost route to be "${routeName}"; topmost key was "${lastSeen}"`,
-    },
-  );
-
-  return lastSeen;
-}
-
-/** Taps a Push/Pop/Toggle button on the topmost stacked screen. */
-async function tapTopmostStackButton(label: string): Promise<void> {
-  await tapTopmost(by.text(label));
-}
-
-/** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
-async function expectTopmostStackButtons(labels: string[]): Promise<void> {
-  for (const label of labels) {
-    await expectTopmostVisible(() => by.text(label));
-  }
-}
 
 // Each preventing route pushes its own toast text, so the label identifies
 // which screen intercepted — the point of the layered-prevention steps.
@@ -202,32 +116,32 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
 
   it('should show Home as the root screen with no back chevron or Pop button', async () => {
     homeKey = await waitForTopmostRoute('Home');
-    await expectTopmostStackButtons([PUSH_A, PUSH_B, PUSH_NESTED_STACK]);
+    await expectTopmostButtons([PUSH_A, PUSH_B, PUSH_NESTED_STACK]);
     await expect(element(by.text(POP))).not.toExist();
-    await expect(element(stackV5BackButtonMatcher())).not.toExist();
+    await expect(element(stackV5BackButton())).not.toExist();
   });
 
   it('should push A with prevent native dismiss disabled', async () => {
-    await tapTopmostStackButton(PUSH_A);
+    await tapTopmostButton(PUSH_A);
 
     aKey = await waitForTopmostRoute('A');
     jestExpect(aKey).not.toBe(homeKey);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
-    await expectTopmostVisible(stackV5BackButtonMatcher);
-    await expectTopmostStackButtons([PUSH_A, PUSH_B, PUSH_NESTED_STACK, POP]);
+    await expectTopmostVisible(stackV5BackButton);
+    await expectTopmostButtons([PUSH_A, PUSH_B, PUSH_NESTED_STACK, POP]);
     // Neither Home nor A carries a Toggle, so absence is unambiguous here.
     await expect(element(by.text(TOGGLE))).not.toExist();
   });
 
   it('should push B with prevent native dismiss enabled', async () => {
-    await tapTopmostStackButton(PUSH_B);
+    await tapTopmostButton(PUSH_B);
 
     bKey = await waitForTopmostRoute('B');
     jestExpect(bKey).not.toBe(aKey);
     jestExpect(bKey).not.toBe(homeKey);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
-    await expectTopmostVisible(stackV5BackButtonMatcher);
-    await expectTopmostStackButtons([
+    await expectTopmostVisible(stackV5BackButton);
+    await expectTopmostButtons([
       PUSH_A,
       PUSH_B,
       PUSH_NESTED_STACK,
@@ -246,35 +160,28 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
 
   it('should pop B with the on-screen Pop button even while prevent is enabled', async () => {
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
     await expectNoToast();
   });
 
   it('should mount the nested stack showing its headerless root', async () => {
-    await tapTopmostStackButton(PUSH_NESTED_STACK);
+    await tapTopmostButton(PUSH_NESTED_STACK);
 
     nestedHomeKey = await waitForTopmostRoute('NestedHome');
     jestExpect(nestedHomeKey).not.toBe(aKey);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
-    await expectTopmostStackButtons([
-      PUSH_NESTED_A,
-      PUSH_NESTED_B,
-      POP,
-      TOGGLE,
-    ]);
+    await expectTopmostButtons([PUSH_NESTED_A, PUSH_NESTED_B, POP, TOGGLE]);
     // Neither the nested root nor the `NestedStack` host route configures a
     // header, so no toolbar carries NestedHome's title. That the nested root
     // shows *no* header at all cannot be asserted here — see
-    // `stackV5BackButtonMatcher` — and stays a manual, visual check.
-    await expect(
-      element(stackV5HeaderTitleMatcher('NestedHome')),
-    ).not.toExist();
+    // `stackV5BackButton` — and stays a manual, visual check.
+    await expect(element(stackV5HeaderTitle('NestedHome'))).not.toExist();
   });
 
   it('should flip the label to Disabled when toggling it on the nested root', async () => {
-    await tapTopmostStackButton(TOGGLE);
+    await tapTopmostButton(TOGGLE);
 
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
     // Left Disabled on purpose: the next-but-one step asserts a *fresh*
@@ -284,14 +191,14 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
   });
 
   it('should exit the nested stack with the Pop button from its sole attached route', async () => {
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
     await expectNoToast();
   });
 
   it('should restore the default flag on a fresh nested root instance', async () => {
-    await tapTopmostStackButton(PUSH_NESTED_STACK);
+    await tapTopmostButton(PUSH_NESTED_STACK);
 
     const freshNestedHomeKey = await waitForTopmostRoute('NestedHome');
     jestExpect(freshNestedHomeKey).not.toBe(nestedHomeKey);
@@ -301,40 +208,35 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
   });
 
   it('should push NestedA inside the nested stack with prevent disabled', async () => {
-    await tapTopmostStackButton(PUSH_NESTED_A);
+    await tapTopmostButton(PUSH_NESTED_A);
 
     nestedAKey = await waitForTopmostRoute('NestedA');
     jestExpect(nestedAKey).not.toBe(nestedHomeKey);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
-    await expectTopmostStackButtons([PUSH_NESTED_A, PUSH_NESTED_B, POP]);
+    await expectTopmostButtons([PUSH_NESTED_A, PUSH_NESTED_B, POP]);
     // Unlike its root, a nested non-root screen renders the nested stack's own
     // header — titled and with a back chevron.
-    await expect(element(stackV5HeaderTitleMatcher('NestedA'))).toBeVisible();
-    await expectTopmostVisible(stackV5BackButtonMatcher);
+    await expect(element(stackV5HeaderTitle('NestedA'))).toBeVisible();
+    await expectTopmostVisible(stackV5BackButton);
   });
 
   it('should pop NestedA back to the preserved nested root with the Pop button', async () => {
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('NestedHome', nestedHomeKey);
     await expectNoToast();
   });
 
   it('should push NestedB with prevent native dismiss enabled', async () => {
-    await tapTopmostStackButton(PUSH_NESTED_B);
+    await tapTopmostButton(PUSH_NESTED_B);
 
     nestedBKey = await waitForTopmostRoute('NestedB');
     jestExpect(nestedBKey).not.toBe(nestedHomeKey);
     jestExpect(nestedBKey).not.toBe(nestedAKey);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
-    await expect(element(stackV5HeaderTitleMatcher('NestedB'))).toBeVisible();
-    await expectTopmostVisible(stackV5BackButtonMatcher);
-    await expectTopmostStackButtons([
-      PUSH_NESTED_A,
-      PUSH_NESTED_B,
-      POP,
-      TOGGLE,
-    ]);
+    await expect(element(stackV5HeaderTitle('NestedB'))).toBeVisible();
+    await expectTopmostVisible(stackV5BackButton);
+    await expectTopmostButtons([PUSH_NESTED_A, PUSH_NESTED_B, POP, TOGGLE]);
   });
 
   it('should intercept the native header back button on NestedB while prevent is enabled', async () => {
@@ -360,9 +262,9 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
 
   it('should honor the latest flag value when toggled on NestedB', async () => {
     // Off, then straight back on — the press must see the latest value.
-    await tapTopmostStackButton(TOGGLE);
+    await tapTopmostButton(TOGGLE);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
-    await tapTopmostStackButton(TOGGLE);
+    await tapTopmostButton(TOGGLE);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
 
     await tapStackV5BackButton();
@@ -372,27 +274,27 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
   });
 
   it('should pop out of the nested stack with the Pop button, one route at a time', async () => {
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('NestedHome', nestedHomeKey);
     await expectNoToast();
 
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
     await expectNoToast();
   });
 
   it('should push a preventing nested screen on top of a preventing outer screen', async () => {
-    await tapTopmostStackButton(PUSH_B);
+    await tapTopmostButton(PUSH_B);
     bKey = await waitForTopmostRoute('B');
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
 
-    await tapTopmostStackButton(PUSH_NESTED_STACK);
+    await tapTopmostButton(PUSH_NESTED_STACK);
     nestedHomeKey = await waitForTopmostRoute('NestedHome');
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
     jestExpect(nestedHomeKey).not.toBe(bKey);
-    await tapTopmostStackButton(PUSH_NESTED_B);
+    await tapTopmostButton(PUSH_NESTED_B);
     nestedBKey = await waitForTopmostRoute('NestedB');
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_ENABLED);
   });
@@ -407,15 +309,15 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
   });
 
   it('should return to B, not A, when the nested stack is popped', async () => {
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('NestedHome', nestedHomeKey);
     await expectNoToast();
 
-    await tapTopmostStackButton(TOGGLE);
+    await tapTopmostButton(TOGGLE);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
 
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('B', bKey);
     await expectNoToast();
@@ -429,7 +331,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
   });
 
   it('should pop B back to A with the Pop button', async () => {
-    await tapTopmostStackButton(POP);
+    await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
     await expectNoToast();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
@@ -61,6 +61,7 @@ const readTopmostPreventNativeDismissInfo = () =>
 // Each preventing route pushes its own toast text, so the label identifies
 // which screen intercepted — the point of the layered-prevention steps.
 const TOAST_FROM_B = 'Native dismiss prevented - B';
+const TOAST_FROM_NESTED_HOME = 'Native dismiss prevented - NestedHome';
 const TOAST_FROM_NESTED_B = 'Native dismiss prevented - NestedB';
 
 describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
@@ -94,7 +95,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
    */
   async function expectSoleToast(message: string): Promise<void> {
     await dismissNextToast(message);
-    await expectNoToast();
+    await expectNoToast(message);
   }
 
   beforeAll(async () => {
@@ -163,7 +164,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_B);
   });
 
   it('should mount the nested stack showing its headerless root', async () => {
@@ -194,7 +195,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_NESTED_HOME);
   });
 
   it('should restore the default flag on a fresh nested root instance', async () => {
@@ -277,12 +278,12 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('NestedHome', nestedHomeKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_NESTED_B);
 
     await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_NESTED_HOME);
   });
 
   it('should push a preventing nested screen on top of a preventing outer screen', async () => {
@@ -312,7 +313,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('NestedHome', nestedHomeKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_NESTED_B);
 
     await tapTopmostButton(TOGGLE);
     await expectPreventNativeDismiss(PREVENT_NATIVE_DISMISS_DISABLED);
@@ -320,7 +321,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('B', bKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_NESTED_HOME);
   });
 
   it('should resume intercepting on B once it is the topmost screen again', async () => {
@@ -334,6 +335,6 @@ describeIfAndroid('Stack v5: prevent native dismiss - nested stack', () => {
     await tapTopmostButton(POP);
 
     await expectStillOn('A', aKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_FROM_B);
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -124,11 +124,11 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await tapTopmostButton(POP);
 
     jestExpect(await waitForTopmostRoute('A')).toBe(aKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_MESSAGE);
     await tapTopmostButton(POP);
 
     jestExpect(await waitForTopmostRoute('Home')).toBe(homeKey);
-    await expectNoToast();
+    await expectNoToast(TOAST_MESSAGE);
   });
 
   it('should flip the label when toggling prevent native dismiss at runtime', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -1,10 +1,9 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
-import { NativeMatcher } from 'detox/detox';
 import {
   describeIfAndroid,
   dismissToast,
-  getMatches,
+  expectTopmostVisible,
   getTopmostMatch,
   selectSingleFeatureTestsScreen,
   tapTopmost,
@@ -30,54 +29,6 @@ import {
 const TOAST_MESSAGE = 'Native dismiss prevented';
 const toastLabel = (position: number) => `${position}. ${TOAST_MESSAGE}`;
 
-/**
- * Only "nothing matched yet" / "not visible yet" are worth retrying. Anything
- * else — a crashed app, a lost session, a bad matcher — must surface as itself,
- * not as a settle timeout.
- */
-function isTransientMatchError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes('No views in hierarchy found matching') ||
-    message.includes('not visible')
-  );
-}
-
-/**
- * Asserts `matcher`'s last match — the topmost stacked screen's copy — is
- * visible. Indexed because a bare `toBeVisible()` throws "matches N views" once
- * several screens are attached; polled because native header chrome can lag the
- * screen's content and `getMatches` throws on the transient 0-match state.
- *
- * Only for elements expected to be present — absence burns the full timeout;
- * use `not.toExist()` instead.
- */
-async function expectTopmostVisible(
-  matcher: NativeMatcher,
-  timeout = 3000,
-  interval = 100,
-): Promise<void> {
-  const deadline = Date.now() + timeout;
-  let lastError: unknown = '<never attempted>';
-  while (Date.now() <= deadline) {
-    try {
-      const count = (await getMatches(matcher)).length;
-      await expect(element(matcher).atIndex(count - 1)).toBeVisible();
-      return;
-    } catch (error) {
-      if (!isTransientMatchError(error)) {
-        throw error;
-      }
-      lastError = error;
-      await new Promise(resolve => setTimeout(resolve, interval));
-    }
-  }
-  throw new Error(
-    `expectTopmostVisible timed out after ${timeout}ms waiting for the ` +
-      `topmost match to be visible; last failure: ${lastError}`,
-  );
-}
-
 describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   // React Native's core `<Button>` uppercases its `title` on Android
   // (`title.toUpperCase()`), so buttons are matched by their rendered text.
@@ -88,9 +39,12 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
   // Scoped to the Stack v5 header's toolbar: the example app's own v4 header is
   // a `CustomToolbar`, which extends `Toolbar` but not `MaterialToolbar`.
-  const backButtonMatcher = by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
-    .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
+  // A factory: on Android `atIndex` rewrites a matcher in place, so a shared
+  // instance would stay pinned to whatever index `tapTopmost` last resolved.
+  const backButtonMatcher = () =>
+    by
+      .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
+      .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
 
   // Covered screens stay attached on Android, so a matcher resolves to one
   // element per stacked screen and has to be normalized to the topmost match.
@@ -120,7 +74,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   /** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
   async function expectTopmostButtons(titles: string[]): Promise<void> {
     for (const title of titles) {
-      await expectTopmostVisible(by.text(title));
+      await expectTopmostVisible(() => by.text(title));
     }
   }
 
@@ -197,7 +151,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     homeKey = await waitForTopmostRoute('Home');
     await expectTopmostButtons([PUSH_A, PUSH_B]);
     await expect(element(by.text(POP))).not.toExist();
-    await expect(element(backButtonMatcher)).not.toExist();
+    await expect(element(backButtonMatcher())).not.toExist();
   });
 
   it('should push A with prevent native dismiss disabled', async () => {
@@ -208,7 +162,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(await readPreventInfo()).toBe(
       'Prevent native dismiss: Disabled',
     );
-    await expectTopmostVisible(backButtonMatcher);
+    await expectTopmostVisible(() => backButtonMatcher());
     await expectTopmostButtons([PUSH_A, PUSH_B, POP]);
   });
 
@@ -219,13 +173,13 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(bKey).not.toBe(aKey);
     jestExpect(bKey).not.toBe(homeKey);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-    await expectTopmostVisible(backButtonMatcher);
+    await expectTopmostVisible(() => backButtonMatcher());
     await expectTopmostButtons([PUSH_A, PUSH_B, POP, TOGGLE]);
   });
 
   it('should intercept the native header back button while prevent is enabled', async () => {
     await expectStillOnB(bKey);
-    await tapTopmost(backButtonMatcher);
+    await tapTopmost(backButtonMatcher());
 
     // Asserts the toast fired, then clears it for the next step.
     await dismissToasts(1);
@@ -234,9 +188,9 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
   it('should intercept every back press individually while prevent is enabled', async () => {
     await expectStillOnB(bKey);
-    await tapTopmost(backButtonMatcher);
-    await tapTopmost(backButtonMatcher);
-    await tapTopmost(backButtonMatcher);
+    await tapTopmost(backButtonMatcher());
+    await tapTopmost(backButtonMatcher());
+    await tapTopmost(backButtonMatcher());
 
     // A new toast per press — three presses, three toasts, and B never popped.
     await dismissToasts(3);
@@ -268,7 +222,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await tapTopmostButton(TOGGLE);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
 
-    await tapTopmost(backButtonMatcher);
+    await tapTopmost(backButtonMatcher());
 
     await dismissToasts(1);
     await expectStillOnB(currentBKey);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack.e2e.ts
@@ -3,15 +3,16 @@ import { device, expect, element, by } from 'detox';
 import {
   describeIfAndroid,
   dismissToast,
+  expectNoToast,
+  expectTopmostButtons,
   expectTopmostVisible,
-  getTopmostMatch,
+  readTopmostText,
   selectSingleFeatureTestsScreen,
+  stackV5BackButton,
   tapTopmost,
+  tapTopmostButton,
+  waitForTopmostRoute,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON,
-  CLASS_NAME_ANDROID_MATERIAL_TOOLBAR,
-} from '../../native-class-names';
 
 /**
  * Stack v5 `preventNativeDismiss` — single stack. See the scenario for what is
@@ -37,78 +38,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
   const POP = 'POP';
   const TOGGLE = 'TOGGLE PREVENT NATIVE DISMISS';
 
-  // Scoped to the Stack v5 header's toolbar: the example app's own v4 header is
-  // a `CustomToolbar`, which extends `Toolbar` but not `MaterialToolbar`.
-  // A factory: on Android `atIndex` rewrites a matcher in place, so a shared
-  // instance would stay pinned to whatever index `tapTopmost` last resolved.
-  const backButtonMatcher = () =>
-    by
-      .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_BUTTON)
-      .withAncestor(by.type(CLASS_NAME_ANDROID_MATERIAL_TOOLBAR));
-
-  // Covered screens stay attached on Android, so a matcher resolves to one
-  // element per stacked screen and has to be normalized to the topmost match.
-  async function readTopmostText(testID: string): Promise<string> {
-    const top = await getTopmostMatch(by.id(testID));
-    return (top.text ?? top.label ?? '').trim();
-  }
-
-  const readRouteKey = () => readTopmostText('stack-route-key');
   const readPreventInfo = () => readTopmostText('prevent-native-dismiss-info');
-
-  type RouteName = 'Home' | 'A' | 'B';
-
-  /**
-   * Matches the `stack-route-key` label of any screen on `routeName`. Keys are
-   * minted as `r-<routeName>-<id>` with an increasing id
-   * (`generateRouteKeyForRouteName`), so this pins the route, not the instance.
-   */
-  const routeKeyPattern = (routeName: RouteName) =>
-    new RegExp(`^Key: r-${routeName}-\\d+$`);
-
-  /** Taps a Push/Pop/Toggle button on the topmost stacked screen. */
-  async function tapTopmostButton(title: string): Promise<void> {
-    await tapTopmost(by.text(title));
-  }
-
-  /** Asserts the Push/Pop/Toggle buttons present on the topmost screen. */
-  async function expectTopmostButtons(titles: string[]): Promise<void> {
-    for (const title of titles) {
-      await expectTopmostVisible(() => by.text(title));
-    }
-  }
-
-  /**
-   * Waits until the topmost screen is `routeName` and returns its route key.
-   * Reading the key rather than the `Name: X` label identifies the route *and*
-   * which instance is on top, so one read settles continuity (same key) or a
-   * push (new key).
-   *
-   * Polled against `getTopmostMatch` rather than `by.text(...)`: covered screens
-   * stay attached, and Detox intersects a view only with its parents, never with
-   * an occluding sibling — so `toBeVisible()` on a buried screen passes at once
-   * and would not gate a pop.
-   */
-  async function waitForTopmostRoute(
-    routeName: RouteName,
-    timeout = 3000,
-    interval = 100,
-  ): Promise<string> {
-    const pattern = routeKeyPattern(routeName);
-    const deadline = Date.now() + timeout;
-    let lastSeen = '<never read>';
-    while (Date.now() <= deadline) {
-      lastSeen = await readRouteKey();
-      if (pattern.test(lastSeen)) {
-        return lastSeen;
-      }
-      await new Promise(resolve => setTimeout(resolve, interval));
-    }
-    throw new Error(
-      `waitForTopmostRoute timed out waiting for topmost route to be ` +
-        `"${routeName}"; topmost key was "${lastSeen}"`,
-    );
-  }
 
   /** Asserts B is still on top with its original key — the press was swallowed. */
   async function expectStillOnB(expectedKey: string): Promise<void> {
@@ -123,14 +53,6 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     for (let position = count; position >= 1; position--) {
       await dismissToast(toastLabel(position));
     }
-  }
-
-  /**
-   * Asserts no `onNativeDismissPrevented` toast is on screen. Every step clears
-   * its own toasts, so an unexpected one always lands at position 1.
-   */
-  async function expectNoToast(): Promise<void> {
-    await expect(element(by.label(toastLabel(1)))).not.toExist();
   }
 
   beforeAll(async () => {
@@ -151,7 +73,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     homeKey = await waitForTopmostRoute('Home');
     await expectTopmostButtons([PUSH_A, PUSH_B]);
     await expect(element(by.text(POP))).not.toExist();
-    await expect(element(backButtonMatcher())).not.toExist();
+    await expect(element(stackV5BackButton())).not.toExist();
   });
 
   it('should push A with prevent native dismiss disabled', async () => {
@@ -162,7 +84,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(await readPreventInfo()).toBe(
       'Prevent native dismiss: Disabled',
     );
-    await expectTopmostVisible(() => backButtonMatcher());
+    await expectTopmostVisible(stackV5BackButton);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP]);
   });
 
@@ -173,13 +95,13 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     jestExpect(bKey).not.toBe(aKey);
     jestExpect(bKey).not.toBe(homeKey);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
-    await expectTopmostVisible(() => backButtonMatcher());
+    await expectTopmostVisible(stackV5BackButton);
     await expectTopmostButtons([PUSH_A, PUSH_B, POP, TOGGLE]);
   });
 
   it('should intercept the native header back button while prevent is enabled', async () => {
     await expectStillOnB(bKey);
-    await tapTopmost(backButtonMatcher());
+    await tapTopmost(stackV5BackButton());
 
     // Asserts the toast fired, then clears it for the next step.
     await dismissToasts(1);
@@ -188,9 +110,9 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
 
   it('should intercept every back press individually while prevent is enabled', async () => {
     await expectStillOnB(bKey);
-    await tapTopmost(backButtonMatcher());
-    await tapTopmost(backButtonMatcher());
-    await tapTopmost(backButtonMatcher());
+    await tapTopmost(stackV5BackButton());
+    await tapTopmost(stackV5BackButton());
+    await tapTopmost(stackV5BackButton());
 
     // A new toast per press — three presses, three toasts, and B never popped.
     await dismissToasts(3);
@@ -222,7 +144,7 @@ describeIfAndroid('Stack v5: prevent native dismiss - single stack', () => {
     await tapTopmostButton(TOGGLE);
     jestExpect(await readPreventInfo()).toBe('Prevent native dismiss: Enabled');
 
-    await tapTopmost(backButtonMatcher());
+    await tapTopmost(stackV5BackButton());
 
     await dismissToasts(1);
     await expectStillOnB(currentBKey);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
@@ -1,6 +1,8 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
 import {
+  getSingleMatch,
+  textOf,
   describeIfAndroid,
   describeIfiOS,
   readTopmostText,
@@ -40,9 +42,10 @@ describeIfiOS('Stack v5: simple navigation', () => {
    * Reads the currently-visible route's `Key` label. Because
    * react-native-screens detaches covered screens, only the top screen's
    * `stack-route-key` element is in the hierarchy, so this resolves
-   * unambiguously to the current screen.
+   * unambiguously to the current screen — asserted by `getSingleMatch`.
    */
-  const readRouteKey = () => readTopmostText('stack-route-key');
+  const readRouteKey = async () =>
+    textOf(await getSingleMatch(by.id('stack-route-key'), 'stack-route-key'));
 
   async function waitForRoute(routeName: 'Home' | 'A' | 'B'): Promise<void> {
     await waitFor(element(by.text(`Name: ${routeName}`)))

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
@@ -8,6 +8,7 @@ import {
   readTopmostText,
   selectSingleFeatureTestsScreen,
   tapTopmostButton,
+  waitForRouteName,
   waitUntil,
 } from '../../e2e-utils';
 import { tapBarBackButton } from '../../elements/back-button';
@@ -46,12 +47,6 @@ describeIfiOS('Stack v5: simple navigation', () => {
    */
   const readRouteKey = async () =>
     textOf(await getSingleMatch(by.id('stack-route-key'), 'stack-route-key'));
-
-  async function waitForRoute(routeName: 'Home' | 'A' | 'B'): Promise<void> {
-    await waitFor(element(by.text(`Name: ${routeName}`)))
-      .toBeVisible()
-      .withTimeout(3000);
-  }
 
   /**
    * Waits until a screen with the same route name as `previousKey` but a
@@ -103,7 +98,7 @@ describeIfiOS('Stack v5: simple navigation', () => {
   let firstBKey = '';
 
   it('should show Home as the root screen with no back or Pop button', async () => {
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     homeKey = await readRouteKey();
     await expect(element(by.text('Push A'))).toBeVisible();
     await expect(element(by.text('Push B'))).toBeVisible();
@@ -113,7 +108,7 @@ describeIfiOS('Stack v5: simple navigation', () => {
 
   it('should push A with a new key and reveal Pop + back button', async () => {
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     firstAKey = await readRouteKey();
     jestExpect(firstAKey).not.toBe(homeKey);
     await expect(element(by.text('Pop'))).toBeVisible();
@@ -122,7 +117,7 @@ describeIfiOS('Stack v5: simple navigation', () => {
 
   it('should push B on top of A with a new key', async () => {
     await element(by.text('Push B')).tap();
-    await waitForRoute('B');
+    await waitForRouteName('B');
     firstBKey = await readRouteKey();
     jestExpect(firstBKey).not.toBe(firstAKey);
     jestExpect(firstBKey).not.toBe(homeKey);
@@ -131,26 +126,26 @@ describeIfiOS('Stack v5: simple navigation', () => {
 
   it('should push a second A instance with a key distinct from the first A', async () => {
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     const secondAKey = await readRouteKey();
     jestExpect(secondAKey).not.toBe(firstAKey);
   });
 
   it('should pop back to B keeping its original key', async () => {
     await element(by.text('Pop')).tap();
-    await waitForRoute('B');
+    await waitForRouteName('B');
     jestExpect(await readRouteKey()).toBe(firstBKey);
   });
 
   it('should pop back to A keeping its original key', async () => {
     await element(by.text('Pop')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     jestExpect(await readRouteKey()).toBe(firstAKey);
   });
 
   it('should pop back to Home with no Pop or back button', async () => {
     await element(by.text('Pop')).tap();
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
     jestExpect(await readRouteKey()).toBe(homeKey);
     await expect(element(by.text('Pop'))).not.toExist();
     await expect(backButtonIcon).not.toExist();
@@ -158,16 +153,16 @@ describeIfiOS('Stack v5: simple navigation', () => {
 
   it('should navigate to Home with egde swipe', async () => {
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     firstAKey = await readRouteKey();
     await element(by.text('Push B')).tap();
-    await waitForRoute('B');
+    await waitForRouteName('B');
     await element(by.id('screenB-layout-view')).swipe('right');
     jestExpect(await readRouteKey()).toBe(firstAKey);
   });
 
   it('should assign a distinct key to every pushed A instance', async () => {
-    await waitForRoute('A');
+    await waitForRouteName('A');
     const a1 = await readRouteKey();
 
     await element(by.text('Push A')).tap();
@@ -188,21 +183,21 @@ describeIfiOS('Stack v5: simple navigation', () => {
     await element(by.text('Pop')).tap();
     await waitForKeyChange(top);
     await element(by.text('Pop')).tap();
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
   });
 
   it('should pop via the native back button like the Pop button', async () => {
-    await waitForRoute('Home');
+    await waitForRouteName('Home');
 
     await element(by.text('Push A')).tap();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     const aKey = await readRouteKey();
 
     await element(by.text('Push B')).tap();
-    await waitForRoute('B');
+    await waitForRouteName('B');
 
     await tapBarBackButton();
-    await waitForRoute('A');
+    await waitForRouteName('A');
     jestExpect(await readRouteKey()).toBe(aKey);
   });
 });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
@@ -3,10 +3,9 @@ import { device, expect, element, by, waitFor } from 'detox';
 import {
   describeIfAndroid,
   describeIfiOS,
-  getElementAttributes,
-  getTopmostMatch,
+  readTopmostText,
   selectSingleFeatureTestsScreen,
-  tapTopmost,
+  tapTopmostButton,
   waitUntil,
 } from '../../e2e-utils';
 import { tapBarBackButton } from '../../elements/back-button';
@@ -43,14 +42,7 @@ describeIfiOS('Stack v5: simple navigation', () => {
    * `stack-route-key` element is in the hierarchy, so this resolves
    * unambiguously to the current screen.
    */
-  async function readRouteKey(): Promise<string> {
-    const attrs = await getElementAttributes({
-      by: 'id',
-      value: 'stack-route-key',
-    });
-    const value = attrs.text ?? attrs.label ?? '';
-    return value.trim();
-  }
+  const readRouteKey = () => readTopmostText('stack-route-key');
 
   async function waitForRoute(routeName: 'Home' | 'A' | 'B'): Promise<void> {
     await waitFor(element(by.text(`Name: ${routeName}`)))
@@ -219,20 +211,9 @@ describeIfAndroid('Stack v5: simple navigation', () => {
   const PUSH_B = 'PUSH B';
   const POP = 'POP';
 
-  /** Reads the `Key`/`Name` label text from the topmost stacked screen. */
-  async function readTopmostText(testID: string): Promise<string> {
-    const top = await getTopmostMatch(by.id(testID));
-    return (top.text ?? top.label ?? '').trim();
-  }
-
   /** Reads the topmost route's unique `routeKey`. */
   async function readRouteKey(): Promise<string> {
     return readTopmostText('stack-route-key');
-  }
-
-  /** Taps a Push/Pop button on the topmost stacked screen. */
-  async function tapTopmostButton(title: string): Promise<void> {
-    await tapTopmost(by.text(title));
   }
 
   /**

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-simple-nav.e2e.ts
@@ -1,6 +1,5 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
-import { IosElementAttributes, AndroidElementAttributes } from 'detox/detox';
 import {
   describeIfAndroid,
   describeIfiOS,
@@ -36,8 +35,6 @@ import {
  *   gesture-back are verified on iOS and manually on Android via the direct
  *   launch documented in the scenario.
  */
-
-type AnyAttributes = IosElementAttributes | AndroidElementAttributes;
 
 describeIfiOS('Stack v5: simple navigation', () => {
   /**

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-a11y-android.e2e.ts
@@ -1,8 +1,28 @@
 import { device, expect, element, by } from 'detox';
 import {
   describeIfAndroid,
+  openOverflowMenu,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
+
+// No scroll view testID on this screen: pickers are tapped in place and the
+// popup is closed with a plain Back press.
+const setTarget = (option: 'action-item' | 'overflow-item') =>
+  selectPickerOption({
+    pickerId: 'cmd-target-picker',
+    label: 'target id',
+    option,
+  });
+
+const setLabel = (option: 'Updated label' | 'undefined') =>
+  selectPickerOption({
+    pickerId: 'cmd-label-picker',
+    label: 'accessibilityLabel',
+    option,
+  });
+
+const sendCommand = () => element(by.id('send-command-button')).tap();
 
 describeIfAndroid('Stack Toolbar Menu A11y', () => {
   beforeAll(async () => {
@@ -18,73 +38,51 @@ describeIfAndroid('Stack Toolbar Menu A11y', () => {
   });
 
   it('should find overflow item by accessibilityLabel', async () => {
-    await element(by.label('More options')).tap();
+    await openOverflowMenu();
     await expect(element(by.label('Accessibility for Beta'))).toBeVisible();
     await expect(element(by.label('Accessibility for Gamma'))).toBeVisible();
     await device.pressBack();
   });
 
   it('should find submenu item by accessibilityLabel', async () => {
-    await element(by.label('More options')).tap();
+    await openOverflowMenu();
     await element(by.label('Accessibility for Gamma')).tap();
     await expect(element(by.label('Accessibility for Delta'))).toBeVisible();
     await device.pressBack();
   });
 
   it('should update accessibilityLabel via view command', async () => {
-    await element(by.id('cmd-target-picker')).tap();
-    await element(by.text('action-item')).tap();
-
-    await element(by.id('cmd-label-picker')).tap();
-    await element(by.text('Updated label')).tap();
-
-    await element(by.id('send-command-button')).tap();
-
-    await element(by.id('cmd-target-picker')).tap();
-    await element(by.id('cmd-label-picker')).tap();
+    await setTarget('action-item');
+    await setLabel('Updated label');
+    await sendCommand();
 
     await expect(element(by.label('Updated label'))).toBeVisible();
     await expect(element(by.label('Accessibility for Alpha'))).not.toExist();
   });
 
   it('should reset accessibilityLabel to title fallback', async () => {
-    await element(by.id('cmd-label-picker')).tap();
-    await element(by.text('undefined')).tap();
-
-    await element(by.id('send-command-button')).tap();
-
-    await element(by.id('cmd-label-picker')).tap();
+    await setLabel('undefined');
+    await sendCommand();
 
     await expect(element(by.label('Alpha'))).toBeVisible();
     await expect(element(by.label('Updated label'))).not.toExist();
   });
 
   it('should update overflow item accessibilityLabel via view command', async () => {
-    await element(by.id('cmd-target-picker')).tap();
-    await element(by.text('overflow-item')).tap();
+    await setTarget('overflow-item');
+    await setLabel('Updated label');
+    await sendCommand();
 
-    await element(by.id('cmd-label-picker')).tap();
-    await element(by.text('Updated label')).tap();
-
-    await element(by.id('send-command-button')).tap();
-
-    await element(by.id('cmd-target-picker')).tap();
-    await element(by.id('cmd-label-picker')).tap();
-
-    await element(by.label('More options')).tap();
+    await openOverflowMenu();
     await expect(element(by.label('Updated label'))).toBeVisible();
     await device.pressBack();
   });
 
   it('should reset overflow item to no content description', async () => {
-    await element(by.id('cmd-label-picker')).tap();
-    await element(by.text('undefined')).tap();
+    await setLabel('undefined');
+    await sendCommand();
 
-    await element(by.id('send-command-button')).tap();
-
-    await element(by.id('cmd-label-picker')).tap();
-
-    await element(by.label('More options')).tap();
+    await openOverflowMenu();
 
     await expect(element(by.text('Beta'))).toBeVisible();
     await expect(element(by.label('Updated label'))).not.toExist();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -26,8 +26,9 @@ const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 const SCROLL_STEP = { pixels: 300 };
 const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
 
-// Generous on purpose: a slow image download must not read as a failed batch.
-const IMAGE_LOAD_TIMEOUT_MS = 90000;
+// Generous on purpose: the failing-image cases wait on a network error, and a
+// slow one must not read as a stuck batch.
+const IMAGE_LOAD_TIMEOUT_MS = 30000;
 
 const APPLE = 'Apple';
 
@@ -35,7 +36,8 @@ async function expectAppleNotInToolbar() {
   await expect(element(actionMenuItem(APPLE))).not.toExist();
 }
 
-const expectAppleInToolbarWithIcon = () => expectIconActionItem(APPLE);
+const expectAppleInToolbarWithIcon = () =>
+  expectIconActionItem(APPLE, IMAGE_LOAD_TIMEOUT_MS);
 const expectAppleInToolbarWithoutIcon = () => expectTextActionItem(APPLE);
 
 async function scrollIntoView(id: string) {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -1,7 +1,7 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
-import type { NativeMatcher } from 'detox/detox';
 import {
+  actionMenuItem,
   createOverflowMenuHelpers,
   describeIfAndroid,
   expectCheckBox,
@@ -12,7 +12,6 @@ import {
   scrollToAndTap,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import { CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW } from '../../native-class-names';
 
 // Stateful walkthrough of scenario.md: the menu's checked state is cumulative
 // and the screen has no full reset, so each case starts where the previous one
@@ -27,11 +26,9 @@ const EVENT_TIMEOUT_MS = 3000;
 // Generous on purpose: a slow image download must not read as a failed batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
-// `by.label` matches the button in both its icon-only (title as content
-// description) and text form; the form is told apart by the rendered text.
-const appleToolbarButton: NativeMatcher = by
-  .label('Apple')
-  .and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
+// Matches the button in both its icon-only and text form; the form is told
+// apart by the rendered text.
+const appleToolbarButton = actionMenuItem('Apple');
 
 async function expectAppleNotInToolbar() {
   await expect(element(appleToolbarButton)).not.toExist();

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -9,7 +9,8 @@ import {
   expectRadioButton,
   expectTextActionItem,
   menuItemRow,
-  readText as readTextIn,
+  DEFAULT_TIMEOUT_MS,
+  readText,
   rewindAndScrollUntilVisible,
   scrollToAndTap,
   selectSingleFeatureTestsScreen,
@@ -25,7 +26,7 @@ const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 const SCROLL_STEP = { pixels: 300 };
 const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
 
-const EVENT_TIMEOUT_MS = 3000;
+const EVENT_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 // Generous on purpose: a slow image download must not read as a failed batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
@@ -50,8 +51,6 @@ const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
   scrollViewId: SCROLLVIEW_ID,
 });
 
-const readText = (id: string) => readTextIn(id, SETTINGS_CONTROL);
-
 async function expectEventCount(n: number, timeoutMs = EVENT_TIMEOUT_MS) {
   await scrollIntoView('events-count-text');
   await waitFor(element(by.id('events-count-text')))
@@ -60,7 +59,7 @@ async function expectEventCount(n: number, timeoutMs = EVENT_TIMEOUT_MS) {
 }
 
 async function expectEventCountUnchanged(action: () => Promise<void>) {
-  const before = await readText('events-count-text');
+  const before = await readText('events-count-text', SETTINGS_CONTROL);
   jestExpect(before).toMatch(/^Events received: \d+$/);
   await action();
   await scrollIntoView('events-count-text');
@@ -87,7 +86,7 @@ function parseLogEntry(raw: string): { groupId: string; ids: string[] } {
 
 // Compares ids sorted — order-insensitive, duplicates still fail.
 async function expectLogEntry(index: number, groupId: string, ids: string[]) {
-  const raw = await readText(`event-log-entry-${index}`);
+  const raw = await readText(`event-log-entry-${index}`, SETTINGS_CONTROL);
   const entry = parseLogEntry(raw);
   jestExpect(entry.groupId).toBe(groupId);
   jestExpect([...entry.ids].sort()).toEqual([...ids].sort());

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -5,9 +5,11 @@ import {
   createOverflowMenuHelpers,
   describeIfAndroid,
   expectCheckBox,
+  expectIconActionItem,
   expectRadioButton,
-  getElementAttributes,
+  expectTextActionItem,
   menuItemRow,
+  readText as readTextIn,
   rewindAndScrollUntilVisible,
   scrollToAndTap,
   selectSingleFeatureTestsScreen,
@@ -21,47 +23,34 @@ import {
 const SCROLLVIEW_ID = 'toolbar-menu-batch-commands-scrollview';
 const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 const SCROLL_STEP = { pixels: 300 };
+const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
 
 const EVENT_TIMEOUT_MS = 3000;
 // Generous on purpose: a slow image download must not read as a failed batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
-// Matches the button in both its icon-only and text form; the form is told
-// apart by the rendered text.
-const appleToolbarButton = actionMenuItem('Apple');
+const APPLE = 'Apple';
 
 async function expectAppleNotInToolbar() {
-  await expect(element(appleToolbarButton)).not.toExist();
+  await expect(element(actionMenuItem(APPLE))).not.toExist();
 }
 
-// Asserted positively: on Android a negated matcher passes on a missing view.
-async function expectAppleInToolbarWithIcon() {
-  await expect(element(appleToolbarButton)).toBeVisible();
-  // AppCompat clears an icon-only action button's text (`setText(null)`).
-  await expect(element(appleToolbarButton)).toHaveText('');
-}
-
-async function expectAppleInToolbarWithoutIcon() {
-  await expect(element(appleToolbarButton)).toBeVisible();
-  await expect(element(appleToolbarButton)).toHaveText('Apple');
-}
+const expectAppleInToolbarWithIcon = () => expectIconActionItem(APPLE);
+const expectAppleInToolbarWithoutIcon = () => expectTextActionItem(APPLE);
 
 async function scrollIntoView(id: string) {
   await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SCROLL_STEP);
 }
 
 async function tapById(id: string) {
-  await scrollToAndTap(id, { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP });
+  await scrollToAndTap(id, SETTINGS_CONTROL);
 }
 
 const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
   scrollViewId: SCROLLVIEW_ID,
 });
 
-async function readText(id: string): Promise<string> {
-  await scrollIntoView(id);
-  return (await getElementAttributes({ by: 'id', value: id })).text ?? '';
-}
+const readText = (id: string) => readTextIn(id, SETTINGS_CONTROL);
 
 async function expectEventCount(n: number, timeoutMs = EVENT_TIMEOUT_MS) {
   await scrollIntoView('events-count-text');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -26,7 +26,6 @@ const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 const SCROLL_STEP = { pixels: 300 };
 const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
 
-const EVENT_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 // Generous on purpose: a slow image download must not read as a failed batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
@@ -51,7 +50,7 @@ const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
   scrollViewId: SCROLLVIEW_ID,
 });
 
-async function expectEventCount(n: number, timeoutMs = EVENT_TIMEOUT_MS) {
+async function expectEventCount(n: number, timeoutMs = DEFAULT_TIMEOUT_MS) {
   await scrollIntoView('events-count-text');
   await waitFor(element(by.id('events-count-text')))
     .toHaveText(`Events received: ${n}`)

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -28,7 +28,7 @@ const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
 
 // Generous on purpose: the failing-image cases wait on a network error, and a
 // slow one must not read as a stuck batch.
-const IMAGE_LOAD_TIMEOUT_MS = 30000;
+const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
 const APPLE = 'Apple';
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -1,19 +1,23 @@
-import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
 import {
   createOverflowMenuHelpers,
   describeIfAndroid,
+  expectLastClicked as expectLastClickedText,
+  expectOverflowMenuOrder,
   openOverflowMenu,
+  overflowMenuText,
+  rewindAndScrollUntilVisible,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
+  toggleSettingsSwitch,
 } from '../../e2e-utils';
-import { CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW } from '../../native-class-names';
 
 const SCROLLVIEW_ID = 'toolbar-menu-commands-scrollview';
 const HEADER_TITLE = 'Toolbar Menu Commands Test';
 
-// Detox's idle sync does not cover popup window animations, so every wait that
-// straddles the overflow menu opening or dismissing has to be explicit.
-const MENU_ANIMATION_TIMEOUT = 2000;
+// 300px steps keep a short picker option row from being carried past the
+// viewport.
+const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, pixels: 300 };
 
 // Every title this scenario can put into the menu. Assertions check the full
 // set — expected titles visible, all others absent — so a leaked entry fails.
@@ -27,42 +31,17 @@ const ALL_TITLES = [
 
 type MenuTitle = (typeof ALL_TITLES)[number];
 
-// Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
-// @see apps/src/shared/SettingsPicker.tsx
-function optionId(pickerLabel: string, option: string): string {
-  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
-}
+/** A row of the focused popup, addressed by its visible text. */
+const overflowRow = (title: MenuTitle) => overflowMenuText(title);
 
-// Rewinds to the top first, so a target above the current offset is still
-// reachable — `whileElement` only scrolls one way.
 async function scrollIntoView(id: string) {
-  await element(by.id(SCROLLVIEW_ID)).scrollTo('top');
-  await waitFor(element(by.id(id)))
-    .toBeVisible()
-    .whileElement(by.id(SCROLLVIEW_ID))
-    .scroll(300, 'down', Number.NaN, 0.85);
+  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SETTINGS_CONTROL);
 }
 
 // Closing the picker again matters: its option rows stay in the hierarchy and
 // would collide with the `by.text` matchers used for the toolbar menu items.
-async function selectOption(
-  pickerId: string,
-  pickerLabel: string,
-  option: string,
-) {
-  await scrollIntoView(pickerId);
-  await element(by.id(pickerId)).tap();
-
-  const rowId = optionId(pickerLabel, option);
-  await scrollIntoView(rowId);
-  await element(by.id(rowId)).tap();
-
-  await scrollIntoView(pickerId);
-  await element(by.id(pickerId)).tap();
-
-  await expect(element(by.id(pickerId))).toHaveText(
-    `${pickerLabel}: ${option}`,
-  );
+async function selectOption(pickerId: string, label: string, option: string) {
+  await selectPickerOption({ pickerId, label, option }, SETTINGS_CONTROL);
 }
 
 type CmdTitle =
@@ -95,73 +74,20 @@ async function setSlotTitle(slot: number, title: string) {
 // The switch only toggles, so `include` is the state expected afterwards — a
 // swallowed tap fails here instead of as a wrong-menu assertion steps later.
 async function setSlotInclude(slot: number, include: boolean) {
-  const switchId = `slot-${slot}-include-switch`;
-  await scrollIntoView(switchId);
-  await element(by.id(switchId)).tap();
-
-  await expect(
-    element(by.text(`slot ${slot} include: ${include}`)),
-  ).toBeVisible();
+  await toggleSettingsSwitch(
+    {
+      switchId: `slot-${slot}-include-switch`,
+      label: `slot ${slot} include`,
+      to: include,
+    },
+    SETTINGS_CONTROL,
+  );
 }
 
-const { waitForScreen, closeMenuIfOpen, withOverflowMenu } =
+const { closeMenuIfOpen, withOverflowMenu, waitForMenuItem, tapMenuItem } =
   createOverflowMenuHelpers({
     scrollViewId: SCROLLVIEW_ID,
   });
-
-async function waitForMenuItem(title: MenuTitle) {
-  await waitFor(
-    element(
-      by
-        .text(title)
-        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-    ),
-  )
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-}
-
-async function tapMenuItem(title: MenuTitle) {
-  await waitForMenuItem(title);
-  await element(
-    by
-      .text(title)
-      .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-  ).tap();
-  await waitFor(
-    element(
-      by
-        .text(title)
-        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-    ),
-  )
-    .not.toExist()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-  await waitForScreen();
-}
-
-// Rows are stacked vertically, so their on-screen positions carry the order the
-// menu was built in. Only callable while the menu is open.
-async function expectMenuOrder(titles: readonly MenuTitle[]): Promise<void> {
-  const rows: { title: MenuTitle; top: number }[] = [];
-
-  for (const title of titles) {
-    const attributes = await element(
-      by
-        .text(title)
-        .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-    ).getAttributes();
-
-    if ('elements' in attributes) {
-      throw new Error(`Expected a single menu row titled "${title}".`);
-    }
-
-    rows.push({ title, top: attributes.frame.y });
-  }
-
-  const topToBottom = [...rows].sort((a, b) => a.top - b.top).map(r => r.title);
-  jestExpect(topToBottom).toEqual([...titles]);
-}
 
 // Asserts the exact menu contents, then closes it. `expectedVisible` is a
 // non-empty subset of ALL_TITLES — a title outside that set would go unasserted,
@@ -177,40 +103,23 @@ async function expectMenuItems(
     await waitForMenuItem(expectedVisible[0]);
 
     for (const title of expectedVisible) {
-      await expect(
-        element(
-          by
-            .text(title)
-            .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)),
-        ),
-      ).toBeVisible();
+      await expect(element(overflowRow(title))).toBeVisible();
     }
 
     if (checkOrder) {
-      await expectMenuOrder(expectedVisible);
+      await expectOverflowMenuOrder(expectedVisible);
     }
 
     for (const title of ALL_TITLES) {
       if (!expectedVisible.includes(title)) {
-        await expect(
-          element(
-            by
-              .text(title)
-              .withAncestor(
-                by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW),
-              ),
-          ),
-        ).not.toExist();
+        await expect(element(overflowRow(title))).not.toExist();
       }
     }
   });
 }
 
 async function expectLastClicked(id: string) {
-  await scrollIntoView('last-clicked-text');
-  await expect(element(by.id('last-clicked-text'))).toHaveText(
-    `Last clicked: ${id}`,
-  );
+  await expectLastClickedText(id, SETTINGS_CONTROL);
 }
 
 describeIfAndroid('Stack Toolbar Menu Commands', () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-commands-android.e2e.ts
@@ -2,7 +2,7 @@ import { device, expect, element, by } from 'detox';
 import {
   createOverflowMenuHelpers,
   describeIfAndroid,
-  expectLastClicked as expectLastClickedText,
+  expectLastClicked,
   expectOverflowMenuOrder,
   openOverflowMenu,
   overflowMenuText,
@@ -118,10 +118,6 @@ async function expectMenuItems(
   });
 }
 
-async function expectLastClicked(id: string) {
-  await expectLastClickedText(id, SETTINGS_CONTROL);
-}
-
 describeIfAndroid('Stack Toolbar Menu Commands', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -150,7 +146,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
 
       await expect(element(by.text('Title B'))).not.toExist();
       await expect(element(by.text('Title C'))).not.toExist();
-      await expectLastClicked('item-1');
+      await expectLastClicked('item-1', SETTINGS_CONTROL);
     });
 
     it('reports item-3 when tapping "Title C"', async () => {
@@ -158,7 +154,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
       await tapMenuItem('Title C');
 
       await expect(element(by.text('Title A'))).not.toExist();
-      await expectLastClicked('item-3');
+      await expectLastClicked('item-3', SETTINGS_CONTROL);
     });
   });
 
@@ -171,7 +167,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
       });
 
       await expectMenuItems(['Title A', 'Title B', 'Title C']);
-      await expectLastClicked('item-3');
+      await expectLastClicked('item-3', SETTINGS_CONTROL);
     });
   });
 
@@ -191,7 +187,7 @@ describeIfAndroid('Stack Toolbar Menu Commands', () => {
       await tapMenuItem('Changed');
 
       await expect(element(by.text('Title A'))).not.toExist();
-      await expectLastClicked('item-2');
+      await expectLastClicked('item-2', SETTINGS_CONTROL);
     });
   });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
@@ -56,7 +56,7 @@ const actionBarButton = by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW);
 
 // The row, not its title `TextView`: `View.setEnabled` does not propagate to
 // children, so only the row reflects a disabled element.
-const menuRow = (title: RowTitle): NativeMatcher => menuItemRow(title);
+const popupRow = (title: RowTitle): NativeMatcher => menuItemRow(title);
 
 const attributesOf = (matcher: NativeMatcher, description?: string) =>
   getSingleMatch(matcher, description) as Promise<AndroidElementAttributes>;
@@ -73,7 +73,7 @@ const { withOverflowMenu } = createOverflowMenuHelpers({
 });
 
 async function waitForMenuRow(title: RowTitle) {
-  await waitFor(element(menuRow(title)))
+  await waitFor(element(popupRow(title)))
     .toBeVisible()
     .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
 }
@@ -81,7 +81,7 @@ async function waitForMenuRow(title: RowTitle) {
 // Only where it is expected to open; a disabled **More** has nothing to wait for.
 async function openSubmenu() {
   await waitForMenuRow('More');
-  await element(menuRow('More')).tap();
+  await element(popupRow('More')).tap();
   await waitForMenuRow('Sub Item');
 }
 
@@ -91,13 +91,13 @@ async function openSubmenu() {
 // would pass before a submenu that did open is up.
 async function expectSubmenuStayedClosed() {
   await expectRowEnabled('More', false);
-  await expect(element(menuRow('Sub Item'))).not.toExist();
+  await expect(element(popupRow('Sub Item'))).not.toExist();
 }
 
 async function expectRowEnabled(title: RowTitle, enabled: boolean) {
   await waitForMenuRow(title);
   jestExpect(
-    (await attributesOf(menuRow(title), `row "${title}"`)).enabled,
+    (await attributesOf(popupRow(title), `row "${title}"`)).enabled,
   ).toBe(enabled);
 }
 
@@ -105,7 +105,7 @@ async function expectRowEnabled(title: RowTitle, enabled: boolean) {
 async function expectRowChecked(title: RowTitle, checked: boolean) {
   await waitForMenuRow(title);
   const attributes = await attributesOf(
-    by.type(CLASS_NAME_ANDROID_CHECK_BOX).withAncestor(menuRow(title)),
+    by.type(CLASS_NAME_ANDROID_CHECK_BOX).withAncestor(popupRow(title)),
   );
   jestExpect(attributes.value).toBe(checked);
 }
@@ -251,7 +251,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await expectLastEventUnchanged(async () => {
         await withOverflowMenu(async () => {
           await waitForMenuRow('Action Overflow');
-          await element(menuRow('Action Overflow')).tap();
+          await element(popupRow('Action Overflow')).tap();
         });
       });
     });
@@ -260,7 +260,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await setDisabledViaProps('action-overflow', false);
       await withOverflowMenu(async () => {
         await expectRowEnabled('Action Overflow', true);
-        await element(menuRow('Action Overflow')).tap();
+        await element(popupRow('Action Overflow')).tap();
       });
       await expectLastEvent('Pressed: action-overflow');
     });
@@ -279,7 +279,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await expectLastEventUnchanged(async () => {
         await withOverflowMenu(async () => {
           await waitForMenuRow('Option A');
-          await element(menuRow('Option A')).tap();
+          await element(popupRow('Option A')).tap();
           await expectRowChecked('Option A', true);
         });
       });
@@ -297,7 +297,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await expectLastEventUnchanged(async () => {
         await withOverflowMenu(async () => {
           await waitForMenuRow('Option B');
-          await element(menuRow('Option B')).tap();
+          await element(popupRow('Option B')).tap();
           await expectRowChecked('Option B', false);
         });
       });
@@ -318,7 +318,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     it('reports both opt-a and opt-b in the "options" selection when opt-b is checked', async () => {
       await withOverflowMenu(async () => {
         await waitForMenuRow('Option B');
-        await element(menuRow('Option B')).tap();
+        await element(popupRow('Option B')).tap();
       });
       await expectLastSelection('options', ['opt-a', 'opt-b']);
     });
@@ -326,7 +326,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     it('drops opt-a from the selection when opt-a is unchecked', async () => {
       await withOverflowMenu(async () => {
         await waitForMenuRow('Option A');
-        await element(menuRow('Option A')).tap();
+        await element(popupRow('Option A')).tap();
       });
       await expectLastSelection('options', ['opt-b']);
     });
@@ -348,7 +348,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await setDisabledViaProps('submenu', true);
       await withOverflowMenu(async () => {
         await expectRowEnabled('More', false);
-        await element(menuRow('More')).tap();
+        await element(popupRow('More')).tap();
         await expectSubmenuStayedClosed();
       });
     });
@@ -375,7 +375,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await expectLastEventUnchanged(async () => {
         await withOverflowMenu(async () => {
           await openSubmenu();
-          await element(menuRow('Sub Item')).tap();
+          await element(popupRow('Sub Item')).tap();
         });
       });
     });
@@ -385,7 +385,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await withOverflowMenu(async () => {
         await openSubmenu();
         await expectRowEnabled('Sub Item', true);
-        await element(menuRow('Sub Item')).tap();
+        await element(popupRow('Sub Item')).tap();
       });
       await expectLastEvent('Pressed: sub-item');
     });
@@ -405,7 +405,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await sendCommand({ target: 'submenu', disabled: 'true' });
       await withOverflowMenu(async () => {
         await expectRowEnabled('More', false);
-        await element(menuRow('More')).tap();
+        await element(popupRow('More')).tap();
         await expectSubmenuStayedClosed();
       });
     });
@@ -416,7 +416,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
         await withOverflowMenu(async () => {
           await expectRowEnabled('Option A', false);
           await expectRowChecked('Option A', true);
-          await element(menuRow('Option A')).tap();
+          await element(popupRow('Option A')).tap();
           await expectRowChecked('Option A', true);
         });
       });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
@@ -58,8 +58,8 @@ const actionBarButton = by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW);
 // children, so only the row reflects a disabled element.
 const menuRow = (title: RowTitle): NativeMatcher => menuItemRow(title);
 
-const attributesOf = (matcher: NativeMatcher) =>
-  getSingleMatch(matcher) as Promise<AndroidElementAttributes>;
+const attributesOf = (matcher: NativeMatcher, description?: string) =>
+  getSingleMatch(matcher, description) as Promise<AndroidElementAttributes>;
 
 // Targets sit either side of the current offset, hence the rewind.
 async function scrollIntoView(id: string) {
@@ -96,7 +96,9 @@ async function expectSubmenuStayedClosed() {
 
 async function expectRowEnabled(title: RowTitle, enabled: boolean) {
   await waitForMenuRow(title);
-  jestExpect((await attributesOf(menuRow(title))).enabled).toBe(enabled);
+  jestExpect(
+    (await attributesOf(menuRow(title), `row "${title}"`)).enabled,
+  ).toBe(enabled);
 }
 
 // The checkbox AppCompat inflates carries the toggle state in `value`.
@@ -109,7 +111,9 @@ async function expectRowChecked(title: RowTitle, checked: boolean) {
 }
 
 async function expectActionBarEnabled(enabled: boolean) {
-  jestExpect((await attributesOf(actionBarButton)).enabled).toBe(enabled);
+  jestExpect(
+    (await attributesOf(actionBarButton, 'the toolbar action button')).enabled,
+  ).toBe(enabled);
 }
 
 const readLastEvent = () => readText('last-event-text', SETTINGS_CONTROL);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
@@ -7,9 +7,10 @@ import type { AndroidElementAttributes, NativeMatcher } from 'detox/detox';
 import {
   createOverflowMenuHelpers,
   describeIfAndroid,
-  getMatches,
+  getSingleMatch,
   menuItemRow,
   MENU_ANIMATION_TIMEOUT_MS,
+  readText,
   rewindAndScrollUntilVisible,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
@@ -57,19 +58,8 @@ const actionBarButton = by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW);
 // children, so only the row reflects a disabled element.
 const menuRow = (title: RowTitle): NativeMatcher => menuItemRow(title);
 
-// Zero matches already throws inside `getMatches`, so only ambiguity is left.
-async function attributesOf(
-  matcher: NativeMatcher,
-): Promise<AndroidElementAttributes> {
-  const matches = await getMatches(matcher);
-  if (matches.length > 1) {
-    throw new Error(
-      `Matcher resolved to ${matches.length} elements, expected exactly one. ` +
-        'Narrow the matcher, or the view hierarchy changed.',
-    );
-  }
-  return matches[0] as AndroidElementAttributes;
-}
+const attributesOf = (matcher: NativeMatcher) =>
+  getSingleMatch(matcher) as Promise<AndroidElementAttributes>;
 
 // Targets sit either side of the current offset, hence the rewind.
 async function scrollIntoView(id: string) {
@@ -122,10 +112,7 @@ async function expectActionBarEnabled(enabled: boolean) {
   jestExpect((await attributesOf(actionBarButton)).enabled).toBe(enabled);
 }
 
-async function readLastEvent(): Promise<string> {
-  await scrollIntoView('last-event-text');
-  return (await attributesOf(by.id('last-event-text'))).text ?? '';
-}
+const readLastEvent = () => readText('last-event-text', SETTINGS_CONTROL);
 
 async function expectLastEvent(expected: string) {
   await scrollIntoView('last-event-text');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-disabled-android.e2e.ts
@@ -5,16 +5,19 @@ import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
 import type { AndroidElementAttributes, NativeMatcher } from 'detox/detox';
 import {
+  createOverflowMenuHelpers,
   describeIfAndroid,
   getMatches,
+  menuItemRow,
+  MENU_ANIMATION_TIMEOUT_MS,
   rewindAndScrollUntilVisible,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
+  toggleSettingsSwitch,
 } from '../../e2e-utils';
 import {
   CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
   CLASS_NAME_ANDROID_CHECK_BOX,
-  CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
 } from '../../native-class-names';
 // Typed from the screen, so a rename there fails type-checking here.
 import type {
@@ -29,13 +32,8 @@ import type {
 const SCROLLVIEW_ID = 'toolbar-menu-disabled-scrollview';
 const HEADER_TITLE: HeaderTitle = 'Toolbar Menu Disabled Test';
 
-// Detox's idle sync does not cover popup animations, so waits that straddle a
-// menu opening or dismissing must be explicit. An upper bound — only
-// `isScreenAddressable`, which is expected to time out, pays it in full.
-const MENU_ANIMATION_TIMEOUT_MS = 5000;
-
-// Probes a settled popup, not an animation: it is either up or never opened.
-const MENU_PRESENCE_TIMEOUT_MS = 250;
+// Small steps keep short switch rows from being scrolled past.
+const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID, pixels: 300 };
 
 // Rendered as `${label}: ${value}`. `ItemLabels` checks keys and exact strings.
 const SWITCH_LABELS: ItemLabels = {
@@ -57,11 +55,7 @@ const actionBarButton = by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW);
 
 // The row, not its title `TextView`: `View.setEnabled` does not propagate to
 // children, so only the row reflects a disabled element.
-function menuRow(title: RowTitle): NativeMatcher {
-  return by
-    .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
-    .withDescendant(by.text(title));
-}
+const menuRow = (title: RowTitle): NativeMatcher => menuItemRow(title);
 
 // Zero matches already throws inside `getMatches`, so only ambiguity is left.
 async function attributesOf(
@@ -77,35 +71,16 @@ async function attributesOf(
   return matches[0] as AndroidElementAttributes;
 }
 
-// Targets sit either side of the current offset, hence the rewind; the small
-// step keeps short switch rows from being scrolled past.
+// Targets sit either side of the current offset, hence the rewind.
 async function scrollIntoView(id: string) {
-  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, { pixels: 300 });
+  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SETTINGS_CONTROL);
 }
 
-// Detox searches one window: while a popup holds focus nothing behind it is in
-// the hierarchy, so the screen itself has to become addressable again.
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLLVIEW_ID)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
-}
-
-// `waitForScreen` reported rather than thrown — stacked popups keep it false.
-async function isScreenAddressable(): Promise<boolean> {
-  return waitForScreen().then(
-    () => true,
-    () => false,
-  );
-}
-
-// Waits for the popup, not a row: bodies that tap first would race the animation.
-async function openMenu() {
-  await element(by.label('More options')).tap();
-  await waitFor(element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
-}
+// A submenu opens on top of the overflow menu, so at most two popups stack.
+const { withOverflowMenu } = createOverflowMenuHelpers({
+  scrollViewId: SCROLLVIEW_ID,
+  maxMenuDepth: 2,
+});
 
 async function waitForMenuRow(title: RowTitle) {
   await waitFor(element(menuRow(title)))
@@ -127,60 +102,6 @@ async function openSubmenu() {
 async function expectSubmenuStayedClosed() {
   await expectRowEnabled('More', false);
   await expect(element(menuRow('Sub Item'))).not.toExist();
-}
-
-async function isMenuOpen(): Promise<boolean> {
-  return waitFor(element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW)))
-    .toExist()
-    .withTimeout(MENU_PRESENCE_TIMEOUT_MS)
-    .then(
-      () => true,
-      () => false,
-    );
-}
-
-// A submenu opens on top of the overflow menu, so at most two popups stack.
-const MAX_STACKED_MENUS = 2;
-
-// Presses Back only while a popup is up, or the press pops the test screen.
-// Submenus stack, hence the loop.
-async function closeMenus() {
-  for (let attempt = 0; attempt < MAX_STACKED_MENUS; attempt++) {
-    if (!(await isMenuOpen())) {
-      break;
-    }
-    await device.pressBack();
-
-    // A dismissed popup lingers while animating out, so re-probing would read it
-    // as a second stacked menu. Waiting for the screen settles that instead.
-    if (await isScreenAddressable()) {
-      return;
-    }
-  }
-  await waitForScreen();
-}
-
-// Runs `body` with the menu open, closing it afterwards even when an assertion
-// throws — a popup left covering the screen would fail every later step.
-async function withMenu(body: () => Promise<void>) {
-  await openMenu();
-
-  try {
-    await body();
-  } catch (error) {
-    // Swallowed only here, so a failing cleanup cannot replace the assertion
-    // that failed. Logged, because it leaves the popup up and the *next* test
-    // then fails with no trace in its own output.
-    await closeMenus().catch(cleanupError => {
-      console.warn(
-        'closeMenus failed while cleaning up after a failed assertion:',
-        cleanupError,
-      );
-    });
-    throw error;
-  }
-
-  await closeMenus();
 }
 
 async function expectRowEnabled(title: RowTitle, enabled: boolean) {
@@ -241,48 +162,20 @@ async function expectLastSelection(groupId: string, ids: string[]) {
 // The switch only toggles, so `disabled` is the state expected afterwards — a
 // swallowed tap fails here instead of as a wrong-menu assertion steps later.
 async function setDisabledViaProps(id: ElementId, disabled: boolean) {
-  const switchId = `disable-${id}-switch`;
-  await scrollIntoView(switchId);
-  await element(by.id(switchId)).tap();
-
-  await expect(
-    element(by.text(`disable ${SWITCH_LABELS[id]}: ${disabled}`)),
-  ).toBeVisible();
-}
-
-// Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
-// @see apps/src/shared/SettingsPicker.tsx
-function optionId(pickerLabel: string, option: string): string {
-  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
+  await toggleSettingsSwitch(
+    {
+      switchId: `disable-${id}-switch`,
+      label: `disable ${SWITCH_LABELS[id]}`,
+      to: disabled,
+    },
+    SETTINGS_CONTROL,
+  );
 }
 
 // Closing the picker again matters: its option rows stay in the hierarchy and
 // would collide with the `by.text` matchers used for the toolbar menu items.
-async function selectOption(
-  pickerId: string,
-  pickerLabel: string,
-  option: string,
-) {
-  const expected = `${pickerLabel}: ${option}`;
-  await scrollIntoView(pickerId);
-
-  // Pickers keep their value, so re-picking one costs three taps and three
-  // scroll rewinds for nothing. Reading the closed label avoids a probe that
-  // would have to time out.
-  if ((await attributesOf(by.id(pickerId))).text === expected) {
-    return;
-  }
-
-  await element(by.id(pickerId)).tap();
-
-  const rowId = optionId(pickerLabel, option);
-  await scrollIntoView(rowId);
-  await element(by.id(rowId)).tap();
-
-  await scrollIntoView(pickerId);
-  await element(by.id(pickerId)).tap();
-
-  await expect(element(by.id(pickerId))).toHaveText(expected);
+async function selectOption(pickerId: string, label: string, option: string) {
+  await selectPickerOption({ pickerId, label, option }, SETTINGS_CONTROL);
 }
 
 async function sendCommand(options: {
@@ -322,7 +215,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     });
 
     it('lists every overflow element as enabled, with opt-a checked', async () => {
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Action Overflow', true);
         await expectRowEnabled('Option A', true);
         await expectRowEnabled('Option B', true);
@@ -358,14 +251,14 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
   describe('props — disabled action item, overflow', () => {
     it('marks the overflow row disabled', async () => {
       await setDisabledViaProps('action-overflow', true);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Action Overflow', false);
       });
     });
 
     it('leaves Last Event unchanged when the disabled overflow row is tapped', async () => {
       await expectLastEventUnchanged(async () => {
-        await withMenu(async () => {
+        await withOverflowMenu(async () => {
           await waitForMenuRow('Action Overflow');
           await element(menuRow('Action Overflow')).tap();
         });
@@ -374,7 +267,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('sets Last Event to "Pressed: action-overflow" when the re-enabled overflow row is tapped', async () => {
       await setDisabledViaProps('action-overflow', false);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Action Overflow', true);
         await element(menuRow('Action Overflow')).tap();
       });
@@ -385,7 +278,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
   describe('props — disabled checkable items', () => {
     it('disables opt-a while keeping its initial checked state', async () => {
       await setDisabledViaProps('opt-a', true);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Option A', false);
         await expectRowChecked('Option A', true);
       });
@@ -393,7 +286,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('leaves Last Event unchanged when the disabled checked item is tapped', async () => {
       await expectLastEventUnchanged(async () => {
-        await withMenu(async () => {
+        await withOverflowMenu(async () => {
           await waitForMenuRow('Option A');
           await element(menuRow('Option A')).tap();
           await expectRowChecked('Option A', true);
@@ -403,7 +296,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('disables opt-b while keeping its initial unchecked state', async () => {
       await setDisabledViaProps('opt-b', true);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Option B', false);
         await expectRowChecked('Option B', false);
       });
@@ -411,7 +304,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('leaves Last Event unchanged when the disabled unchecked item is tapped', async () => {
       await expectLastEventUnchanged(async () => {
-        await withMenu(async () => {
+        await withOverflowMenu(async () => {
           await waitForMenuRow('Option B');
           await element(menuRow('Option B')).tap();
           await expectRowChecked('Option B', false);
@@ -423,7 +316,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await setDisabledViaProps('opt-a', false);
       await setDisabledViaProps('opt-b', false);
 
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('Option A', true);
         await expectRowEnabled('Option B', true);
         await expectRowChecked('Option A', true);
@@ -432,7 +325,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     });
 
     it('reports both opt-a and opt-b in the "options" selection when opt-b is checked', async () => {
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await waitForMenuRow('Option B');
         await element(menuRow('Option B')).tap();
       });
@@ -440,7 +333,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     });
 
     it('drops opt-a from the selection when opt-a is unchecked', async () => {
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await waitForMenuRow('Option A');
         await element(menuRow('Option A')).tap();
       });
@@ -452,7 +345,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
       await setDisabledViaProps('action-bar', true);
       await setDisabledViaProps('action-bar', false);
 
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowChecked('Option A', true);
         await expectRowChecked('Option B', false);
       });
@@ -462,7 +355,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
   describe('props — disabled submenu', () => {
     it('disables the submenu row and does not open it when tapped', async () => {
       await setDisabledViaProps('submenu', true);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('More', false);
         await element(menuRow('More')).tap();
         await expectSubmenuStayedClosed();
@@ -471,7 +364,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('opens the submenu once it is re-enabled', async () => {
       await setDisabledViaProps('submenu', false);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('More', true);
         await openSubmenu();
       });
@@ -481,7 +374,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
   describe('props — disabled item inside a submenu', () => {
     it('disables the sub item', async () => {
       await setDisabledViaProps('sub-item', true);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await openSubmenu();
         await expectRowEnabled('Sub Item', false);
       });
@@ -489,7 +382,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('leaves Last Event unchanged when the disabled sub item is tapped', async () => {
       await expectLastEventUnchanged(async () => {
-        await withMenu(async () => {
+        await withOverflowMenu(async () => {
           await openSubmenu();
           await element(menuRow('Sub Item')).tap();
         });
@@ -498,7 +391,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('sets Last Event to "Pressed: sub-item" when the re-enabled sub item is tapped', async () => {
       await setDisabledViaProps('sub-item', false);
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await openSubmenu();
         await expectRowEnabled('Sub Item', true);
         await element(menuRow('Sub Item')).tap();
@@ -519,7 +412,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
 
     it('disables the submenu so it can no longer be opened', async () => {
       await sendCommand({ target: 'submenu', disabled: 'true' });
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('More', false);
         await element(menuRow('More')).tap();
         await expectSubmenuStayedClosed();
@@ -529,7 +422,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
     it('disables a checked item without clearing its check or updating Last Event', async () => {
       await sendCommand({ target: 'opt-a', disabled: 'true' });
       await expectLastEventUnchanged(async () => {
-        await withMenu(async () => {
+        await withOverflowMenu(async () => {
           await expectRowEnabled('Option A', false);
           await expectRowChecked('Option A', true);
           await element(menuRow('Option A')).tap();
@@ -552,7 +445,7 @@ describeIfAndroid('Stack Toolbar Menu Disabled', () => {
   describe('commands — three-state reset via `undefined`', () => {
     it('clears the disabled override and falls back to the default', async () => {
       await sendCommand({ target: 'submenu', disabled: 'undefined' });
-      await withMenu(async () => {
+      await withOverflowMenu(async () => {
         await expectRowEnabled('More', true);
         await openSubmenu();
       });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
@@ -278,7 +278,7 @@ describeIfAndroid('Stack Toolbar Menu Groups', () => {
 
   it('should not emit when re-selecting the checked single-selection item', async () => {
     await tapOverflowItem('Large');
-    await expectNoToast();
+    await expectNoToast('size: ["large"]');
 
     await withOverflowMenu(async () => {
       await expectRadioButton('Large', true);
@@ -415,7 +415,7 @@ describeIfAndroid('Stack Toolbar Menu Groups', () => {
     await dismissNextToast('size: ["medium"]');
 
     await sendCommand({ id: 'medium', checked: 'false' });
-    await expectNoToast();
+    await expectNoToast('size: ["medium"]');
     await withOverflowMenu(async () => {
       await expectRadioButton('Medium', true);
     });

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
@@ -1,19 +1,23 @@
 import { device, expect, element, by } from 'detox';
-import { NativeMatcher } from 'detox/detox';
 import {
+  createOverflowMenuHelpers,
   describeIfAndroid,
   dismissNextToast,
+  expectCheckBox,
   expectNoToast,
-  rewindAndScrollUntilVisible,
+  expectRadioButton,
+  MENU_ANIMATION_TIMEOUT_MS,
+  menuItemImage,
+  menuItemRow,
+  menuItemToggle,
+  openOverflowMenu,
+  scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
   toggleSettingsSwitch,
 } from '../../e2e-utils';
 import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
   CLASS_NAME_ANDROID_CHECK_BOX,
-  CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
   CLASS_NAME_ANDROID_RADIO_BUTTON,
 } from '../../native-class-names';
 
@@ -21,59 +25,10 @@ import {
 // state the previous one left.
 
 const SCROLLVIEW_ID = 'toolbar-menu-groups-scrollview';
-const OVERFLOW_MENU_LABEL = 'More options';
-
-/** Detox's idle sync misses popup animations, so these waits are explicit. */
-const MENU_ANIMATION_TIMEOUT_MS = 5000;
-
-/** Probes a settled popup: by now the menu is either up or was never opened. */
-const MENU_PRESENCE_TIMEOUT_MS = 250;
-
-/**
- * One Back press per popup window. A submenu replaces its parent on phones and
- * stacks on it on tablets, so at most two are ever up.
- */
-const MAX_MENU_DEPTH = 3;
-
-/**
- * A multi-toggle group renders check boxes and a single-selection one radio
- * buttons, so the class asserts the group type.
- */
-type ToggleWidget =
-  | typeof CLASS_NAME_ANDROID_CHECK_BOX
-  | typeof CLASS_NAME_ANDROID_RADIO_BUTTON;
-
-function menuItemRow(title: string): NativeMatcher {
-  return by
-    .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
-    .withDescendant(by.text(title));
-}
-
-function menuItemToggle(title: string, widget: ToggleWidget): NativeMatcher {
-  return by.type(widget).withAncestor(menuItemRow(title));
-}
 
 /** Anchors blocks made only of `not.toExist`, which a closed menu would satisfy. */
 async function expectMenuItemRow(title: string) {
   await expect(element(menuItemRow(title))).toBeVisible();
-}
-
-async function expectCheckBox(title: string, checked: boolean) {
-  await expect(
-    element(menuItemToggle(title, CLASS_NAME_ANDROID_RADIO_BUTTON)),
-  ).not.toExist();
-  await expect(
-    element(menuItemToggle(title, CLASS_NAME_ANDROID_CHECK_BOX)),
-  ).toHaveToggleValue(checked);
-}
-
-async function expectRadioButton(title: string, checked: boolean) {
-  await expect(
-    element(menuItemToggle(title, CLASS_NAME_ANDROID_CHECK_BOX)),
-  ).not.toExist();
-  await expect(
-    element(menuItemToggle(title, CLASS_NAME_ANDROID_RADIO_BUTTON)),
-  ).toHaveToggleValue(checked);
 }
 
 async function expectNoCheckmark(title: string) {
@@ -91,12 +46,6 @@ async function expectNoCheckmark(title: string) {
  * resource id, which Detox cannot match — so a row is asserted to hold at most
  * one visible image view at a time.
  */
-function menuItemImage(title: string): NativeMatcher {
-  return by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
-    .withAncestor(menuItemRow(title));
-}
-
 /** `by.type` matches visible views only, so `not.toExist` means "not visible". */
 async function expectGroupDivider(title: string, visible: boolean) {
   const divider = element(menuItemImage(title));
@@ -121,12 +70,7 @@ const SETTINGS_CONTROL = {
   pixels: SCROLL_STEP_PX,
 };
 
-async function tapById(id: string) {
-  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, {
-    pixels: SCROLL_STEP_PX,
-  });
-  await element(by.id(id)).tap();
-}
+const tapById = (id: string) => scrollToAndTap(id, SETTINGS_CONTROL);
 
 const SWITCHES = {
   singleSelection: {
@@ -188,56 +132,12 @@ async function sendCommand({ id, checked, title, hidden }: CommandSpec) {
   await tapById('send-command-button');
 }
 
-const overflowMenu = () =>
-  element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW));
-
-/** Nothing behind a focused popup is in the hierarchy Detox searches. */
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLLVIEW_ID)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
-}
-
-/** Resolves instead of throwing, so it can be used as a condition. */
-async function isMenuOpen(): Promise<boolean> {
-  return waitFor(overflowMenu())
-    .toExist()
-    .withTimeout(MENU_PRESENCE_TIMEOUT_MS)
-    .then(
-      () => true,
-      () => false,
-    );
-}
-
-/** Waits here, so a menu that never opened fails before any `try` below. */
-async function openOverflowMenu() {
-  await element(by.label(OVERFLOW_MENU_LABEL)).tap();
-  await waitFor(overflowMenu())
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
-}
-
 /**
- * Back only ever goes to an open popup: with no menu up the activity takes it
- * and pops the test screen, failing every later case in this stateful suite.
+ * A submenu replaces its parent on phones and stacks on it on tablets, so at
+ * most two popups are ever up — the default `maxMenuDepth` covers that.
  */
-async function closeMenuIfOpen() {
-  let pressCount = 0;
-
-  while (await isMenuOpen()) {
-    if (pressCount === MAX_MENU_DEPTH) {
-      throw new Error(
-        `The overflow menu was still open after ${MAX_MENU_DEPTH} Back presses.`,
-      );
-    }
-    await device.pressBack();
-    pressCount++;
-  }
-
-  if (pressCount > 0) {
-    await waitForScreen();
-  }
-}
+const { waitForScreen, closeMenuIfOpen, closingMenuAfter, withOverflowMenu } =
+  createOverflowMenuHelpers({ scrollViewId: SCROLLVIEW_ID });
 
 async function tapMenuItem(title: string) {
   await element(by.text(title)).tap();
@@ -268,32 +168,6 @@ async function tapSubmenuItem(title: string) {
   await openOverflowMenu();
   await openSubmenu();
   await tapLeafItem(title);
-}
-
-/** Closes the menu even on failure; a leaked popup would fail every later case. */
-async function closingMenuAfter(assertions: () => Promise<void>) {
-  let assertionFailed = false;
-
-  try {
-    await assertions();
-  } catch (error) {
-    assertionFailed = true;
-    throw error;
-  } finally {
-    try {
-      await closeMenuIfOpen();
-    } catch (cleanupError) {
-      // A throw from `finally` would replace the error that actually failed.
-      if (!assertionFailed) {
-        throw cleanupError;
-      }
-    }
-  }
-}
-
-async function withOverflowMenu(assertions: () => Promise<void>) {
-  await openOverflowMenu();
-  await closingMenuAfter(assertions);
 }
 
 /**

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-groups-android.e2e.ts
@@ -11,6 +11,7 @@ import {
   menuItemRow,
   menuItemToggle,
   openOverflowMenu,
+  overflowMenuText,
   scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
@@ -136,38 +137,33 @@ async function sendCommand({ id, checked, title, hidden }: CommandSpec) {
  * A submenu replaces its parent on phones and stacks on it on tablets, so at
  * most two popups are ever up — the default `maxMenuDepth` covers that.
  */
-const { waitForScreen, closeMenuIfOpen, closingMenuAfter, withOverflowMenu } =
+const { closeMenuIfOpen, closingMenuAfter, withOverflowMenu, tapMenuItem } =
   createOverflowMenuHelpers({ scrollViewId: SCROLLVIEW_ID });
-
-async function tapMenuItem(title: string) {
-  await element(by.text(title)).tap();
-}
 
 /** The only submenu row no case hides or renames. */
 const SUBMENU_ANCHOR_TITLE = 'Info';
 
+/**
+ * Opens the submenu via "More". Unlike a leaf tap, this opens a popup instead
+ * of closing one, so it can't use the shared `tapMenuItem`'s "gone after tap"
+ * assertion — it waits for the submenu's own content instead.
+ */
 async function openSubmenu() {
-  await tapMenuItem('More');
+  await element(overflowMenuText('More')).tap();
   await waitFor(element(menuItemRow(SUBMENU_ANCHOR_TITLE)))
     .toBeVisible()
     .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
 }
 
-/** A leaf tap dismisses the menu; the toast it emits is on the screen behind. */
-async function tapLeafItem(title: string) {
-  await tapMenuItem(title);
-  await waitForScreen();
-}
-
 async function tapOverflowItem(title: string) {
   await openOverflowMenu();
-  await tapLeafItem(title);
+  await tapMenuItem(title);
 }
 
 async function tapSubmenuItem(title: string) {
   await openOverflowMenu();
   await openSubmenu();
-  await tapLeafItem(title);
+  await tapMenuItem(title);
 }
 
 /**

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
@@ -1,17 +1,18 @@
-import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by, waitFor } from 'detox';
 import {
+  actionMenuItem,
+  createOverflowMenuHelpers,
   describeIfAndroid,
-  rewindAndScrollUntilVisible,
+  expectLastClicked as expectLastClickedText,
+  expectOverflowMenuOrder,
+  menuItemImage,
+  openOverflowMenu,
+  OVERFLOW_MENU_LABEL,
+  overflowMenuText,
+  scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
-  CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
-} from '../../native-class-names';
 // Typed from the screen, so a rename there fails type-checking here.
 import type {
   CmdIconOption,
@@ -33,13 +34,6 @@ const HEADER_TITLE: HeaderTitle = 'Show As Action Test';
 // enough not to carry a short picker option row past the viewport.
 const SCROLL_STEP = { pixels: 300 };
 
-// Detox's idle sync does not cover popup animations, so waits that straddle the
-// menu opening or dismissing must be explicit.
-const MENU_ANIMATION_TIMEOUT = 2000;
-
-// Probes an already-settled popup: by then it is either up or was never opened.
-const MENU_PRESENCE_TIMEOUT = 250;
-
 // A `showAsAction` change re-inflates the action menu, and a rotation does it
 // from a configuration change, so the toolbar can lag the assertion.
 const TOOLBAR_UPDATE_TIMEOUT = 3000;
@@ -54,37 +48,20 @@ const ALL_TITLES = Object.keys({
   'Item Number Three': true,
 } satisfies Record<MenuTitle, true>) as MenuTitle[];
 
-const popup = by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW);
+const overflowRow = (title: MenuTitle) => overflowMenuText(title);
 
-const overflowRow = (title: MenuTitle) => by.text(title).withAncestor(popup);
-
-// A row's `group_divider` and `submenuarrow` share this class but are GONE here,
-// and `by.type` matches visible views only — so a match is an icon.
-const overflowRowImage = (title: MenuTitle) =>
-  by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
-    .withAncestor(
-      by
-        .type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW)
-        .withDescendant(by.text(title)),
-    );
+// A row's `group_divider` and `submenuarrow` are GONE here, so a match is an
+// icon.
+const overflowRowImage = (title: MenuTitle) => menuItemImage(title);
 
 // `by.label` matches the action button in both its forms — icon-only (title as
 // content description) and text (title as text) — so the form is told apart by
 // the rendered text: AppCompat clears an icon-only button's text (`setText(null)`)
 // and shows the title only while no icon is set or WITH_TEXT is in effect.
 // @see androidx.appcompat.view.menu.ActionMenuItemView.updateTextButtonVisibility
-const actionItem = (title: MenuTitle) =>
-  element(
-    by.label(title).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW)),
-  );
+const actionItem = (title: MenuTitle) => element(actionMenuItem(title));
 
 const SCROLL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
-
-async function scrollToAndTap(id: string) {
-  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID, SCROLL_STEP);
-  await element(by.id(id)).tap();
-}
 
 type Slot = 1 | 2 | 3;
 
@@ -139,14 +116,10 @@ async function sendCommand(options: {
     SCROLL,
   );
 
-  await scrollToAndTap('send-command-button');
+  await scrollToAndTap('send-command-button', SCROLL);
 }
 
-const overflowButton = () => element(by.label('More options'));
-
-async function openMenu() {
-  await overflowButton().tap();
-}
+const overflowButton = () => element(by.label(OVERFLOW_MENU_LABEL));
 
 /**
  * With every item promoted nothing is left to overflow, so AppCompat drops the
@@ -158,66 +131,8 @@ async function expectNoOverflowMenu() {
     .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
 }
 
-async function waitForMenuItem(title: MenuTitle) {
-  await waitFor(element(overflowRow(title)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-}
-
-// Detox searches one window: while the popup holds focus nothing behind it is
-// in the hierarchy, so the screen itself has to become addressable again.
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLLVIEW_ID)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-}
-
-async function tapMenuItem(title: MenuTitle) {
-  await waitForMenuItem(title);
-  await element(overflowRow(title)).tap();
-  await waitFor(element(overflowRow(title)))
-    .not.toExist()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-  await waitForScreen();
-}
-
-// Back only when the popup is up: otherwise the activity takes it and pops the
-// test screen.
-async function closeMenuIfOpen() {
-  const isOpen = await waitFor(element(popup))
-    .toExist()
-    .withTimeout(MENU_PRESENCE_TIMEOUT)
-    .then(
-      () => true,
-      () => false,
-    );
-
-  if (!isOpen) {
-    return;
-  }
-
-  await device.pressBack();
-  await waitForScreen();
-}
-
-// Rows are stacked vertically, so their y positions carry the menu order. Only
-// callable while the menu is open.
-async function expectMenuOrder(titles: readonly MenuTitle[]): Promise<void> {
-  const rows: { title: MenuTitle; top: number }[] = [];
-
-  for (const title of titles) {
-    const attributes = await element(overflowRow(title)).getAttributes();
-
-    if ('elements' in attributes) {
-      throw new Error(`Expected a single menu row titled "${title}".`);
-    }
-
-    rows.push({ title, top: attributes.frame.y });
-  }
-
-  const topToBottom = [...rows].sort((a, b) => a.top - b.top).map(r => r.title);
-  jestExpect(topToBottom).toEqual([...titles]);
-}
+const { closeMenuIfOpen, withOverflowMenu, waitForMenuItem, tapMenuItem } =
+  createOverflowMenuHelpers({ scrollViewId: SCROLLVIEW_ID });
 
 // Asserts the exact overflow menu contents — the given titles top to bottom in
 // that order, each row icon-less, all other titles absent — then closes it.
@@ -226,11 +141,9 @@ async function expectMenuOrder(titles: readonly MenuTitle[]): Promise<void> {
 async function expectMenuItems(
   expectedVisible: [MenuTitle, ...MenuTitle[]],
 ): Promise<void> {
-  await openMenu();
-
-  let assertionFailed = false;
-
-  try {
+  // A leaked popup would fail every later step of this stateful suite;
+  // `withOverflowMenu` closes it even when an assertion throws.
+  await withOverflowMenu(async () => {
     // Rows populate in one layout pass, so once the first is up the
     // `not.toExist()` checks below cannot pass prematurely.
     await waitForMenuItem(expectedVisible[0]);
@@ -241,27 +154,14 @@ async function expectMenuItems(
       await expect(element(overflowRowImage(title))).not.toExist();
     }
 
-    await expectMenuOrder(expectedVisible);
+    await expectOverflowMenuOrder(expectedVisible);
 
     for (const title of ALL_TITLES) {
       if (!expectedVisible.includes(title)) {
         await expect(element(overflowRow(title))).not.toExist();
       }
     }
-  } catch (error) {
-    assertionFailed = true;
-    throw error;
-  } finally {
-    // A leaked popup would fail every later step of this stateful suite.
-    try {
-      await closeMenuIfOpen();
-    } catch (cleanupError) {
-      // A throw from `finally` would replace the error that actually failed.
-      if (!assertionFailed) {
-        throw cleanupError;
-      }
-    }
-  }
+  });
 }
 
 /**
@@ -306,14 +206,7 @@ async function expectNoActionItems() {
 }
 
 async function expectLastClicked(id: IdOption) {
-  await rewindAndScrollUntilVisible(
-    'last-clicked-text',
-    SCROLLVIEW_ID,
-    SCROLL_STEP,
-  );
-  await expect(element(by.id('last-clicked-text'))).toHaveText(
-    `Last clicked: ${id}`,
-  );
+  await expectLastClickedText(id, SCROLL);
 }
 
 describeIfAndroid('Stack Toolbar Menu Show As Action', () => {
@@ -343,14 +236,14 @@ describeIfAndroid('Stack Toolbar Menu Show As Action', () => {
     });
 
     it('reports item-1 when tapping "I1" in the overflow menu', async () => {
-      await openMenu();
+      await openOverflowMenu();
       await tapMenuItem('I1');
 
       await expectLastClicked('item-1');
     });
 
     it('reports item-3 when tapping "Item Number Three"', async () => {
-      await openMenu();
+      await openOverflowMenu();
       await tapMenuItem('Item Number Three');
 
       await expectLastClicked('item-3');

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
@@ -3,8 +3,11 @@ import {
   actionMenuItem,
   createOverflowMenuHelpers,
   describeIfAndroid,
+  expectIconActionItem,
   expectLastClicked as expectLastClickedText,
+  expectNoActionItem,
   expectOverflowMenuOrder,
+  expectTextActionItem,
   menuItemImage,
   openOverflowMenu,
   OVERFLOW_MENU_LABEL,
@@ -12,6 +15,7 @@ import {
   scrollToAndTap,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
+  TOOLBAR_UPDATE_TIMEOUT_MS,
 } from '../../e2e-utils';
 // Typed from the screen, so a rename there fails type-checking here.
 import type {
@@ -34,10 +38,6 @@ const HEADER_TITLE: HeaderTitle = 'Show As Action Test';
 // enough not to carry a short picker option row past the viewport.
 const SCROLL_STEP = { pixels: 300 };
 
-// A `showAsAction` change re-inflates the action menu, and a rotation does it
-// from a configuration change, so the toolbar can lag the assertion.
-const TOOLBAR_UPDATE_TIMEOUT = 3000;
-
 // Every title this scenario can put into the menu. Assertions check the full
 // set — expected present, all others absent — so an item that fails to move
 // between toolbar and overflow fails the test. `Record<MenuTitle, …>` makes a
@@ -54,11 +54,6 @@ const overflowRow = (title: MenuTitle) => overflowMenuText(title);
 // icon.
 const overflowRowImage = (title: MenuTitle) => menuItemImage(title);
 
-// `by.label` matches the action button in both its forms — icon-only (title as
-// content description) and text (title as text) — so the form is told apart by
-// the rendered text: AppCompat clears an icon-only button's text (`setText(null)`)
-// and shows the title only while no icon is set or WITH_TEXT is in effect.
-// @see androidx.appcompat.view.menu.ActionMenuItemView.updateTextButtonVisibility
 const actionItem = (title: MenuTitle) => element(actionMenuItem(title));
 
 const SCROLL = { scrollViewId: SCROLLVIEW_ID, ...SCROLL_STEP };
@@ -128,7 +123,7 @@ const overflowButton = () => element(by.label(OVERFLOW_MENU_LABEL));
 async function expectNoOverflowMenu() {
   await waitFor(overflowButton())
     .not.toExist()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
+    .withTimeout(TOOLBAR_UPDATE_TIMEOUT_MS);
 }
 
 const { closeMenuIfOpen, withOverflowMenu, waitForMenuItem, tapMenuItem } =
@@ -164,41 +159,7 @@ async function expectMenuItems(
   });
 }
 
-/**
- * Promoted to the toolbar, rendering its icon in place of its title. Asserted
- * positively through the cleared text — on Android a negated matcher passes on
- * a missing view. Which icon it is stays manual (see the header comment).
- */
-async function expectIconActionItem(title: MenuTitle) {
-  await waitFor(actionItem(title))
-    .toBeVisible()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
-  await waitFor(actionItem(title))
-    .toHaveText('')
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
-}
-
-/**
- * Promoted to the toolbar with its title as text — no icon set, or WITH_TEXT
- * put the title beside the icon. Whether an icon sits next to the text is not
- * assertable: it is a compound drawable of the same `TextView`, not a view.
- */
-async function expectTextActionItem(title: MenuTitle) {
-  await waitFor(actionItem(title))
-    .toBeVisible()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
-  await waitFor(actionItem(title))
-    .toHaveText(title)
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
-}
-
-/** Not promoted: the button is in neither form in the toolbar. */
-async function expectNoActionItem(title: MenuTitle) {
-  await waitFor(actionItem(title))
-    .not.toExist()
-    .withTimeout(TOOLBAR_UPDATE_TIMEOUT);
-}
-
+// Which icon renders stays manual (see the header comment).
 async function expectNoActionItems() {
   for (const title of ALL_TITLES) {
     await expectNoActionItem(title);

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-show-as-action-android.e2e.ts
@@ -4,7 +4,7 @@ import {
   createOverflowMenuHelpers,
   describeIfAndroid,
   expectIconActionItem,
-  expectLastClicked as expectLastClickedText,
+  expectLastClicked,
   expectNoActionItem,
   expectOverflowMenuOrder,
   expectTextActionItem,
@@ -166,10 +166,6 @@ async function expectNoActionItems() {
   }
 }
 
-async function expectLastClicked(id: IdOption) {
-  await expectLastClickedText(id, SCROLL);
-}
-
 describeIfAndroid('Stack Toolbar Menu Show As Action', () => {
   beforeAll(async () => {
     await device.reloadReactNative();
@@ -200,14 +196,14 @@ describeIfAndroid('Stack Toolbar Menu Show As Action', () => {
       await openOverflowMenu();
       await tapMenuItem('I1');
 
-      await expectLastClicked('item-1');
+      await expectLastClicked('item-1', SCROLL);
     });
 
     it('reports item-3 when tapping "Item Number Three"', async () => {
       await openOverflowMenu();
       await tapMenuItem('Item Number Three');
 
-      await expectLastClicked('item-3');
+      await expectLastClicked('item-3', SCROLL);
     });
   });
 
@@ -238,7 +234,7 @@ describeIfAndroid('Stack Toolbar Menu Show As Action', () => {
     it('reports item-1 when tapping the action button', async () => {
       await actionItem('I1').tap();
 
-      await expectLastClicked('item-1');
+      await expectLastClicked('item-1', SCROLL);
     });
   });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android.e2e.ts
@@ -50,9 +50,8 @@ type MenuText = Exclude<
   'undefined' | 'no change'
 >;
 
-// The screen assigns each picker `testID` from its label, replacing spaces with
-// dashes and lowercasing; renaming a label on the screen breaks the ids built
-// below. Option ids come from `pickerOptionId` inside `selectPickerOption`.
+// The screen derives picker `testID`s from their labels (slug + `-picker`);
+// renaming a label on the screen breaks the ids built here.
 const pickerId = (label: string) =>
   `${label.split(' ').join('-')}-picker`.toLowerCase();
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-title-android.e2e.ts
@@ -1,13 +1,15 @@
-import { device, expect, element, by, waitFor } from 'detox';
+import { device, expect, element, by } from 'detox';
 import {
+  createOverflowMenuHelpers,
+  actionMenuItem,
   describeIfAndroid,
-  scrollUntilVisible,
+  OVERFLOW_MENU_LABEL,
+  overflowMenuText,
+  scrollToAndTap,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
-} from '../../native-class-names';
+import { CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW } from '../../native-class-names';
 import type {
   CmdCondensedOption,
   CmdTitleOption,
@@ -21,20 +23,12 @@ import type {
 
 const SCROLL_VIEW = 'toolbar-menu-title-scrollview';
 const SEND_COMMAND_BUTTON = 'send-command-button';
-
-// Detox's idle sync does not cover popup window animations, so every wait that
-// straddles the overflow menu opening or dismissing has to be explicit.
-const MENU_ANIMATION_TIMEOUT_MS = 5000;
-
-// Probes an already-settled popup rather than an animation — by the time it is
-// used the menu is either up or was never opened.
-const MENU_PRESENCE_TIMEOUT_MS = 250;
+const SETTINGS_CONTROL = { scrollViewId: SCROLL_VIEW };
 
 const HEADER_TITLE: HeaderTitle = 'Title / Condensed / Tooltip';
 const ITEM_1_TITLE: ItemTitle = 'First Item';
 const ITEM_2_TITLE: ItemTitle = 'Second Item Title';
 const ITEM_3_TITLE: ItemTitle = 'Third Item Long Title';
-const OVERFLOW_BUTTON = 'More options';
 
 // Only the props the test drives are listed; the screen's tooltip pickers are
 // exercised manually (see `scenario.md`), so they have no entry here.
@@ -56,33 +50,11 @@ type MenuText = Exclude<
   'undefined' | 'no change'
 >;
 
-// Rewinds to the top first, so a target above the current offset is still
-// reachable — `scrollUntilVisible` only scrolls one way.
-async function scrollToControl(id: string) {
-  await element(by.id(SCROLL_VIEW)).scrollTo('top');
-  await scrollUntilVisible(id, SCROLL_VIEW);
-}
-
-/** Opens a picker, taps an option and closes the picker again. */
-async function selectOption(pickerId: string, optionId: string) {
-  await scrollToControl(pickerId);
-  await element(by.id(pickerId)).tap();
-
-  // The rows open directly below the picker, so the lower ones can start off
-  // screen.
-  await scrollUntilVisible(optionId, SCROLL_VIEW);
-  await element(by.id(optionId)).tap();
-
-  await scrollToControl(pickerId);
-  await element(by.id(pickerId)).tap();
-}
-
-// `SettingsPicker` derives its testIDs from the label it is given, replacing
-// spaces with dashes and lowercasing; renaming a label on the screen breaks the
-// ids built below.
-const pickerId = (label: string) => `${label}-picker`.toLowerCase();
-const optionId = (label: string, value: string) =>
-  `${label}-${value}`.toLowerCase();
+// The screen assigns each picker `testID` from its label, replacing spaces with
+// dashes and lowercasing; renaming a label on the screen breaks the ids built
+// below. Option ids come from `pickerOptionId` inside `selectPickerOption`.
+const pickerId = (label: string) =>
+  `${label.split(' ').join('-')}-picker`.toLowerCase();
 
 const SLOT_NUMBER = {
   'item-1': 1,
@@ -95,12 +67,16 @@ async function selectItemProp<Prop extends keyof ItemProps>(
   prop: Prop,
   value: ItemProps[Prop],
 ) {
-  const label = `slot-${SLOT_NUMBER[id]}-${prop}`;
-  await selectOption(pickerId(label), optionId(label, value));
+  const label = `Slot ${SLOT_NUMBER[id]} ${prop}`;
+  await selectPickerOption(
+    { pickerId: pickerId(label), label, option: value },
+    SETTINGS_CONTROL,
+  );
 }
 
+/** The picker `label`s on the screen, which the option `testID`s derive from. */
 const COMMAND_LABELS = {
-  targetId: 'target-id',
+  targetId: 'target id',
   title: 'title',
   titleCondensed: 'titleCondensed',
 } as const satisfies Record<keyof CommandProps, string>;
@@ -109,89 +85,29 @@ async function selectCommandProp<Prop extends keyof CommandProps>(
   prop: Prop,
   value: CommandProps[Prop],
 ) {
-  const label = `cmd-${COMMAND_LABELS[prop]}`;
-  await selectOption(pickerId(label), optionId(label, value));
+  const label = `cmd ${COMMAND_LABELS[prop]}`;
+  await selectPickerOption(
+    { pickerId: pickerId(label), label, option: value },
+    SETTINGS_CONTROL,
+  );
 }
 
 async function sendCommand() {
-  await scrollToControl(SEND_COMMAND_BUTTON);
-  await element(by.id(SEND_COMMAND_BUTTON)).tap();
+  await scrollToAndTap(SEND_COMMAND_BUTTON, SETTINGS_CONTROL);
 }
 
-const openOverflowMenu = () => element(by.label(OVERFLOW_BUTTON)).tap();
-
-const overflowMenu = () =>
-  element(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW));
-
-// Detox resolves matchers against a single window: while the popup holds focus
-// nothing behind it is in the searched hierarchy, so the popup going away is
-// not enough — the screen itself has to become addressable again.
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLL_VIEW)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT_MS);
-}
-
-/**
- * Presses Back only when the popup is actually up: a menu that never opened
- * would otherwise take the Back press itself and pop the test screen. A
- * left-over popup is not a local failure either — every later matcher would
- * resolve against the popup window instead of the activity, so the whole rest
- * of the suite fails on views that are plainly there.
- */
-async function closeOverflowMenuIfOpen() {
-  const isOpen = await waitFor(overflowMenu())
-    .toExist()
-    .withTimeout(MENU_PRESENCE_TIMEOUT_MS)
-    .then(
-      () => true,
-      () => false,
-    );
-
-  if (!isOpen) {
-    return;
-  }
-
-  await device.pressBack();
-  await waitForScreen();
-}
-
-/**
- * While the menu is open, Espresso resolves matchers against its window, so
- * `assertions` can only address rows inside it.
- */
-async function withOverflowMenu(assertions: () => Promise<void>) {
-  await openOverflowMenu();
-
-  let assertionFailed = false;
-
-  try {
-    await assertions();
-  } catch (error) {
-    assertionFailed = true;
-    throw error;
-  } finally {
-    try {
-      await closeOverflowMenuIfOpen();
-    } catch (cleanupError) {
-      // A throw from `finally` would replace the error that actually failed.
-      if (!assertionFailed) {
-        throw cleanupError;
-      }
-    }
-  }
-}
+const { closeMenuIfOpen, withOverflowMenu } = createOverflowMenuHelpers({
+  scrollViewId: SCROLL_VIEW,
+});
 
 const overflowRow = (title: MenuText): Detox.NativeMatcher =>
-  by
-    .text(title)
-    .withAncestor(by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW));
+  overflowMenuText(title);
 
 // An action button exposes its full title as content description while it is
 // icon-only, and renders text — `titleCondensed` when set — instead once there
 // is room for a label. It never has both.
 const toolbarButtonByLabel = (label: MenuText): Detox.NativeMatcher =>
-  by.label(label).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
+  actionMenuItem(label);
 
 const toolbarButtonByText = (text: MenuText): Detox.NativeMatcher =>
   by.text(text).and(by.type(CLASS_NAME_ANDROID_ACTION_MENU_ITEM_VIEW));
@@ -207,7 +123,7 @@ describeIfAndroid('Stack Toolbar Menu Title (Android)', () => {
 
   // Safety net: a test that fails mid-menu must not leave the popup up and
   // take every following test down with it.
-  afterEach(closeOverflowMenuIfOpen);
+  afterEach(closeMenuIfOpen);
 
   afterAll(async () => {
     await device.setOrientation('portrait');
@@ -221,7 +137,7 @@ describeIfAndroid('Stack Toolbar Menu Title (Android)', () => {
       await expect(element(toolbarButtonByText(ITEM_1_TITLE))).not.toExist();
       await expect(element(toolbarButtonByLabel(ITEM_2_TITLE))).toBeVisible();
       await expect(element(toolbarButtonByText(ITEM_2_TITLE))).not.toExist();
-      await expect(element(by.label(OVERFLOW_BUTTON))).toBeVisible();
+      await expect(element(by.label(OVERFLOW_MENU_LABEL))).toBeVisible();
       await expect(element(toolbarButtonByText('Cond'))).not.toExist();
     });
 

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
@@ -1,20 +1,24 @@
 import { expect as jestExpect } from '@jest/globals';
-import { device, expect, element, by, waitFor } from 'detox';
+import { device, expect, element, by } from 'detox';
 import type { AndroidElementAttributes } from 'detox/detox';
 import {
   countMatches,
+  createOverflowMenuHelpers,
   describeIfAndroid,
-  getElementAttributes,
+  expectLastClicked as expectLastClickedText,
   getMatches,
-  scrollUntilVisible,
+  MENU_ANIMATION_TIMEOUT_MS,
+  menuItemImage,
+  OVERFLOW_MENU_LABEL,
+  overflowMenuMatcher,
+  overflowMenuText,
+  rewindAndScrollUntilVisible,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
+  toggleSettingsSwitch,
   waitUntil,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW,
-  CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW,
-  CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW,
-} from '../../native-class-names';
+import { CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW } from '../../native-class-names';
 import type {
   AllIds,
   CmdHiddenOption,
@@ -26,13 +30,7 @@ import type {
 
 const SCROLLVIEW_ID = 'toolbar-nested-menu-scrollview';
 const HEADER_TITLE = 'Toolbar Nested Menu Test';
-const OVERFLOW_BUTTON = 'More options';
-
-// Detox's idle sync does not cover popup animations, so menu waits are explicit.
-const MENU_ANIMATION_TIMEOUT = 2000;
-
-// Probes an already-settled popup, not an animation.
-const MENU_PRESENCE_TIMEOUT = 250;
+const SETTINGS_CONTROL = { scrollViewId: SCROLLVIEW_ID };
 
 // Every text this scenario can put into a popup. Assertions cover the full set,
 // so a leaked entry fails.
@@ -57,16 +55,11 @@ type MenuText = (typeof ALL_MENU_TEXTS)[number];
 
 // Espresso only searches the focused window, so parent popups behind a submenu
 // are out of reach of anything anchored here.
-const focusedPopup = by.type(CLASS_NAME_ANDROID_MENU_DROP_DOWN_LIST_VIEW);
+const focusedPopup = overflowMenuMatcher();
 
 // A row or header in the focused popup.
 const menuText = (text: MenuText): Detox.NativeMatcher =>
-  by.text(text).withAncestor(focusedPopup);
-
-// A submenu header is a `FrameLayout`, not a row, so this matches the item alone
-// even where both show the same string.
-const menuItemRow = (text: MenuText): Detox.NativeMatcher =>
-  by.type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW).withDescendant(by.text(text));
+  overflowMenuText(text);
 
 // Any row of the focused popup — the only handle on an entry with no title.
 // Built per call, never hoisted to a const: Detox's `atIndex` rewrites the
@@ -79,9 +72,7 @@ const menuRow = (): Detox.NativeMatcher =>
 // `group_divider` and icon slot, which differ only by resource id (unmatchable
 // in Detox) — but this screen sets neither, so the caret is a row's only image.
 const submenuArrow = (text: MenuText): Detox.NativeMatcher =>
-  by
-    .type(CLASS_NAME_ANDROID_APP_COMPAT_IMAGE_VIEW)
-    .withAncestor(menuItemRow(text));
+  menuItemImage(text);
 
 // Every row inflates the caret and leaf items merely set it to `GONE`, so only
 // `visibility` separates a submenu from an item.
@@ -96,51 +87,16 @@ async function expectSubmenuArrow(text: MenuText, present: boolean) {
   }).toEqual({ text, arrows: present ? 1 : 0 });
 }
 
-// Mirrors the option `testID` that `SettingsPicker` derives from its `label`.
-// @see apps/src/shared/SettingsPicker.tsx
-function optionId(pickerLabel: string, option: string): string {
-  return `${pickerLabel.split(' ').join('-')}-${option}`.toLowerCase();
-}
-
-// Rewinds first — `whileElement` only scrolls one way.
 async function scrollIntoView(id: string) {
-  await element(by.id(SCROLLVIEW_ID)).scrollTo('top');
-  await scrollUntilVisible(id, SCROLLVIEW_ID);
+  await rewindAndScrollUntilVisible(id, SCROLLVIEW_ID);
 }
 
 /**
- * Sets a picker to `option`, then closes it: open option rows stay in the
- * hierarchy and would collide with the `by.text` menu matchers. Re-picking the
- * current value is skipped — it costs several taps and two scroll passes.
+ * Open option rows stay in the hierarchy and would collide with the `by.text`
+ * menu matchers, so the picker is closed again.
  */
-async function selectOption(
-  pickerId: string,
-  pickerLabel: string,
-  option: string,
-) {
-  const expectedText = `${pickerLabel}: ${option}`;
-
-  await scrollIntoView(pickerId);
-  const attributes = (await getElementAttributes({
-    by: 'id',
-    value: pickerId,
-  })) as AndroidElementAttributes;
-
-  if (attributes.text === expectedText) {
-    return;
-  }
-
-  await element(by.id(pickerId)).tap();
-
-  // Rows open below the picker, so the lower ones can start off screen.
-  const rowId = optionId(pickerLabel, option);
-  await scrollIntoView(rowId);
-  await element(by.id(rowId)).tap();
-
-  await scrollIntoView(pickerId);
-  await element(by.id(pickerId)).tap();
-
-  await expect(element(by.id(pickerId))).toHaveText(expectedText);
+async function selectOption(pickerId: string, label: string, option: string) {
+  await selectPickerOption({ pickerId, label, option }, SETTINGS_CONTROL);
 }
 
 interface Command {
@@ -182,10 +138,7 @@ async function setSubmenu1MenuTitle(menuTitle: Submenu1MenuTitleOption) {
 // The switch only toggles, so `value` is the state expected afterwards — a
 // swallowed tap fails here, not as a wrong-menu assertion steps later.
 async function setSwitch(switchId: string, label: string, value: boolean) {
-  await scrollIntoView(switchId);
-  await element(by.id(switchId)).tap();
-
-  await expect(element(by.text(`${label}: ${value}`))).toBeVisible();
+  await toggleSettingsSwitch({ switchId, label, to: value }, SETTINGS_CONTROL);
 }
 
 const setIncludeSubmenu1 = (value: boolean) =>
@@ -197,44 +150,10 @@ const setIncludeSubmenu2 = (value: boolean) =>
 const setAddExtraItem = (value: boolean) =>
   setSwitch('add-extra-item-switch', 'add extra item to submenu-1', value);
 
-// A row going away is not enough — with a popup focused nothing behind it is
-// searched, so the screen itself has to become addressable again.
-async function waitForScreen() {
-  await waitFor(element(by.id(SCROLLVIEW_ID)))
-    .toBeVisible()
-    .withTimeout(MENU_ANIMATION_TIMEOUT);
-}
-
-async function isScreenReachable(): Promise<boolean> {
-  return waitFor(element(by.id(SCROLLVIEW_ID)))
-    .toBeVisible()
-    .withTimeout(MENU_PRESENCE_TIMEOUT)
-    .then(
-      () => true,
-      () => false,
-    );
-}
-
-/**
- * Presses Back until the screen is addressable again. Submenus stack and each
- * Back closes one; the check before every press keeps a press with no popup up
- * from popping the test screen itself. A left-over popup is never a local
- * failure — every later matcher would resolve against the popup window.
- */
-async function closeMenus() {
-  // One press per popup of the deepest path (overflow, submenu, nested
-  // submenu), plus one to notice an unexpected extra level.
-  const MAX_POPUP_DEPTH = 4;
-
-  for (let i = 0; i < MAX_POPUP_DEPTH; i++) {
-    if (await isScreenReachable()) {
-      return;
-    }
-    await device.pressBack();
-  }
-
-  await waitForScreen();
-}
+// One Back press per popup of the deepest path (overflow, submenu, nested
+// submenu), plus one to notice an unexpected extra level.
+const { waitForScreen, closeMenuIfOpen, closingMenuAfter } =
+  createOverflowMenuHelpers({ scrollViewId: SCROLLVIEW_ID, maxMenuDepth: 4 });
 
 /**
  * Waits until exactly `count` elements in the focused popup show `text`. The
@@ -251,7 +170,7 @@ async function waitForMenuTextCount(text: MenuText, count: number) {
       return matches === count;
     },
     {
-      timeout: MENU_ANIMATION_TIMEOUT,
+      timeout: MENU_ANIMATION_TIMEOUT_MS,
       message: () =>
         `expected ${count} element(s) reading "${text}" in the focused popup, saw ${matches}`,
     },
@@ -259,7 +178,7 @@ async function waitForMenuTextCount(text: MenuText, count: number) {
 }
 
 async function openOverflowMenu() {
-  await element(by.label(OVERFLOW_BUTTON)).tap();
+  await element(by.label(OVERFLOW_MENU_LABEL)).tap();
   // No step ever renames or hides "Top Item", so it gates the open animation.
   await waitForMenuTextCount('Top Item', 1);
 }
@@ -327,25 +246,6 @@ async function expectMenuContents(
  * Runs `assertions`, then closes every open popup. A left-over popup would make
  * every later matcher in this stateful suite resolve against the popup window.
  */
-async function withMenusClosedAfter(assertions: () => Promise<void>) {
-  let assertionFailed = false;
-
-  try {
-    await assertions();
-  } catch (error) {
-    assertionFailed = true;
-    throw error;
-  } finally {
-    try {
-      await closeMenus();
-    } catch (cleanupError) {
-      // A throw from `finally` would replace the real failure.
-      if (!assertionFailed) {
-        throw cleanupError;
-      }
-    }
-  }
-}
 
 /**
  * Asserts the exact contents of the menu reached through `path`, then closes
@@ -363,7 +263,7 @@ async function expectMenu(
 
   await openMenu(path, gate, countOf(expected, gate));
 
-  await withMenusClosedAfter(() => expectMenuContents(expected, submenus));
+  await closingMenuAfter(() => expectMenuContents(expected, submenus));
 }
 
 // `submenu-1` sits between `item-top` and `submenu-2`, the only handle on it
@@ -381,7 +281,7 @@ async function expectUntitledSubmenu(
 ) {
   await openOverflowMenu();
 
-  await withMenusClosedAfter(async () => {
+  await closingMenuAfter(async () => {
     jestExpect(await countMatches(menuRow(), { orEmpty: true })).toBe(rowCount);
 
     await element(menuRow()).atIndex(UNTITLED_SUBMENU_ROW_INDEX).tap();
@@ -404,10 +304,7 @@ async function tapMenuItem(path: readonly MenuText[], item: MenuText) {
 }
 
 async function expectLastClicked(id: AllIds) {
-  await scrollIntoView('last-clicked-text');
-  await expect(element(by.id('last-clicked-text'))).toHaveText(
-    `Last clicked: ${id}`,
-  );
+  await expectLastClickedText(id, SETTINGS_CONTROL);
 }
 
 describeIfAndroid('Stack Toolbar Nested Menu', () => {
@@ -418,7 +315,7 @@ describeIfAndroid('Stack Toolbar Nested Menu', () => {
       'test-stack-toolbar-nested-menu-android',
     );
   });
-  afterEach(closeMenus);
+  afterEach(closeMenuIfOpen);
 
   describe('baseline — initial render and submenu structure', () => {
     it('renders the header title and the prop-configured top-level menu', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
@@ -5,12 +5,12 @@ import {
   countMatches,
   createOverflowMenuHelpers,
   describeIfAndroid,
-  expectLastClicked as expectLastClickedText,
+  expectLastClicked,
   getMatches,
   MENU_ANIMATION_TIMEOUT_MS,
   menuItemImage,
   openOverflowMenu,
-  overflowMenuMatcher,
+  overflowMenuRow,
   overflowMenuText,
   rewindAndScrollUntilVisible,
   selectPickerOption,
@@ -18,7 +18,6 @@ import {
   toggleSettingsSwitch,
   waitUntil,
 } from '../../e2e-utils';
-import { CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW } from '../../native-class-names';
 import type {
   AllIds,
   CmdHiddenOption,
@@ -53,20 +52,12 @@ const ALL_MENU_TEXTS = [
 
 type MenuText = (typeof ALL_MENU_TEXTS)[number];
 
-// Espresso only searches the focused window, so parent popups behind a submenu
-// are out of reach of anything anchored here.
-const focusedPopup = overflowMenuMatcher();
+// Espresso only searches the focused window, so parent popups behind a
+// submenu are out of reach of anything anchored to the focused popup.
 
 // A row or header in the focused popup.
 const menuText = (text: MenuText): Detox.NativeMatcher =>
   overflowMenuText(text);
-
-// Any row of the focused popup — the only handle on an entry with no title.
-// Built per call, never hoisted to a const: Detox's `atIndex` rewrites the
-// matcher it is given, so a shared one would stay pinned to the index it was
-// last tapped at.
-const menuRow = (): Detox.NativeMatcher =>
-  by.type(CLASS_NAME_ANDROID_LIST_MENU_ITEM_VIEW).withAncestor(focusedPopup);
 
 // The caret marking an entry as a submenu. It shares its class with the row's
 // `group_divider` and icon slot, which differ only by resource id (unmatchable
@@ -282,9 +273,11 @@ async function expectUntitledSubmenu(
   await openTopLevelMenu();
 
   await closingMenuAfter(async () => {
-    jestExpect(await countMatches(menuRow(), { orEmpty: true })).toBe(rowCount);
+    jestExpect(await countMatches(overflowMenuRow(), { orEmpty: true })).toBe(
+      rowCount,
+    );
 
-    await element(menuRow()).atIndex(UNTITLED_SUBMENU_ROW_INDEX).tap();
+    await element(overflowMenuRow()).atIndex(UNTITLED_SUBMENU_ROW_INDEX).tap();
 
     const gate = expected[0];
     await waitForMenuTextCount(gate, countOf(expected, gate));
@@ -301,10 +294,6 @@ async function tapMenuItem(path: readonly MenuText[], item: MenuText) {
 
   // Selecting an item dismisses every popup in the chain.
   await waitForScreen();
-}
-
-async function expectLastClicked(id: AllIds) {
-  await expectLastClickedText(id, SETTINGS_CONTROL);
 }
 
 describeIfAndroid('Stack Toolbar Nested Menu', () => {
@@ -349,31 +338,31 @@ describeIfAndroid('Stack Toolbar Nested Menu', () => {
     it('reports item-top as last clicked', async () => {
       await tapMenuItem([], 'Top Item');
 
-      await expectLastClicked('item-top');
+      await expectLastClicked('item-top', SETTINGS_CONTROL);
     });
 
     it('reports sub-1-1 for the first item of submenu-1 as last clicked', async () => {
       await tapMenuItem(['Submenu A'], 'Sub A.1');
 
-      await expectLastClicked('sub-1-1');
+      await expectLastClicked('sub-1-1', SETTINGS_CONTROL);
     });
 
     it('reports sub-1-2 for the second item of submenu-1 as last clicked', async () => {
       await tapMenuItem(['Submenu A'], 'Sub A.2');
 
-      await expectLastClicked('sub-1-2');
+      await expectLastClicked('sub-1-2', SETTINGS_CONTROL);
     });
 
     it('reports sub-2-1 for the item of submenu-2 as last clicked', async () => {
       await tapMenuItem(['Submenu B'], 'Sub B.1');
 
-      await expectLastClicked('sub-2-1');
+      await expectLastClicked('sub-2-1', SETTINGS_CONTROL);
     });
 
     it('reports deep-1 for the item of the doubly nested submenu as last clicked', async () => {
       await tapMenuItem(['Submenu B', 'Deep'], 'Deep.1');
 
-      await expectLastClicked('deep-1');
+      await expectLastClicked('deep-1', SETTINGS_CONTROL);
     });
   });
 
@@ -387,7 +376,7 @@ describeIfAndroid('Stack Toolbar Nested Menu', () => {
     it('keeps the id stable across the title change', async () => {
       await tapMenuItem(['Submenu A'], 'Title X');
 
-      await expectLastClicked('sub-1-1');
+      await expectLastClicked('sub-1-1', SETTINGS_CONTROL);
     });
 
     it('hides sub-1-2 when hidden = true', async () => {
@@ -602,7 +591,7 @@ describeIfAndroid('Stack Toolbar Nested Menu', () => {
     it('keeps the id of the deeply nested item stable', async () => {
       await tapMenuItem(['Submenu B', 'Deep'], 'Title X');
 
-      await expectLastClicked('deep-1');
+      await expectLastClicked('deep-1', SETTINGS_CONTROL);
     });
 
     it('retitles the nested submenu container itself', async () => {

--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-nested-menu-android.e2e.ts
@@ -9,7 +9,7 @@ import {
   getMatches,
   MENU_ANIMATION_TIMEOUT_MS,
   menuItemImage,
-  OVERFLOW_MENU_LABEL,
+  openOverflowMenu,
   overflowMenuMatcher,
   overflowMenuText,
   rewindAndScrollUntilVisible,
@@ -177,9 +177,9 @@ async function waitForMenuTextCount(text: MenuText, count: number) {
   );
 }
 
-async function openOverflowMenu() {
-  await element(by.label(OVERFLOW_MENU_LABEL)).tap();
-  // No step ever renames or hides "Top Item", so it gates the open animation.
+async function openTopLevelMenu() {
+  await openOverflowMenu();
+  // No step ever renames or hides "Top Item", so it gates the rows populating.
   await waitForMenuTextCount('Top Item', 1);
 }
 
@@ -193,7 +193,7 @@ async function openMenu(
   gate: MenuText,
   gateCount: number,
 ) {
-  await openOverflowMenu();
+  await openTopLevelMenu();
 
   for (let i = 0; i < path.length; i++) {
     await element(menuText(path[i])).tap();
@@ -279,7 +279,7 @@ async function expectUntitledSubmenu(
   rowCount: number,
   expected: [MenuText, ...MenuText[]],
 ) {
-  await openOverflowMenu();
+  await openTopLevelMenu();
 
   await closingMenuAfter(async () => {
     jestExpect(await countMatches(menuRow(), { orEmpty: true })).toBe(rowCount);

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -6,7 +6,7 @@ import {
   expectBottomAccessoryAboveTabBar,
   forceTapByLabeliOS,
   getBottomAccessoryAttributes,
-  getElementAttributes,
+  getSingleMatch,
   getTabBarAttributes,
   scrollUntilVisible,
   selectSingleFeatureTestsScreen,
@@ -291,11 +291,9 @@ describeIfiPadOS26('@ipad Tabs bottomAccessory (iPadOS 26+)', () => {
       'test-tabs-bottom-accessory-layout-ios',
     );
     await expect(element(by.id('config-scrollview'))).toBeVisible();
-    configScrollView = (await getElementAttributes({
-      by: 'id',
-      value: 'config-scrollview',
-      index: 0,
-    })) as IosElementAttributes;
+    configScrollView = (await getSingleMatch(
+      by.id('config-scrollview'),
+    )) as IosElementAttributes;
   });
 
   it('should display the Config tab content and initial accessory on load', async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -6,7 +6,7 @@ import {
   expectBottomAccessoryAboveTabBar,
   forceTapByLabeliOS,
   getBottomAccessoryAttributes,
-  getSingleMatch,
+  getMatches,
   getTabBarAttributes,
   scrollUntilVisible,
   selectSingleFeatureTestsScreen,
@@ -291,10 +291,10 @@ describeIfiPadOS26('@ipad Tabs bottomAccessory (iPadOS 26+)', () => {
       'test-tabs-bottom-accessory-layout-ios',
     );
     await expect(element(by.id('config-scrollview'))).toBeVisible();
-    configScrollView = (await getSingleMatch(
-      by.id('config-scrollview'),
-      'config-scrollview',
-    )) as IosElementAttributes;
+    // The first match, as several copies can be attached while tabs switch.
+    configScrollView = (
+      await getMatches(by.id('config-scrollview'))
+    )[0] as IosElementAttributes;
   });
 
   it('should display the Config tab content and initial accessory on load', async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -293,6 +293,7 @@ describeIfiPadOS26('@ipad Tabs bottomAccessory (iPadOS 26+)', () => {
     await expect(element(by.id('config-scrollview'))).toBeVisible();
     configScrollView = (await getSingleMatch(
       by.id('config-scrollview'),
+      'config-scrollview',
     )) as IosElementAttributes;
   });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-layout-ios.e2e.ts
@@ -3,34 +3,21 @@ import { expect as jestExpect } from '@jest/globals';
 import {
   describeIfiOS26,
   describeIfiPadOS26,
-  selectSingleFeatureTestsScreen,
+  expectBottomAccessoryAboveTabBar,
   forceTapByLabeliOS,
+  getBottomAccessoryAttributes,
   getElementAttributes,
+  getTabBarAttributes,
+  scrollUntilVisible,
+  selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import { IosElementAttributes } from 'detox/detox';
-import {
-  CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
-  CLASS_NAME_UI_TAB_BAR,
-} from '../../native-class-names';
+import { CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY } from '../../native-class-names';
 
 const bottomAccessoryElement = (testID: string) =>
   element(
     by.id(testID).withAncestor(by.type(CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY)),
   ).atIndex(0);
-
-const getBottomAccessoryAttributes = () =>
-  getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
-    index: 0,
-  }) as Promise<IosElementAttributes>;
-
-const getExtendedTabBarAttributes = async () =>
-  getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_UI_TAB_BAR,
-    index: 0,
-  }) as Promise<IosElementAttributes>;
 
 async function expectBottomAccessoryExist(testID: string) {
   await expect(bottomAccessoryElement(testID)).toExist();
@@ -38,15 +25,6 @@ async function expectBottomAccessoryExist(testID: string) {
 
 async function expectBottomAccessoryText(testID: string, text: string) {
   await expect(bottomAccessoryElement(testID)).toHaveText(text);
-}
-
-function expectBottomAccessoryExtended(
-  bottomAccessory: IosElementAttributes,
-  tabBar: IosElementAttributes,
-) {
-  jestExpect(tabBar.frame.y).toBeGreaterThan(
-    bottomAccessory.frame.y + bottomAccessory.frame.height,
-  );
 }
 
 function expectBottomAccessoryInline(
@@ -83,16 +61,17 @@ function expectBottomAccessoryAtTheBottom(
   jestExpect(bottomAccessoryBottom).toBeGreaterThanOrEqual(safeAreaLine);
 }
 
-async function scrollScrollViewToItem(
+// Small steps from low on the screen: the accessory must not swallow the swipe.
+const scrollScrollViewToItem = (
   scrollViewId: string,
   itemId: string,
   direction: 'up' | 'down',
-) {
-  await waitFor(element(by.id(itemId)))
-    .toBeVisible()
-    .whileElement(by.id(scrollViewId))
-    .scroll(150, direction, NaN, 0.3);
-}
+) =>
+  scrollUntilVisible(itemId, scrollViewId, {
+    pixels: 150,
+    startPercentage: 0.3,
+    direction,
+  });
 
 type VariantCase = {
   variantId?: string; // card to tap; omitted for the initial-load variant
@@ -226,10 +205,7 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
 
     await expectBottomAccessoryExist('accessory-center');
     await expectBottomAccessoryText('accessory-center', 'Center');
-    expectBottomAccessoryExtended(
-      await getBottomAccessoryAttributes(),
-      await getExtendedTabBarAttributes(),
-    );
+    await expectBottomAccessoryAboveTabBar();
   });
 
   it('should display the bottom accessory inline when scrolling down on ScrollDown tab', async () => {
@@ -247,17 +223,14 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
     expectBottomAccessoryInline(
       await getBottomAccessoryAttributes(),
       extendedAccessoryWidth,
-      await getExtendedTabBarAttributes(),
+      await getTabBarAttributes(),
     );
   });
 
   it('should display the bottom accessory above the tab bar when scrolling up on ScrollDown tab', async () => {
     await element(by.id('scroll-down-scrollview')).scrollTo('top');
 
-    expectBottomAccessoryExtended(
-      await getBottomAccessoryAttributes(),
-      await getExtendedTabBarAttributes(),
-    );
+    await expectBottomAccessoryAboveTabBar();
   });
 
   // ---------------------------------------------------------------------------
@@ -271,10 +244,7 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
 
     await expectBottomAccessoryExist('accessory-center');
     await expectBottomAccessoryText('accessory-center', 'Center');
-    expectBottomAccessoryExtended(
-      await getBottomAccessoryAttributes(),
-      await getExtendedTabBarAttributes(),
-    );
+    await expectBottomAccessoryAboveTabBar();
   });
 
   it('should display the bottom accessory inline when scrolling up on ScrollUp tab', async () => {
@@ -292,7 +262,7 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
     expectBottomAccessoryInline(
       await getBottomAccessoryAttributes(),
       extendedAccessoryWidth,
-      await getExtendedTabBarAttributes(),
+      await getTabBarAttributes(),
     );
   });
 
@@ -304,10 +274,7 @@ describeIfiOS26('Tabs bottomAccessory (iOS 26+)', () => {
       'down',
     );
 
-    expectBottomAccessoryExtended(
-      await getBottomAccessoryAttributes(),
-      await getExtendedTabBarAttributes(),
-    );
+    await expectBottomAccessoryAboveTabBar();
   });
 });
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -1,5 +1,6 @@
 import { device, expect, element, by, waitFor } from 'detox';
 import {
+  DEFAULT_TIMEOUT_MS,
   describeIfiOS26,
   expectBottomAccessoryAboveTabBar,
   selectSingleFeatureTestsScreen,
@@ -20,7 +21,7 @@ const ACCESSORY_TEXT = 'bottom-accessory-text';
 const ACCESSORY_CONTENT = 'Bottom Accessory';
 
 // Grace period for the animated `setBottomAccessory:` attach / detach.
-const TRANSITION_TIMEOUT_MS = 3000;
+const TRANSITION_TIMEOUT_MS = DEFAULT_TIMEOUT_MS;
 
 const SETTINGS_CONTROL = { scrollViewId: SCROLL_VIEW };
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-bottom-accessory-visibility-ios.e2e.ts
@@ -1,16 +1,11 @@
 import { device, expect, element, by, waitFor } from 'detox';
-import { expect as jestExpect } from '@jest/globals';
-import type { IosElementAttributes } from 'detox/detox';
 import {
   describeIfiOS26,
-  getElementAttributes,
+  expectBottomAccessoryAboveTabBar,
   selectSingleFeatureTestsScreen,
   toggleSettingsSwitch,
 } from '../../e2e-utils';
-import {
-  CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
-  CLASS_NAME_UI_TAB_BAR,
-} from '../../native-class-names';
+import { CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY } from '../../native-class-names';
 
 /**
  * Covers the end state of each `scenario.md` step: after every `hidden` /
@@ -63,19 +58,7 @@ async function expectBottomAccessoryShown() {
   await expect(bottomAccessoryText()).toExist();
   await expect(bottomAccessoryText()).toHaveText(ACCESSORY_CONTENT);
 
-  const accessory = (await getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_RNS_TABS_BOTTOM_ACCESSORY,
-  })) as IosElementAttributes;
-  const tabBar = (await getElementAttributes({
-    by: 'type',
-    value: CLASS_NAME_UI_TAB_BAR,
-    index: 0,
-  })) as IosElementAttributes;
-
-  jestExpect(tabBar.frame.y).toBeGreaterThan(
-    accessory.frame.y + accessory.frame.height,
-  );
+  await expectBottomAccessoryAboveTabBar();
 }
 
 async function expectBottomAccessoryAbsent() {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-general-appearance-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-general-appearance-android.e2e.ts
@@ -1,23 +1,18 @@
 import { device, expect, element, by } from 'detox';
 import {
   describeIfAndroid,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 
-async function selectLabelVisibilityMode(
+const selectLabelVisibilityMode = (
   mode: 'auto' | 'selected' | 'labeled' | 'unlabeled',
-) {
-  await element(
-    by.id('general-appearance-android-label-visibility-picker'),
-  ).tap();
-  await element(by.id(`tabbaritemlabelvisibilitymode-${mode}`)).tap();
-  await expect(
-    element(by.id('general-appearance-android-label-visibility-picker')),
-  ).toHaveLabel(`tabBarItemLabelVisibilityMode: ${mode}`);
-  await element(
-    by.id('general-appearance-android-label-visibility-picker'),
-  ).tap();
-}
+) =>
+  selectPickerOption({
+    pickerId: 'general-appearance-android-label-visibility-picker',
+    label: 'tabBarItemLabelVisibilityMode',
+    option: mode,
+  });
 
 describeIfAndroid(
   'Tab Bar General Appearance (Android) - tabBarItemLabelVisibilityMode',

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-ime-insets-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-ime-insets-android.e2e.ts
@@ -7,9 +7,15 @@ import {
 } from '../../e2e-utils';
 
 const getTabBarItemY = async () =>
-  (await getFrame(by.id('ime-insets-config-tab-item'))).y;
+  (
+    await getFrame(
+      by.id('ime-insets-config-tab-item'),
+      'ime-insets-config-tab-item',
+    )
+  ).y;
 const getTextY = async () =>
-  (await getFrame(by.id('tabs-screen-bottom-text'))).y;
+  (await getFrame(by.id('tabs-screen-bottom-text'), 'tabs-screen-bottom-text'))
+    .y;
 
 describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
   beforeAll(async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-ime-insets-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-ime-insets-android.e2e.ts
@@ -1,23 +1,15 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
-import { AndroidElementAttributes } from 'detox/detox';
 import {
   describeIfAndroid,
+  getFrame,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 
-async function getTabBarItemAttrs(): Promise<AndroidElementAttributes> {
-  const attrs = (await element(
-    by.id('ime-insets-config-tab-item'),
-  ).getAttributes()) as AndroidElementAttributes;
-  return attrs;
-}
-async function getTextAttrs(): Promise<AndroidElementAttributes> {
-  const attrs = (await element(
-    by.id('tabs-screen-bottom-text'),
-  ).getAttributes()) as AndroidElementAttributes;
-  return attrs;
-}
+const getTabBarItemY = async () =>
+  (await getFrame(by.id('ime-insets-config-tab-item'))).y;
+const getTextY = async () =>
+  (await getFrame(by.id('tabs-screen-bottom-text'))).y;
 
 describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
   beforeAll(async () => {
@@ -50,13 +42,13 @@ describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
       element(by.id('tab-bar-respects-ime-insets-switch')),
     ).toHaveLabel('tabBarRespectsIMEInsets: false');
 
-    const yTabBefore = (await getTabBarItemAttrs()).frame.y;
-    const yTextBefore = (await getTextAttrs()).frame.y;
+    const yTabBefore = await getTabBarItemY();
+    const yTextBefore = await getTextY();
 
     await element(by.id('ime-insets-text-input')).tap();
 
-    const yTabAfter = (await getTabBarItemAttrs()).frame.y;
-    const yTextAfter = (await getTextAttrs()).frame.y;
+    const yTabAfter = await getTabBarItemY();
+    const yTextAfter = await getTextY();
 
     jestExpect(yTabAfter).toEqual(yTabBefore);
     jestExpect(yTextAfter).toEqual(yTextBefore);
@@ -70,13 +62,13 @@ describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
       element(by.id('tab-bar-respects-ime-insets-switch')),
     ).toHaveLabel('tabBarRespectsIMEInsets: true');
 
-    const yTabBefore = (await getTabBarItemAttrs()).frame.y;
-    const yTextBefore = (await getTextAttrs()).frame.y;
+    const yTabBefore = await getTabBarItemY();
+    const yTextBefore = await getTextY();
 
     await element(by.id('ime-insets-text-input')).tap();
 
-    const yTabAfter = (await getTabBarItemAttrs()).frame.y;
-    const yTextAfter = (await getTextAttrs()).frame.y;
+    const yTabAfter = await getTabBarItemY();
+    const yTextAfter = await getTextY();
 
     jestExpect(yTabAfter).toBeLessThan(yTabBefore);
     jestExpect(yTextAfter).toBeLessThan(yTextBefore);
@@ -84,7 +76,7 @@ describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
 
     await device.pressBack();
 
-    const yTabRestored = (await getTabBarItemAttrs()).frame.y;
+    const yTabRestored = await getTabBarItemY();
 
     jestExpect(yTabRestored).toEqual(yTabBefore);
   });
@@ -98,15 +90,15 @@ describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
       element(by.id('tab-bar-respects-ime-insets-switch')),
     ).toHaveLabel('tabBarRespectsIMEInsets: true');
 
-    const yTabBefore = (await getTabBarItemAttrs()).frame.y;
-    const yTextBefore = (await getTextAttrs()).frame.y;
+    const yTabBefore = await getTabBarItemY();
+    const yTextBefore = await getTextY();
 
     jestExpect(yTextBefore).toBeGreaterThan(yTabBefore);
 
     await element(by.id('ime-insets-text-input')).tap();
 
-    const yTabAfter = (await getTabBarItemAttrs()).frame.y;
-    const yTextAfter = (await getTextAttrs()).frame.y;
+    const yTabAfter = await getTabBarItemY();
+    const yTextAfter = await getTextY();
 
     jestExpect(yTabAfter).toBeLessThan(yTabBefore);
     jestExpect(yTextAfter).toEqual(yTextBefore);
@@ -123,14 +115,14 @@ describeIfAndroid('Tabs: tabBarRespectsIMEInsets', () => {
       element(by.id('tab-bar-respects-ime-insets-switch')),
     ).toHaveLabel('tabBarRespectsIMEInsets: false');
 
-    const yTabBefore = (await getTabBarItemAttrs()).frame.y;
-    const yTextBefore = (await getTextAttrs()).frame.y;
+    const yTabBefore = await getTabBarItemY();
+    const yTextBefore = await getTextY();
     jestExpect(yTextBefore).toBeGreaterThan(yTabBefore);
 
     await element(by.id('ime-insets-text-input')).tap();
 
-    const yTabAfter = (await getTabBarItemAttrs()).frame.y;
-    const yTextAfter = (await getTextAttrs()).frame.y;
+    const yTabAfter = await getTabBarItemY();
+    const yTextAfter = await getTextY();
 
     jestExpect(yTabAfter).toEqual(yTabBefore);
     jestExpect(yTextAfter).toEqual(yTextBefore);

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-item-badge.e2e.ts
@@ -1,21 +1,13 @@
 import { device, expect, element, by } from 'detox';
-import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
-import isVersionEqualOrHigherThan from '../../helpers/isVersionEqualOrHigherThan';
+import {
+  describeIfiOS,
+  isIOSVersionAtLeast,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
 import {
   CLASS_NAME_UI_TAB_BAR_BADGE_VIEW_IOS26,
   CLASS_NAME_UI_TAB_BAR_BADGE_VIEW_LEGACY,
 } from '../../native-class-names';
-const {
-  getIOSVersionNumber,
-} = require('../../../../scripts/e2e/ios-devices.js');
-
-function isIOSVersionAtLeast(version: string): boolean {
-  return (
-    device.getPlatform() === 'ios' &&
-    isVersionEqualOrHigherThan(getIOSVersionNumber(), version)
-  );
-}
-
 const tabBarBadgeViewType = isIOSVersionAtLeast('26.0')
   ? CLASS_NAME_UI_TAB_BAR_BADGE_VIEW_IOS26
   : CLASS_NAME_UI_TAB_BAR_BADGE_VIEW_LEGACY;

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
@@ -4,6 +4,7 @@ import { IosElementAttributes } from 'detox/detox';
 import {
   describeIfiOS,
   forceTapByLabeliOS,
+  getElementAttributes,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import { CLASS_NAME_UI_TAB_BAR } from '../../native-class-names';
@@ -34,21 +35,8 @@ async function getTabBarFrame(): Promise<{
   return (attrs as IosElementAttributes).frame;
 }
 
-async function getElementFrame(testID: string): Promise<{
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}> {
-  const attrs = await element(by.id(testID)).getAttributes();
-
-  if ('elements' in attrs) {
-    throw new Error(
-      `Multiple elements (${attrs.elements.length}) found for testID: "${testID}".`,
-    );
-  }
-  return (attrs as IosElementAttributes).frame;
-}
+const getElementFrame = async (testID: string) =>
+  (await getElementAttributes({ by: 'id', value: testID })).frame;
 
 function isAboveTabBar(
   itemFrame: { y: number; height: number },

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
@@ -11,7 +11,7 @@ import {
 import { CLASS_NAME_UI_TAB_BAR } from '../../native-class-names';
 
 const getScrollViewSafeAreaInsetsTop = async (testID: string) => ({
-  top: ((await getSingleMatch(by.id(testID))) as IosElementAttributes)
+  top: ((await getSingleMatch(by.id(testID), testID)) as IosElementAttributes)
     .safeAreaInsets.top,
 });
 
@@ -22,8 +22,9 @@ function isAboveSaveAreaInset(
   return itemFrame.y + itemFrame.height <= scrollViewSAVInsetTop;
 }
 
-const getTabBarFrame = () => getFrame(by.type(CLASS_NAME_UI_TAB_BAR));
-const getElementFrame = (testID: string) => getFrame(by.id(testID));
+const getTabBarFrame = () =>
+  getFrame(by.type(CLASS_NAME_UI_TAB_BAR), 'the UITabBar');
+const getElementFrame = (testID: string) => getFrame(by.id(testID), testID);
 
 function isAboveTabBar(
   itemFrame: { y: number; height: number },

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-override-scroll-view-content-inset-ios.e2e.ts
@@ -4,19 +4,16 @@ import { IosElementAttributes } from 'detox/detox';
 import {
   describeIfiOS,
   forceTapByLabeliOS,
-  getElementAttributes,
+  getFrame,
+  getSingleMatch,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import { CLASS_NAME_UI_TAB_BAR } from '../../native-class-names';
 
-async function getScrollViewSafeAreaInsetsTop(testID: string): Promise<{
-  top: number;
-}> {
-  const attrs = (await element(
-    by.id(testID),
-  ).getAttributes()) as IosElementAttributes;
-  return { top: attrs.safeAreaInsets.top };
-}
+const getScrollViewSafeAreaInsetsTop = async (testID: string) => ({
+  top: ((await getSingleMatch(by.id(testID))) as IosElementAttributes)
+    .safeAreaInsets.top,
+});
 
 function isAboveSaveAreaInset(
   itemFrame: { y: number; height: number },
@@ -25,18 +22,8 @@ function isAboveSaveAreaInset(
   return itemFrame.y + itemFrame.height <= scrollViewSAVInsetTop;
 }
 
-async function getTabBarFrame(): Promise<{
-  x: number;
-  y: number;
-  width: number;
-  height: number;
-}> {
-  const attrs = await element(by.type(CLASS_NAME_UI_TAB_BAR)).getAttributes();
-  return (attrs as IosElementAttributes).frame;
-}
-
-const getElementFrame = async (testID: string) =>
-  (await getElementAttributes({ by: 'id', value: testID })).frame;
+const getTabBarFrame = () => getFrame(by.type(CLASS_NAME_UI_TAB_BAR));
+const getElementFrame = (testID: string) => getFrame(by.id(testID));
 
 function isAboveTabBar(
   itemFrame: { y: number; height: number },

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-system-item-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-system-item-ios.e2e.ts
@@ -1,18 +1,17 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
 import { IosElementAttributes } from 'detox/detox';
-import { selectSingleFeatureTestsScreen, describeIfiOS } from '../../e2e-utils';
-import isVersionEqualOrHigherThan from '../../helpers/isVersionEqualOrHigherThan';
+import {
+  describeIfiOS,
+  isIOSVersionAtLeast,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
 import {
   CLASS_NAME_UI_TAB_BAR,
   CLASS_NAME_UI_TAB_BAR_BUTTON_LABEL,
   CLASS_NAME_UI_TAB_BAR_BUTTON_IOS26,
   CLASS_NAME_UI_TAB_BAR_BUTTON_LEGACY,
 } from '../../native-class-names';
-const {
-  getIOSVersionNumber,
-} = require('../../../../scripts/e2e/ios-devices.js');
-
 async function tapOptionButton(optionText: string) {
   await element(by.text(optionText)).tap();
 }
@@ -36,13 +35,6 @@ async function tapSystemTitleOption() {
 
 async function tapSystemIconOption() {
   await element(by.text('system')).atIndex(1).tap();
-}
-
-function isIOSVersionAtLeast(version: string): boolean {
-  return (
-    device.getPlatform() === 'ios' &&
-    isVersionEqualOrHigherThan(getIOSVersionNumber(), version)
-  );
 }
 
 const tabBarButtonType = isIOSVersionAtLeast('26.0')

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-controller-mode-ios.e2e.ts
@@ -2,6 +2,7 @@ import { device, expect, element, by } from 'detox';
 import {
   describeIfiOS,
   describeIfiPad,
+  selectPickerOption,
   selectSingleFeatureTestsScreen,
 } from '../../e2e-utils';
 import {
@@ -17,18 +18,12 @@ const PICKER_ID = 'tab-bar-controller-mode-picker';
 
 type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
-function modeItemId(mode: TabBarControllerMode) {
-  return `tabbarcontrollermode-${mode.toLowerCase()}`;
-}
-
-async function setTabBarControllerMode(mode: TabBarControllerMode) {
-  await element(by.id(PICKER_ID)).tap();
-  await element(by.id(modeItemId(mode))).tap();
-  await expect(element(by.id(PICKER_ID))).toHaveLabel(
-    `tabBarControllerMode: ${mode}`,
-  );
-  await element(by.id(PICKER_ID)).tap();
-}
+const setTabBarControllerMode = (mode: TabBarControllerMode) =>
+  selectPickerOption({
+    pickerId: PICKER_ID,
+    label: 'tabBarControllerMode',
+    option: mode,
+  });
 
 describeIfiPad('@ipad Tabs: tabBarControllerMode (iPad)', () => {
   beforeAll(async () => {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -11,12 +11,10 @@ import {
 const SCROLLVIEW_ID = 'tab-bar-layout-direction-scrollview';
 const DIRECTION_PICKER_ID = 'tab-bar-layout-direction-picker';
 
-// Small steps keep a short picker row from being scrolled past; the Detox
-// default start point is kept.
+// Small steps keep a short picker row from being scrolled past.
 const SCROLL = {
   scrollViewId: SCROLLVIEW_ID,
   pixels: 100,
-  startPercentage: NaN,
 };
 
 async function scrollToDirectionPicker() {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -31,8 +31,14 @@ async function selectDirection(direction: 'inherit' | 'rtl' | 'ltr') {
 }
 
 async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
-  const t1 = await getFrame(by.label('tab-bar-item-1-label'));
-  const t2 = await getFrame(by.label('tab-bar-item-2-label'));
+  const t1 = await getFrame(
+    by.label('tab-bar-item-1-label'),
+    'tab-bar-item-1-label',
+  );
+  const t2 = await getFrame(
+    by.label('tab-bar-item-2-label'),
+    'tab-bar-item-2-label',
+  );
   if (shouldBeLeft) {
     jestExpect(t2.x).toBeGreaterThan(t1.x);
   } else {

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -2,7 +2,7 @@ import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
 import {
   describeIfiOS,
-  getElementAttributes,
+  getFrame,
   scrollUntilVisible,
   selectPickerOption,
   selectSingleFeatureTestsScreen,
@@ -31,18 +31,12 @@ async function selectDirection(direction: 'inherit' | 'rtl' | 'ltr') {
 }
 
 async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
-  const t1 = await getElementAttributes({
-    by: 'label',
-    value: 'tab-bar-item-1-label',
-  });
-  const t2 = await getElementAttributes({
-    by: 'label',
-    value: 'tab-bar-item-2-label',
-  });
+  const t1 = await getFrame(by.label('tab-bar-item-1-label'));
+  const t2 = await getFrame(by.label('tab-bar-item-2-label'));
   if (shouldBeLeft) {
-    jestExpect(t2.frame.x).toBeGreaterThan(t1.frame.x);
+    jestExpect(t2.x).toBeGreaterThan(t1.x);
   } else {
-    jestExpect(t1.frame.x).toBeGreaterThan(t2.frame.x);
+    jestExpect(t1.x).toBeGreaterThan(t2.x);
   }
 }
 

--- a/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/tabs/test-tabs-tab-bar-layout-direction.e2e.ts
@@ -1,43 +1,44 @@
 import { expect as jestExpect } from '@jest/globals';
 import { device, expect, element, by } from 'detox';
-import { AndroidElementAttributes, IosElementAttributes } from 'detox/detox';
-import { describeIfiOS, selectSingleFeatureTestsScreen } from '../../e2e-utils';
+import {
+  describeIfiOS,
+  getElementAttributes,
+  scrollUntilVisible,
+  selectPickerOption,
+  selectSingleFeatureTestsScreen,
+} from '../../e2e-utils';
 
-type ElementAttributes = IosElementAttributes | AndroidElementAttributes;
+const SCROLLVIEW_ID = 'tab-bar-layout-direction-scrollview';
+const DIRECTION_PICKER_ID = 'tab-bar-layout-direction-picker';
 
-async function getElementAttributes(
-  testLabel: string,
-): Promise<ElementAttributes> {
-  const attrs = await element(by.label(testLabel)).getAttributes();
-  return attrs as ElementAttributes;
-}
+// Small steps keep a short picker row from being scrolled past; the Detox
+// default start point is kept.
+const SCROLL = {
+  scrollViewId: SCROLLVIEW_ID,
+  pixels: 100,
+  startPercentage: NaN,
+};
 
-async function scrollTo(selector: { id: string } | { text: string }) {
-  const el =
-    'text' in selector
-      ? element(by.text(selector.text))
-      : element(by.id(selector.id));
-
-  await waitFor(el)
-    .toBeVisible()
-    .whileElement(by.id('tab-bar-layout-direction-scrollview'))
-    .scroll(100, 'down');
+async function scrollToDirectionPicker() {
+  await scrollUntilVisible(DIRECTION_PICKER_ID, SCROLLVIEW_ID, SCROLL);
 }
 
 async function selectDirection(direction: 'inherit' | 'rtl' | 'ltr') {
-  await scrollTo({ id: 'tab-bar-layout-direction-picker' });
-  await element(by.id('tab-bar-layout-direction-picker')).tap();
-  await scrollTo({ text: direction });
-  await element(by.text(direction)).tap();
-  await element(by.id('tab-bar-layout-direction-picker')).tap();
-  await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
-    `direction: ${direction}`,
+  await selectPickerOption(
+    { pickerId: DIRECTION_PICKER_ID, label: 'direction', option: direction },
+    SCROLL,
   );
 }
 
 async function expectTab1ToBeLeftOfTab2(shouldBeLeft: boolean) {
-  const t1 = await getElementAttributes('tab-bar-item-1-label');
-  const t2 = await getElementAttributes('tab-bar-item-2-label');
+  const t1 = await getElementAttributes({
+    by: 'label',
+    value: 'tab-bar-item-1-label',
+  });
+  const t2 = await getElementAttributes({
+    by: 'label',
+    value: 'tab-bar-item-2-label',
+  });
   if (shouldBeLeft) {
     jestExpect(t2.frame.x).toBeGreaterThan(t1.frame.x);
   } else {
@@ -70,7 +71,7 @@ describe('Tab Bar Layout Direction - system/RN settings: LTR', () => {
       'I18nManager.isRTL == false',
     );
 
-    await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+    await scrollToDirectionPicker();
     await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
       'direction: ltr',
     );
@@ -154,7 +155,7 @@ describe('Tab Bar Layout Direction - system/RN settings: RTL', () => {
       'I18nManager.isRTL == true',
     );
 
-    await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+    await scrollToDirectionPicker();
     await expect(element(by.id('tab-bar-layout-direction-picker'))).toHaveLabel(
       'direction: rtl',
     );
@@ -233,7 +234,7 @@ describeIfiOS(
         'I18nManager.isRTL == false',
       );
 
-      await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+      await scrollToDirectionPicker();
       await expect(
         element(by.id('tab-bar-layout-direction-picker')),
       ).toHaveLabel('direction: ltr');
@@ -308,7 +309,7 @@ describeIfiOS(
         'I18nManager.isRTL == true',
       );
 
-      await scrollTo({ id: 'tab-bar-layout-direction-picker' });
+      await scrollToDirectionPicker();
       await expect(
         element(by.id('tab-bar-layout-direction-picker')),
       ).toHaveLabel('direction: rtl');

--- a/apps/src/tests/issue-tests/Test4361.tsx
+++ b/apps/src/tests/issue-tests/Test4361.tsx
@@ -23,8 +23,8 @@ function HomeScreen({ navigation }: any) {
       <Pressable
         style={styles.button}
         onPress={() => navigation.getParent()?.navigate('Calendar')}>
-          <Text style={styles.buttonText}>Push Calendar</Text>
-        </Pressable>
+        <Text style={styles.buttonText}>Push Calendar</Text>
+      </Pressable>
     </View>
   );
 }
@@ -34,14 +34,14 @@ function MyPetsScreen() {
     <View style={styles.screen}>
       <Text>My Pets (Tab B)</Text>
       <ScrollView style={styles.scrollArea}>
-        {Array.from({ length: 30 }, (_, i) =>
+        {Array.from({ length: 30 }, (_, i) => (
           <Pressable
             key={i}
             style={styles.listItem}
             onPress={() => console.log(`pressed pet item ${i}`)}>
-              <Text style={styles.listItemText}>Pet item {i}</Text>
-            </Pressable>
-        )}
+            <Text style={styles.listItemText}>Pet item {i}</Text>
+          </Pressable>
+        ))}
       </ScrollView>
       <Text>
         If touches are broken, tapping items above will produce NO console logs.
@@ -57,12 +57,12 @@ function ProfileScreen() {
       <Pressable
         style={styles.button}
         onPress={() => console.log('Profile button pressed')}>
-          <Text style={styles.buttonText}>Press me</Text>
-        </Pressable>
-        <Text>
-          If touches are broken, pressing the button above will produce NO console
-          log.
-        </Text>
+        <Text style={styles.buttonText}>Press me</Text>
+      </Pressable>
+      <Text>
+        If touches are broken, pressing the button above will produce NO console
+        log.
+      </Text>
     </View>
   );
 }
@@ -72,9 +72,9 @@ function TabsNavigator() {
     <Tab.Navigator>
       <Tab.Screen name="Home" component={HomeScreen} />
       <Tab.Screen
-      name="MyPets"
-      component={MyPetsScreen}
-      options={{ title: 'My Pets' }}
+        name="MyPets"
+        component={MyPetsScreen}
+        options={{ title: 'My Pets' }}
       />
       <Tab.Screen name="Profile" component={ProfileScreen} />
     </Tab.Navigator>
@@ -100,14 +100,14 @@ export default function App() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen
-        name="Tabs"
-        component={TabsNavigator}
-        options={{ headerShown: false }}
+          name="Tabs"
+          component={TabsNavigator}
+          options={{ headerShown: false }}
         />
         <Stack.Screen
-        name="Calendar"
-        component={CalendarScreen}
-        options={{ title: 'Calendar' }}
+          name="Calendar"
+          component={CalendarScreen}
+          options={{ title: 'Calendar' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/apps/src/tests/issue-tests/Test4361.tsx
+++ b/apps/src/tests/issue-tests/Test4361.tsx
@@ -23,8 +23,8 @@ function HomeScreen({ navigation }: any) {
       <Pressable
         style={styles.button}
         onPress={() => navigation.getParent()?.navigate('Calendar')}>
-        <Text style={styles.buttonText}>Push Calendar</Text>
-      </Pressable>
+          <Text style={styles.buttonText}>Push Calendar</Text>
+        </Pressable>
     </View>
   );
 }
@@ -34,14 +34,14 @@ function MyPetsScreen() {
     <View style={styles.screen}>
       <Text>My Pets (Tab B)</Text>
       <ScrollView style={styles.scrollArea}>
-        {Array.from({ length: 30 }, (_, i) => (
+        {Array.from({ length: 30 }, (_, i) =>
           <Pressable
             key={i}
             style={styles.listItem}
             onPress={() => console.log(`pressed pet item ${i}`)}>
-            <Text style={styles.listItemText}>Pet item {i}</Text>
-          </Pressable>
-        ))}
+              <Text style={styles.listItemText}>Pet item {i}</Text>
+            </Pressable>
+        )}
       </ScrollView>
       <Text>
         If touches are broken, tapping items above will produce NO console logs.
@@ -57,12 +57,12 @@ function ProfileScreen() {
       <Pressable
         style={styles.button}
         onPress={() => console.log('Profile button pressed')}>
-        <Text style={styles.buttonText}>Press me</Text>
-      </Pressable>
-      <Text>
-        If touches are broken, pressing the button above will produce NO console
-        log.
-      </Text>
+          <Text style={styles.buttonText}>Press me</Text>
+        </Pressable>
+        <Text>
+          If touches are broken, pressing the button above will produce NO console
+          log.
+        </Text>
     </View>
   );
 }
@@ -72,9 +72,9 @@ function TabsNavigator() {
     <Tab.Navigator>
       <Tab.Screen name="Home" component={HomeScreen} />
       <Tab.Screen
-        name="MyPets"
-        component={MyPetsScreen}
-        options={{ title: 'My Pets' }}
+      name="MyPets"
+      component={MyPetsScreen}
+      options={{ title: 'My Pets' }}
       />
       <Tab.Screen name="Profile" component={ProfileScreen} />
     </Tab.Navigator>
@@ -100,14 +100,14 @@ export default function App() {
     <NavigationContainer>
       <Stack.Navigator>
         <Stack.Screen
-          name="Tabs"
-          component={TabsNavigator}
-          options={{ headerShown: false }}
+        name="Tabs"
+        component={TabsNavigator}
+        options={{ headerShown: false }}
         />
         <Stack.Screen
-          name="Calendar"
-          component={CalendarScreen}
-          options={{ title: 'Calendar' }}
+        name="Calendar"
+        component={CalendarScreen}
+        options={{ title: 'Calendar' }}
         />
       </Stack.Navigator>
     </NavigationContainer>

--- a/apps/src/tests/issue-tests/Test4423.tsx
+++ b/apps/src/tests/issue-tests/Test4423.tsx
@@ -42,7 +42,9 @@ export default function App() {
   };
 
   const detailRouteConfig =
-    pushedScreenKey === 'home' ? null : DETAIL_ROUTE_CONFIGS[pushedScreenKey];
+    pushedScreenKey === 'home'
+      ? null
+      : DETAIL_ROUTE_CONFIGS[pushedScreenKey];
 
   return (
     <ScreenStack style={{ flex: 1 }}>

--- a/apps/src/tests/issue-tests/Test4423.tsx
+++ b/apps/src/tests/issue-tests/Test4423.tsx
@@ -42,9 +42,7 @@ export default function App() {
   };
 
   const detailRouteConfig =
-    pushedScreenKey === 'home'
-      ? null
-      : DETAIL_ROUTE_CONFIGS[pushedScreenKey];
+    pushedScreenKey === 'home' ? null : DETAIL_ROUTE_CONFIGS[pushedScreenKey];
 
   return (
     <ScreenStack style={{ flex: 1 }}>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-back-button-ios/scenario-description.ts
@@ -3,7 +3,8 @@ import type { ScenarioDescription } from '@apps/tests/shared/helpers';
 export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Back Button (iOS)',
   key: 'test-stack-back-button-ios',
-  details: 'Tests back button configuration, layout with respect to changing widths of elements in header, ' +
+  details:
+    'Tests back button configuration, layout with respect to changing widths of elements in header, ' +
     'and toggling the long press navigation history menu. Back button props are configured on the screen ' +
     'that renders the back button, but the native configuration is performed on the screen below.',
   platforms: ['ios'],

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-item-identifier-ios/index.tsx
@@ -149,7 +149,13 @@ function Screen(props: { routeName: string }) {
         ),
       },
     }),
-    [routeName, identifiersEnabled, separatorsEnabled, customViewsEnabled, screenIndex],
+    [
+      routeName,
+      identifiersEnabled,
+      separatorsEnabled,
+      customViewsEnabled,
+      screenIndex,
+    ],
   );
 
   useLayoutEffect(() => {


### PR DESCRIPTION
## Description

First of the two PRs proposed in the e2e helpers [RFC-1754](https://github.com/software-mansion/react-native-screens-labs/pull/1754): the behavioral cleanup. Spec-local helpers that re-implemented (or slightly diverged from) `e2e-utils` exports are replaced by the shared ones, constants that had drifted per spec are consolidated, and the two helper families that were never shared — the iOS header context menu and the Android Stack v5 toolbar overflow menu — are reconciled to a single implementation in place, in `e2e-utils.ts`. No directory restructuring; that is the follow-up PR.

This changes test behavior in a few deliberate places, all verified on device: shared settle waits (5000 ms) for the Android overflow menu, `selectPickerOption`'s early return and value assertion applied everywhere, `expectTopmostVisible` used instead of stale local copies, and `tapBarBackButton` gaining a settle wait and topmost-match tap on both platforms (its Android branch previously matched an id that nothing sets).

## Changes

- `e2e-utils.ts`
  - Helpers moved here from spec-local implementations — and, where specs had diverged, reconciled into one shared version — rather than newly written: `getSingleMatch`, `getFrame`, `readTopmostText`, `readText`, `tapTopmostButton`, `expectLastClicked`, `expectTopmostButtons`, `overflowMenuText`, `actionMenuItem`, `menuItemImage`, `expectOverflowMenuOrder`, Stack v5 toolbar matchers (`stackV5Toolbar`, `stackV5AppBar`, `stackV5BackButton`, `stackV5HeaderTitle`), `expectIconActionItem` / `expectTextActionItem` / `expectNoActionItem`, `waitForRouteName` / `waitForTopmostRoute` (route-key polling for stacked/nested screens), `openHeaderTitleMenu` / `headerTitle`, bottom-accessory getters + `expectBottomAccessoryAboveTabBar`, and `waitForMenuItem` / `tapMenuItem` inside `createOverflowMenuHelpers`.
  - `selectPickerOption` takes an optional `control` (pickers outside a scroll view are tapped in place) and asserts by label on iOS / text on Android. `scrollUntilVisible` gained a `direction` option (kept scoped to testID targets); `rewindAndScrollUntilVisible` rejects `direction` at the type level since it only ever rewinds up then scrolls down.
  - `getElementAttributes` removed in favor of `getSingleMatch`; the two section navigators share one implementation; `DEFAULT_TIMEOUT_MS` replaces scattered `3000` literals.
  - iOS context-menu and header-item helpers (`openContextMenu`, `dismissContextMenu`, `menuRow`, `checkmarkFor`, `chevronFor`, `menuRowIcon`, `submenuTitleRow`, `headerItem`, `barButtonIcon`) consolidated here from six header specs.
  - Doc comments trimmed to the contract.
- `native-class-names.ts`: new `CLASS_NAME_ANDROID_TOOLBAR` (generic `androidx.appcompat.widget.Toolbar` — matches both the legacy `CustomToolbar` and Stack v5's `MaterialToolbar`, since Detox resolves `by.type` with `isAssignableFrom`) and `CLASS_NAME_UI_CONTEXT_MENU_PLATTER_TRANSITION_VIEW` (was a bare literal in one spec).
- `elements/back-button.ts`: waits for the button, taps the topmost match on both platforms; iOS 26 ambiguity handled with a compound matcher. The Android matcher is its own — an `AppCompatImageButton` scoped to the generic `Toolbar` (`CLASS_NAME_ANDROID_TOOLBAR`) rather than the shared `stackV5BackButton`, since that one is scoped to `MaterialToolbar` specifically and would miss the legacy header.
- `helpers/isVersionEqualOrHigherThan.ts`: argument names changed to `version` / `minimumVersion`.
- 29 single-feature specs and `issue-tests/Test758`: local copies of `isIOSVersionAtLeast`, `optionId`, scroll/picker/switch helpers, overflow-menu open/close/wait logic, toolbar matchers and attribute readers dropped in favor of the shared exports; unused imports removed.
- Every changed suite was run on device: iOS (iPhone 17, iOS 26) header, tabs and stack suites; Android (Pixel 9) toolbar-menu, tabs and stack suites. The two `test-tabs-ime-insets-android` keyboard cases fail on an AVD with `hw.keyboard=yes` identically before and after this change.

