### PR TITLE
fix(Android): pin a dismissal snapshot so pop exit animations keep showing screen content

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/NativeProxy.kt
@@ -3,12 +3,17 @@ package com.swmansion.rnscreens
 import android.util.Log
 import com.facebook.jni.HybridData
 import com.facebook.proguard.annotations.DoNotStrip
+import com.facebook.react.bridge.UIManager
+import com.facebook.react.bridge.UIManagerListener
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.swmansion.rnscreens.legacy.Screen
+import com.swmansion.rnscreens.legacy.ScreenDismissSnapshot
 import java.lang.ref.WeakReference
 import java.util.concurrent.ConcurrentHashMap
 
-class NativeProxy {
+@OptIn(UnstableReactNativeAPI::class)
+class NativeProxy : UIManagerListener {
     @DoNotStrip
     @Suppress("unused")
     private val mHybridData: HybridData
@@ -24,6 +29,11 @@ class NativeProxy {
     external fun cleanupExpiredMountingCoordinators()
 
     external fun invalidateNative()
+
+    // Screens that an upcoming, not yet executed transaction dismisses.
+    // Written on the mounting thread (notifyScreenRemoved), drained on the UI
+    // thread right before mount items execute (willMountItems).
+    private val screensAwaitingSnapshot: MutableSet<Int> = ConcurrentHashMap.newKeySet()
 
     companion object {
         // we use ConcurrentHashMap here since it will be read on the JS thread,
@@ -69,6 +79,14 @@ class NativeProxy {
             // To prevent `Screen.isBeingRemoved` from being read as false during teardown,
             // we must set this flag synchronously here.
             screen.markAsBeingRemoved()
+
+            // The same transaction also deletes the screen's content before the
+            // exit animation starts (the differ tears removed subtrees down
+            // bottom-up), so the animation would play on an empty screen. Pin
+            // the screen's currently presented pixels as an overlay right
+            // before that transaction executes - see willMountItems.
+            screensAwaitingSnapshot.add(screenTag)
+
             val isScheduled =
                 screen.post {
                     screen.startRemovalTransition()
@@ -80,4 +98,38 @@ class NativeProxy {
             Log.w("[RNScreens]", "Reference stored in NativeProxy for tag $screenTag no longer points to valid object.")
         }
     }
+
+    // UIManagerListener. Fabric calls willMountItems on the UI thread right
+    // before it executes a round of mount items - the last moment at which a
+    // dismissed screen's content is still intact and presented on screen.
+
+    override fun willMountItems(uiManager: UIManager) {
+        if (screensAwaitingSnapshot.isEmpty()) {
+            return
+        }
+        val iterator = screensAwaitingSnapshot.iterator()
+        while (iterator.hasNext()) {
+            val tag = iterator.next()
+            iterator.remove()
+            viewsMap[tag]?.get()?.let { screen ->
+                ScreenDismissSnapshot.pinDismissSnapshot(screen)
+                // Also start the removal transition here, synchronously, instead
+                // of relying only on the runnable posted in notifyScreenRemoved:
+                // this is the last point guaranteed to run before the deleting
+                // batch. The view retention it starts cannot fully survive a
+                // Reanimated-rebuilt transaction (which is why the snapshot
+                // exists), but it keeps the content alive for the first frames
+                // when the snapshot bails out (e.g. on a missed deadline).
+                screen.startRemovalTransition()
+            }
+        }
+    }
+
+    override fun didMountItems(uiManager: UIManager) = Unit
+
+    override fun didDispatchMountItems(uiManager: UIManager) = Unit
+
+    override fun didScheduleMountItems(uiManager: UIManager) = Unit
+
+    override fun willDispatchViewUpdates(uiManager: UIManager) = Unit
 }

--- a/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreensModule.kt
@@ -5,6 +5,7 @@ import com.facebook.proguard.annotations.DoNotStrip
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.UiThreadUtil
+import com.facebook.react.common.annotations.UnstableReactNativeAPI
 import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.UIManagerHelper
@@ -41,9 +42,14 @@ class ScreensModule(
 
     private external fun nativeUninstall()
 
+    @OptIn(UnstableReactNativeAPI::class)
     override fun invalidate() {
         super.invalidate()
-        proxy?.invalidateNative()
+        proxy?.let {
+            (UIManagerHelper.getUIManager(reactContext, UIManagerType.FABRIC) as? FabricUIManager)
+                ?.removeUIManagerEventListener(it)
+            it.invalidateNative()
+        }
         proxy = null
         reactContext.removeLifecycleEventListener(this)
         nativeUninstall()
@@ -56,11 +62,16 @@ class ScreensModule(
         setupFabric()
     }
 
+    @OptIn(UnstableReactNativeAPI::class)
     private fun setupFabric() {
         val fabricUIManager =
             UIManagerHelper.getUIManager(reactContext, UIManagerType.FABRIC) as FabricUIManager
         proxy?.apply {
             nativeAddMutationsListener(fabricUIManager)
+            // Re-adding is guarded by removing first - setupFabric runs again
+            // on every host resume.
+            fabricUIManager.removeUIManagerEventListener(this)
+            fabricUIManager.addUIManagerEventListener(this)
         }
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenDismissSnapshot.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenDismissSnapshot.kt
@@ -1,0 +1,110 @@
+package com.swmansion.rnscreens.legacy
+
+import android.graphics.Bitmap
+import android.graphics.Rect
+import android.graphics.drawable.BitmapDrawable
+import android.os.Build
+import android.os.Handler
+import android.os.HandlerThread
+import android.view.PixelCopy
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+
+/**
+ * Pins a screen's currently presented pixels as its foreground drawable right
+ * before a dismissing mounting transaction executes, so the exit animation keeps
+ * showing the real content after Fabric has deleted the screen's children.
+ *
+ * This is the Android counterpart of the snapshot iOS takes on dismissal.
+ */
+internal object ScreenDismissSnapshot {
+    // A PixelCopy is a GPU readback of the last presented frame and typically
+    // completes within single milliseconds; the deadline only guards against a
+    // stalled render pipeline.
+    private const val SNAPSHOT_DEADLINE_MS = 64L
+
+    private val snapshotHandler: Handler by lazy {
+        Handler(HandlerThread("RNScreensDismissSnapshot").apply { start() }.looper)
+    }
+
+    /**
+     * Captures the screen's currently presented pixels from the window and sets
+     * them as the screen's foreground drawable. The foreground draws above the
+     * (soon removed) children, so the exit animation keeps showing the real
+     * content. The bitmap dies with the screen view when the fragment view is
+     * dropped at the end of the transition.
+     *
+     * Only call this for screens that a pulled transaction really deletes:
+     * nothing clears the foreground on a screen that stays alive.
+     */
+    fun pinDismissSnapshot(screen: Screen) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            // PixelCopy for a Window source needs API 26.
+            return
+        }
+        if (!screen.isAttachedToWindow || screen.width == 0 || screen.height == 0) {
+            return
+        }
+        if (screen.stackPresentation == Screen.StackPresentation.TRANSPARENT_MODAL) {
+            // The window pixels would bake the content behind the transparent
+            // screen into the overlay.
+            return
+        }
+        if (screen.container?.topScreen !== screen) {
+            // Only the top screen animates out. The window pixels of a covered
+            // screen would capture the top screen's content anyway.
+            return
+        }
+        val window = screen.reactContext.currentActivity?.window ?: return
+
+        val location = IntArray(2)
+        screen.getLocationInWindow(location)
+        val srcRect = Rect(location[0], location[1], location[0] + screen.width, location[1] + screen.height)
+        val decorView = window.decorView
+        if (!srcRect.intersect(0, 0, decorView.width, decorView.height) ||
+            srcRect.width() != screen.width ||
+            srcRect.height() != screen.height
+        ) {
+            // A clipped rect would stretch a partial bitmap over the full view
+            // (the foreground fills the view bounds).
+            return
+        }
+
+        val bitmap =
+            try {
+                Bitmap.createBitmap(srcRect.width(), srcRect.height(), Bitmap.Config.ARGB_8888)
+            } catch (e: OutOfMemoryError) {
+                // Skipping the snapshot falls back to the current behavior;
+                // crashing a back navigation would be worse than the flash.
+                return
+            }
+        val success = AtomicBoolean(false)
+        val latch = CountDownLatch(1)
+        try {
+            PixelCopy.request(
+                window,
+                srcRect,
+                bitmap,
+                { copyResult ->
+                    success.set(copyResult == PixelCopy.SUCCESS)
+                    latch.countDown()
+                },
+                snapshotHandler,
+            )
+            if (!latch.await(SNAPSHOT_DEADLINE_MS, TimeUnit.MILLISECONDS)) {
+                return
+            }
+        } catch (e: IllegalArgumentException) {
+            // The window has no backing surface (e.g. mid-teardown).
+            return
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            return
+        }
+
+        if (success.get()) {
+            screen.foreground = BitmapDrawable(screen.resources, bitmap)
+        }
+    }
+}

--- a/apps/src/tests/issue-tests/Test4570.tsx
+++ b/apps/src/tests/issue-tests/Test4570.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+import { Button, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import {
+  createNativeStackNavigator,
+  NativeStackNavigationProp,
+} from '@react-navigation/native-stack';
+import Animated, {
+  useAnimatedStyle,
+  useFrameCallback,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+// Repro for the Android pop "empty screen" flash: when Reanimated has
+// pending operations at the moment a pop commits, its frame callback
+// flushes the deleting mount batch synchronously on the UI thread
+// (NodesManager.onAnimationFrame -> performOperations ->
+// FabricUIManager.scheduleMountItem), which used to beat the posted
+// startRemovalTransition. The exit animation then played on an empty,
+// background-colored screen. The spinner below keeps such operations
+// flowing; pop while it animates and watch the outgoing screen.
+
+type StackParamList = {
+  Main: undefined;
+  Detail: undefined;
+};
+
+const MainScreen = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList, 'Main'>;
+}): React.JSX.Element => (
+  <View style={[styles.container, styles.mainBackground]}>
+    <Button title="Go to detail" onPress={() => navigation.navigate('Detail')} />
+  </View>
+);
+
+const DetailScreen = ({
+  navigation,
+}: {
+  navigation: NativeStackNavigationProp<StackParamList, 'Detail'>;
+}): React.JSX.Element => {
+  const angle = useSharedValue(0);
+  useFrameCallback(frameInfo => {
+    const dt = frameInfo.timeSincePreviousFrame ?? 0;
+    angle.value = (angle.value + (dt / 1500) * 360) % 360;
+  });
+  const spinner = useAnimatedStyle(() => ({
+    transform: [{ rotate: `${angle.value}deg` }],
+  }));
+  return (
+    <View style={[styles.container, styles.detailBackground]}>
+      <Button title="Go back" onPress={() => navigation.goBack()} />
+      <Text style={styles.detailText}>DETAIL CONTENT</Text>
+      <Animated.View style={[styles.square, spinner]} />
+    </View>
+  );
+};
+
+const Stack = createNativeStackNavigator<StackParamList>();
+
+const App = (): React.JSX.Element => (
+  <NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Main" component={MainScreen} />
+      <Stack.Screen name="Detail" component={DetailScreen} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  mainBackground: {
+    backgroundColor: 'moccasin',
+  },
+  detailBackground: {
+    backgroundColor: 'thistle',
+  },
+  detailText: {
+    fontSize: 28,
+    textAlign: 'center',
+    marginTop: 100,
+  },
+  square: {
+    width: 60,
+    height: 60,
+    backgroundColor: 'black',
+    alignSelf: 'center',
+    marginTop: 40,
+  },
+});
+
+export default App;

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -231,3 +231,4 @@ export { default as TestSplit } from './TestSplit';
 export { default as TestSafeAreaViewIOS } from './TestSafeAreaViewIOS';
 export { default as TestStackNesting } from './TestStackNesting';
 export { default as TestScreenFooterKeyboardInsets } from './TestScreenFooterKeyboardInsets';
+export { default as Test4570 } from './Test4570';

--- a/cpp/legacy/RNSScreenRemovalListener.cpp
+++ b/cpp/legacy/RNSScreenRemovalListener.cpp
@@ -1,7 +1,25 @@
 #include "RNSScreenRemovalListener.h"
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <algorithm>
+#include <cstring>
+#include <unordered_set>
 #include <utility>
 using namespace facebook::react;
+
+namespace {
+
+bool isScreenComponent(const ShadowView &shadowView) {
+  return shadowView.componentName != nullptr &&
+      (std::strcmp(shadowView.componentName, "RNSScreen") == 0 ||
+       std::strcmp(shadowView.componentName, "RNSModalScreen") == 0);
+}
+
+bool isScreenDelete(const ShadowViewMutation &mutation) {
+  return mutation.type == ShadowViewMutation::Type::Delete &&
+      isScreenComponent(mutation.oldChildShadowView);
+}
+
+} // namespace
 
 uint64_t RNSScreenRemovalListener::setListener(
     std::function<void(int)> &&listenerFunction) {
@@ -37,16 +55,32 @@ std::optional<MountingTransaction> RNSScreenRemovalListener::pullTransaction(
         surfaceId, transactionNumber, std::move(mutations), telemetry};
   }
 
-  for (const ShadowViewMutation &mutation : mutations) {
-    // When using RNSModalScreen on Android it should be added here.
-    if (mutation.type == ShadowViewMutation::Type::Remove &&
-        mutation.oldChildShadowView.componentName != nullptr &&
-        std::strcmp(mutation.oldChildShadowView.componentName, "RNSScreen") ==
-            0) {
-      // We call the listener function even if this screen has not been owned
-      // by RNSScreenStack as since RN 0.78 we do not have enough information
-      // here. This final filter is applied later in NativeProxy.
-      listener(mutation.oldChildShadowView.tag);
+  // This runs for every transaction; almost none of them delete a screen, so
+  // detect that cheaply before allocating any lookup state.
+  const bool deletesAnyScreen =
+      std::any_of(mutations.begin(), mutations.end(), isScreenDelete);
+
+  if (deletesAnyScreen) {
+    // A Remove without a matching Delete is a reorder within the parent, not
+    // a dismissal, and must not trigger removal handling. A false positive
+    // here makes NativeProxy pin a snapshot overlay on a live screen, and
+    // nothing ever clears it.
+    std::unordered_set<Tag> deletedScreenTags{};
+    for (const ShadowViewMutation &mutation : mutations) {
+      if (isScreenDelete(mutation)) {
+        deletedScreenTags.insert(mutation.oldChildShadowView.tag);
+      }
+    }
+
+    for (const ShadowViewMutation &mutation : mutations) {
+      if (mutation.type == ShadowViewMutation::Type::Remove &&
+          isScreenComponent(mutation.oldChildShadowView) &&
+          deletedScreenTags.count(mutation.oldChildShadowView.tag) > 0) {
+        // We call the listener function even if this screen has not been owned
+        // by RNSScreenStack as since RN 0.78 we do not have enough information
+        // here. This final filter is applied later in NativeProxy.
+        listener(mutation.oldChildShadowView.tag);
+      }
     }
   }
 


### PR DESCRIPTION
## Description

### Human description

On Android, when you pop screen where some Reanimated animations runs, it can result in race condition when it causes screen content Views to be removed before pop animations finishes so it result in flash of `contentStyle.backgroundColor` color during transition.

*AI disclosure: I used Claude to debug and fix issues with my oversight, and fix was tested in RNS example app, blank Expo app and also in production app. Also attaching screenshots and videos as proof.*

### AI description 

**Root cause.** `notifyScreenRemoved` schedules `startRemovalTransition()` with `screen.post`, and the transaction that deletes the screen's children races that runnable. Which side wins depends on who executes the batch. We instrumented both outcomes in a production app:

Losing pop, batch executed synchronously inside Reanimated's frame callback, before the posted runnable:

```
FabricUIManager.scheduleMountItem            <- executes immediately on the UI thread
  at com.swmansion.reanimated.NativeProxy.performOperations
  at com.swmansion.reanimated.NodesManager.onAnimationFrame
```

Winning pop, batch executed by RN's own vsync callback, 11-15 ms later, posted runnable ran first:

```
FabricUIManager$DispatchUIFrameCallback.doFrameGuarded
  at android.view.Choreographer$CallbackRecord.run
```

Any UI-thread `scheduleMountItem` caller triggers the losing path; Reanimated with pending operations at commit time is the ubiquitous real-world one. This is why the flash is invisible in bare example apps but consistent in apps with running animations.

**Why not just fix the ordering?** Reordering or withholding mutations does not survive other `MountingOverrideDelegate`s (Reanimated's `LayoutAnimationsProxy` rebuilds the whole list). Marking retention earlier is not enough either: we verified frame-by-frame that `startViewTransition` retention keeps the content alive only 2-3 frames through a Reanimated-rebuilt transaction. The only artifact the rebuild cannot touch is a bitmap, which is the approach iOS already takes: snapshot the dismissed screen.

At `UIManagerListener.willMountItems`, the last point guaranteed to run on the UI thread before the deleting batch, the screen's window rect is captured with `PixelCopy` and pinned as `screen.foreground`; the exit animation then shows the real content and the bitmap dies with the fragment view. `startRemovalTransition()` is also called there synchronously, so the existing retention no longer depends on the race and covers the first frames if the snapshot bails out.


## Changes

- `cpp/legacy/RNSScreenRemovalListener.cpp`: notify only screens with a matching `Remove` + `Delete` pair in the transaction. A plain `Remove` is a reorder, and a false positive would pin a permanent overlay on a live screen. Also matches `RNSModalScreen`.
- `NativeProxy.kt`: queues dismissed tags; at `willMountItems` pins the snapshot and starts the removal transition synchronously.
- `ScreenDismissSnapshot.kt` (new): the `PixelCopy` capture. Guards: API >= 26, attached and non-zero size, top screen only, transparent modals skipped, clipped rects skipped, OOM/interruption bail out, 64 ms deadline. Every guard falls back to current behavior.
- `ScreensModule.kt`: registers/unregisters the `UIManagerListener`.
- `Test4570.tsx` (new, issue-tests): repro screen; pop the Detail screen while its Reanimated spinner animates.

## Before & after - visual documentation

`Test4570` in this repo's example app, both pops with a log-verified lost race (retention ran after the children were already deleted), 12 consecutive frames @ 60 fps:

### Before / after

#### RNS example app

<img width="3240" height="1410" alt="rns-example-board-before-after" src="https://github.com/user-attachments/assets/bb1d1723-c0e2-43e5-9c8c-af255091ed43" />

#### Blank example app (Expo SDK 57)

<img width="3240" height="1410" alt="rns-whiteflash-board-before-after" src="https://github.com/user-attachments/assets/c2b219f5-b9fe-420d-946c-c33ead870640" />


#### Screen transition video slowed 10x

<table>
<tr>
<th>Before</th>
<th>After</th>
</tr>
<tr>
<td>

https://github.com/user-attachments/assets/09983023-d63e-4490-9a60-954b5a60a02e

</td>
<td>

https://github.com/user-attachments/assets/3138c0b0-d4ba-4e49-826e-908943f61385

</td>
</tr>
</table>



## Test plan

- `Test4570` (this repo, instrumented run): on stock, pops that lose the retention race play the exit animation on an empty background-colored screen; with this PR the content stays visible through the whole exit. Race outcomes were verified per pop by logging whether `startRemovalTransition` ran before or after the children were deleted.
- Production app validation: before, 40-100% of pops lost the race depending on load, each losing pop flashed; after, every losing pop keeps its content. The PixelCopy deadline bail (1 of 7 pops under heavy load) was reproduced in logs; the synchronous retention marking covers it.
- Reproduction without a build: open a fresh `create-expo-app` (expo-router, two screens) in Expo Go and pop; every pop flashes on stock, because the Expo Go host keeps Reanimated busy. The same JS as a standalone debug build almost never flashes, matching the dispatch analysis above.
- Existing examples (Simple Native Stack and friends): pops are frame-for-frame identical before and after this change.

Co-Authored-By: Claude <noreply@anthropic.com>

https://claude.ai/code/session_01Du1cXLUY1ye11EiHKbQNkW
