### PR TITLE
chore(test): use a bundled image in the toolbar menu test-stack-toolbar-menu-batch-commands-android

### DIFF
--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts
@@ -24,7 +24,8 @@ const HEADER_TITLE = 'Toolbar Menu Batch Commands Test';
 const SCROLL_STEP = { pixels: 300 };
 
 const EVENT_TIMEOUT_MS = 3000;
-// Generous on purpose: a slow image download must not read as a failed batch.
+// Generous on purpose: the failing-image cases wait on a network error, and a
+// slow one must not read as a stuck batch.
 const IMAGE_LOAD_TIMEOUT_MS = 90000;
 
 // `by.label` matches the button in both its icon-only (title as content
@@ -41,7 +42,9 @@ async function expectAppleNotInToolbar() {
 async function expectAppleInToolbarWithIcon() {
   await expect(element(appleToolbarButton)).toBeVisible();
   // AppCompat clears an icon-only action button's text (`setText(null)`).
-  await expect(element(appleToolbarButton)).toHaveText('');
+  await waitFor(element(appleToolbarButton))
+    .toHaveText('')
+    .withTimeout(IMAGE_LOAD_TIMEOUT_MS);
 }
 
 async function expectAppleInToolbarWithoutIcon() {
@@ -220,9 +223,9 @@ describeIfAndroid('Stack Toolbar Menu Batch Commands', () => {
 
     it('applies the icon and the check together only once the image has loaded', async () => {
       await tapById('batch-image-check-button');
-      await expectEventCount(7, IMAGE_LOAD_TIMEOUT_MS);
-      await expectNewestEntry('fruits', ['apple', 'cherry']);
       await expectAppleInToolbarWithIcon();
+      await expectEventCount(7);
+      await expectNewestEntry('fruits', ['apple', 'cherry']);
     });
 
     it('moves Apple back to the overflow menu, checked, with no new event', async () => {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -123,19 +123,17 @@ function MainScreen() {
     });
   }, [setRouteOptions, routeKey, handleGroupChange]);
 
-  // A large image with a random seed each call, so every download is unique and
-  // uncached (even across app restarts) and the async load stays visibly slow.
-  // Requires network access. The icon is only visible while Apple is shown in
-  // the toolbar (overflow menu items don't render icons).
-  const nextPhotoIcon = useCallback((): PlatformIconAndroid => {
-    const seed = Math.floor(Math.random() * 1_000_000_000);
-    return {
+  // A bundled image (no network needed). Image icons are always resolved
+  // asynchronously on Android, so this still exercises the async path that the
+  // queue must serialize. The icon is only visible while Apple is shown in the
+  // toolbar (overflow menu items don't render icons).
+  const nextPhotoIcon = useCallback(
+    (): PlatformIconAndroid => ({
       type: 'imageSource',
-      imageSource: {
-        uri: `https://picsum.photos/seed/rns-${seed}/5000`,
-      },
-    };
-  }, []);
+      imageSource: require('@assets/trees.jpg'),
+    }),
+    [],
+  );
 
   // A guaranteed-to-fail image. The load never yields a drawable; the queue
   // must still complete the batch (icon cleared) rather than wait forever for a
@@ -206,11 +204,11 @@ function MainScreen() {
     ]);
   }, [nextPhotoIcon]);
 
-  // Case #5: two back-to-back commands on Apple. The first loads a slow remote
-  // image alongside checked:true; the second unchecks Apple synchronously. With
-  // the queue they are serialized, so the LAST event reflects the SECOND
-  // command (Apple absent). Without it, the first command's late download would
-  // land last and wrongly re-check Apple.
+  // Case #5: two back-to-back commands on Apple. The first loads an image
+  // asynchronously alongside checked:true; the second unchecks Apple
+  // synchronously. With the queue they are serialized, so the LAST event
+  // reflects the SECOND command (Apple absent). Without it, the first command
+  // would resolve after the second and wrongly re-check Apple.
   const runOrderingRace = useCallback(() => {
     const android = headerConfigRef.current?.android;
     android?.updateToolbarMenuElements([

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx
@@ -6,6 +6,7 @@ import {
   useStackNavigationContext,
 } from '@apps/shared/containers/stack';
 import { Colors } from '@apps/shared/styling';
+import { SettingsSwitch } from '@apps/shared';
 import {
   type StackHeaderConfigRef,
   type StackHeaderToolbarMenuBaseAndroid,
@@ -98,6 +99,7 @@ function MainScreen() {
   const [eventLog, setEventLog] = useState<string[]>([]);
   const [eventCount, setEventCount] = useState(0);
   const [appleInToolbar, setAppleInToolbar] = useState(false);
+  const [useBundledImage, setUseBundledImage] = useState(true);
 
   const headerConfigRef = useRef<StackHeaderConfigRef>(null);
   const { setRouteOptions, routeKey } = useStackNavigationContext();
@@ -123,17 +125,32 @@ function MainScreen() {
     });
   }, [setRouteOptions, routeKey, handleGroupChange]);
 
-  // A bundled image (no network needed). Image icons are always resolved
-  // asynchronously on Android, so this still exercises the async path that the
-  // queue must serialize. The icon is only visible while Apple is shown in the
-  // toolbar (overflow menu items don't render icons).
-  const nextPhotoIcon = useCallback(
-    (): PlatformIconAndroid => ({
-      type: 'imageSource',
-      imageSource: require('@assets/trees.jpg'),
-    }),
-    [],
-  );
+  // The photo icon used by the image cases. The icon is only visible while
+  // Apple is shown in the toolbar (overflow menu items don't render icons).
+  //
+  // Bundled (default, used by e2e): no network needed. Image icons are always
+  // resolved asynchronously on Android, so this still exercises the async path
+  // that the queue must serialize.
+  //
+  // Remote (manual testing): a large image with a random seed each call, so
+  // every download is unique and uncached (even across app restarts) and the
+  // async load stays visibly slow. Requires network access.
+  const nextPhotoIcon = useCallback((): PlatformIconAndroid => {
+    if (useBundledImage) {
+      return {
+        type: 'imageSource',
+        imageSource: require('@assets/trees.jpg'),
+      };
+    } else {
+      const seed = Math.floor(Math.random() * 1_000_000_000);
+      return {
+        type: 'imageSource',
+        imageSource: {
+          uri: `https://picsum.photos/seed/rns-${seed}/5000`,
+        },
+      };
+    }
+  }, [useBundledImage]);
 
   // A guaranteed-to-fail image. The load never yields a drawable; the queue
   // must still complete the batch (icon cleared) rather than wait forever for a
@@ -255,6 +272,13 @@ function MainScreen() {
         contentContainerStyle={styles.content}
         testID="toolbar-menu-batch-commands-scrollview">
         <Text style={styles.heading}>Batch Commands</Text>
+        <SettingsSwitch
+          label="Bundled image"
+          value={useBundledImage}
+          onValueChange={setUseBundledImage}
+          style={styles.switch}
+          testID="bundled-image-switch"
+        />
         <View style={styles.buttons}>
           <Button
             title="Select All (1 event)"
@@ -317,7 +341,8 @@ function MainScreen() {
           don&apos;t render icons); its checkbox is only visible in the overflow
           menu. Icon &amp; showAsAction changes emit no events. Menu checked
           state persists across taps — Reset log clears only the counter and
-          log.
+          log. Turn off &quot;Bundled image&quot; to load the photo from the web
+          instead (slow, uncached; needs network).
         </Text>
 
         <Text testID="events-count-text" style={styles.heading}>
@@ -368,6 +393,9 @@ const styles = StyleSheet.create({
     fontSize: 13,
     color: Colors.primary,
     marginTop: 8,
+  },
+  switch: {
+    marginHorizontal: 0,
   },
   buttons: {
     gap: 8,

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -20,7 +20,7 @@ Incomplete: covers steps 1–18.
 
 Not automated:
 
-- The appearance of a downloaded photo icon — Detox cannot read image bytes,
+- The appearance of the photo icon itself — Detox cannot read image bytes,
   so an icon is only asserted present or absent. Verify visually.
 - Same-instant atomicity of an image-and-check batch — only the final state is
   asserted. Verify visually that the icon and the check appear together.
@@ -28,7 +28,6 @@ Not automated:
 ## Prerequisites
 
 - Android emulator or device
-- Network access (the image-load cases download from https://picsum.photos)
 
 ## Note
 
@@ -43,8 +42,8 @@ Not automated:
   it is in the toolbar, and its checked state is only visible while it is in the
   overflow menu — several steps below move **Apple** between the two to check
   both.
-- The image cases download a large, uncached image, so the async load is
-  visibly delayed.
+- Image icons are loaded asynchronously, so the icon appears a moment after the
+  tap rather than instantly.
 
 ## Steps
 
@@ -110,8 +109,8 @@ Not automated:
 
 8. Tap **Batch: image + check (atomic)**.
 
-- [ ] After a short download, Apple's toolbar button shows the photo and, at the
-      same moment, 1 new event appears (counter → 7): newest ▶
+- [ ] Once the image has loaded, Apple's toolbar button shows the photo and, at
+      the same moment, 1 new event appears (counter → 7): newest ▶
       `fruits: ["apple","cherry"]`. The event does not appear before the image —
       the batch (Apple's icon and check, and Cherry's check) is held until the
       image loads, then applied together.
@@ -132,7 +131,8 @@ Not automated:
 11. Tap **Ordering race (last: Apple absent)**.
 
 - [ ] 2 new events (counter → 10): `fruits: ["apple"]` (the first command, whose
-      image loads slowly) then newest ▶ `fruits: []` (the second command).
+      image loads asynchronously) then newest ▶ `fruits: []` (the second
+      command).
 - [ ] The newest event and the overflow menu both show Apple unchecked — the
       second command is applied last even though the first command's image
       resolves later.
@@ -173,9 +173,9 @@ Not automated:
 17. Tap **Duplicate id: merge + last icon**.
 
 - [ ] The batch lists Apple twice — the first update checks it with an image
-      that fails to load, the second sets a photo (and no check). After the
-      downloads, Apple's toolbar button shows the **photo**: the later icon wins
-      over the failed one.
+      that fails to load, the second sets a photo (and no check). Once both
+      loads have settled, Apple's toolbar button shows the **photo**: the later
+      icon wins over the failed one.
 - [ ] 2 new events (counter → 15): `fruits: ["apple"]` then newest ▶
       `fruits: ["apple","cherry"]`. The first event shows Apple checked — the
       check from the first update is kept even though the second update set only

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -16,10 +16,12 @@ one batch is applied in order, with the last icon winning.
 
 ## E2E test
 
-Incomplete: covers steps 1–18.
+Incomplete: covers steps 1 and 3–19.
 
 Not automated:
 
+- Step 2 (downloading the photo from the web) — the e2e test keeps **Bundled
+  image** on and runs the image cases offline on the bundled photo.
 - The appearance of the photo icon itself — Detox cannot read image bytes,
   so an icon is only asserted present or absent. Verify visually.
 - Same-instant atomicity of an image-and-check batch — only the final state is
@@ -28,6 +30,9 @@ Not automated:
 ## Prerequisites
 
 - Android emulator or device
+- Network access — step 2 switches the photo to a download from
+  https://picsum.photos. To run offline, skip step 2 and leave **Bundled
+  image** on; the image cases then use the bundled photo.
 
 ## Note
 
@@ -44,6 +49,12 @@ Not automated:
   both.
 - Image icons are loaded asynchronously, so the icon appears a moment after the
   tap rather than instantly.
+- The **Bundled image** switch (on by default, and left on by the e2e test)
+  picks where the photo comes from. Step 2 switches it off so that the image
+  cases (steps 9, 12 and 18) download a large, uncached image from the web —
+  the async load is then visibly slow, which makes the "appears at the same
+  moment" and "second command applied last" checks easier to observe. The
+  image cases also work with the switch left on (bundled photo, no network).
 
 ## Steps
 
@@ -57,18 +68,24 @@ Not automated:
       (multi-select) — and a **view** group — List (checked), Grid
       (single-select). "Events received" is 0.
 
+2. Close the overflow menu and turn off the **Bundled image** switch.
+
+- [ ] The switch reads "Bundled image: false" and no new event appears (counter
+      stays 0). From here on, the image cases download the photo from the web
+      instead of using the bundled one.
+
 ---
 
 ### Coalescing — one event per batch
 
-2. Tap **Select All (1 event)**.
+3. Tap **Select All (1 event)**.
 
 - [ ] 1 new event (counter → 1). Newest ▶ reads
       `fruits: ["apple","banana","cherry","date"]` — the four-element batch
       yields one event, not four.
 - [ ] Overflow: all four fruits are checked.
 
-3. Tap **Deselect All (1 event)**.
+4. Tap **Deselect All (1 event)**.
 
 - [ ] 1 new event (counter → 2). Newest ▶ reads `fruits: []`.
 - [ ] Overflow: all four fruits are unchecked.
@@ -77,7 +94,7 @@ Not automated:
 
 ### Coalescing — one event per affected group
 
-4. Tap **Batch across groups (2 events)**.
+5. Tap **Batch across groups (2 events)**.
 
 - [ ] 2 new events (counter → 4), in update order: `fruits: ["cherry"]` then
       newest ▶ `view: ["grid"]` — one event per affected group.
@@ -88,7 +105,7 @@ Not automated:
 
 ### Single-object (non-array) argument
 
-5. Tap **Single object update (1 event)**.
+6. Tap **Single object update (1 event)**.
 
 - [ ] 1 new event (counter → 5). Newest ▶ reads `fruits: ["banana","cherry"]` —
       a single object argument is treated as a one-element batch.
@@ -98,24 +115,24 @@ Not automated:
 
 ### Atomic image load with `showAsAction`
 
-6. Tap **Move Apple to toolbar**.
+7. Tap **Move Apple to toolbar**.
 
 - [ ] No new event (counter stays 5). Apple leaves the overflow menu and appears
       in the app bar as a text button ("APPLE") with no icon.
 
-7. Tap **Deselect All (1 event)**.
+8. Tap **Deselect All (1 event)**.
 
 - [ ] 1 new event (counter → 6). Newest ▶ reads `fruits: []`.
 
-8. Tap **Batch: image + check (atomic)**.
+9. Tap **Batch: image + check (atomic)**.
 
-- [ ] Once the image has loaded, Apple's toolbar button shows the photo and, at
+- [ ] After a short download, Apple's toolbar button shows the photo and, at
       the same moment, 1 new event appears (counter → 7): newest ▶
       `fruits: ["apple","cherry"]`. The event does not appear before the image —
       the batch (Apple's icon and check, and Cherry's check) is held until the
       image loads, then applied together.
 
-9. Tap **Move Apple to overflow**.
+10. Tap **Move Apple to overflow**.
 
 - [ ] No new event (counter stays 7). Apple is back in the overflow menu and is
       checked.
@@ -124,11 +141,11 @@ Not automated:
 
 ### FIFO ordering — a late image must not override a newer command
 
-10. Tap **Deselect All (1 event)**.
+11. Tap **Deselect All (1 event)**.
 
 - [ ] 1 new event (counter → 8). Newest ▶ reads `fruits: []`.
 
-11. Tap **Ordering race (last: Apple absent)**.
+12. Tap **Ordering race (last: Apple absent)**.
 
 - [ ] 2 new events (counter → 10): `fruits: ["apple"]` (the first command, whose
       image loads asynchronously) then newest ▶ `fruits: []` (the second
@@ -141,19 +158,19 @@ Not automated:
 
 ### Robustness — a failing image still completes the batch
 
-12. Tap **Failing image + follow-up**.
+13. Tap **Failing image + follow-up**.
 
 - [ ] 2 new events (counter → 12): `fruits: ["apple"]` then newest ▶
       `fruits: ["apple","banana"]`. The first batch checks Apple with an image
       that cannot load; the second checks Banana. Both apply — a failed image
       does not stop later commands.
 
-13. Tap **Move Apple to toolbar**.
+14. Tap **Move Apple to toolbar**.
 
 - [ ] No new event (counter stays 12). Apple's toolbar button shows "APPLE" with
       no icon — the failed image load leaves the icon cleared.
 
-14. Tap **Move Apple to overflow**.
+15. Tap **Move Apple to overflow**.
 
 - [ ] No new event (counter stays 12). In the overflow menu Apple is checked —
       the failing-image batch applied its check.
@@ -162,15 +179,15 @@ Not automated:
 
 ### Robustness — a repeated id in one batch (last icon wins)
 
-15. Tap **Deselect All (1 event)**.
+16. Tap **Deselect All (1 event)**.
 
 - [ ] 1 new event (counter → 13). Newest ▶ reads `fruits: []`.
 
-16. Tap **Move Apple to toolbar**.
+17. Tap **Move Apple to toolbar**.
 
 - [ ] No new event (counter stays 13). Apple shows "APPLE" with no icon.
 
-17. Tap **Duplicate id: merge + last icon**.
+18. Tap **Duplicate id: merge + last icon**.
 
 - [ ] The batch lists Apple twice — the first update checks it with an image
       that fails to load, the second sets a photo (and no check). Once both
@@ -181,6 +198,6 @@ Not automated:
       check from the first update is kept even though the second update set only
       the icon. A following batch then checks Cherry.
 
-18. Tap **Move Apple to overflow**.
+19. Tap **Move Apple to overflow**.
 
 - [ ] No new event (counter stays 15). In the overflow menu Apple is checked.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/scenario.md
@@ -126,7 +126,7 @@ Not automated:
 
 9. Tap **Batch: image + check (atomic)**.
 
-- [ ] After a short download, Apple's toolbar button shows the photo and, at
+- [ ] After the image loads, Apple's toolbar button shows the photo and, at
       the same moment, 1 new event appears (counter → 7): newest ▶
       `fruits: ["apple","cherry"]`. The event does not appear before the image —
       the batch (Apple's icon and check, and Cherry's check) is held until the


### PR DESCRIPTION
## Description

The `test-stack-toolbar-menu-batch-commands-android` screen loaded its toolbar icon from `https://picsum.photos` with a random seed on every call. That made the e2e test depend on network access and on download timing, and it failed when the image could not be fetched.

The screen now has a **Bundled image** switch that picks where the photo comes from:

- **On (default, used by the e2e test):** the bundled `@assets/trees.jpg`. No network needed. Image icons are still resolved asynchronously on Android, so the async-queue behavior under test (atomic image + check batch, FIFO ordering, duplicate ids) is exercised the same way.
- **Off (manual testing):** the original seeded picsum URI — a large, uncached download on every call, so the async load stays visibly slow and the "icon and event appear together" / "second command applied last" checks are easy to observe.

The manual scenario switches it off as step 2; the e2e test never touches it and runs offline.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1763

## Changes

- `apps/src/tests/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android/index.tsx`: added a `SettingsSwitch` (**Bundled image**, `testID="bundled-image-switch"`, default on). `nextPhotoIcon` returns `require('@assets/trees.jpg')` while the switch is on and the seeded picsum URI while it is off; the on-screen hint mentions the switch.
- `.../scenario.md`: new step 2 turns the switch off (later steps renumbered); network access is a prerequisite only for that step, and the E2E section lists it as not automated (coverage: steps 1 and 3–19). Notes explain both modes.
- `FabricExample/e2e/single-feature-tests/stack-v5/test-stack-toolbar-menu-batch-commands-android.e2e.ts`: in the atomic image + check case, wait for the icon-only toolbar button (`toHaveText('')` with the image-load timeout) before asserting the event count; the timeout comment now refers to the failing-image cases, which still wait on a network error.
