### PR TITLE
fix(Android, FormSheet v5): Move the sheet above the keyboard

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
@@ -78,10 +78,10 @@ internal class FormSheetBehaviorController(
      * behind the status bar, where Material pads insets for us.
      * @param contentHeightForFitToContents - the exact height of the content, e.g. React content calculated by Yoga.
      * Used exclusively when the sheet is in `fitToContents` mode.
-     * @param nativeContainerPaddingBottom - the bottom system inset. In `fitToContents` mode, this is added to the
-     * BottomSheet's height to extend its background behind the system bars, while the inner content remains within
-     * the safe area. For fractional detents it is subtracted from the collapsed peek height, which Material resolves
-     * above the inset, so the lowest detent lands at its fraction of [sheetAvailableSpace] like the other ones.
+     * @param nativeContainerPaddingBottom - the bottom system inset (navigation bar or keyboard). In `fitToContents` mode,
+     * this is added to the BottomSheet's height to extend its background behind the system bars / keyboard, while the inner
+     * content remains within the safe area. For fractional detents it is subtracted from the collapsed peek height, which 
+     * Material resolves above the inset, so the lowest detent lands at its fraction of [sheetAvailableSpace] like the other ones.
      * @param initialDetentIndex - the index of the detent the sheet should snap to while opening.
      * @param applyInitialDetent - whether the sheet should forcefully snap to the initial detent state.
      * This should typically be `true` only when the sheet transitions from closed to open.

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
@@ -78,10 +78,13 @@ internal class FormSheetBehaviorController(
      * behind the status bar, where Material pads insets for us.
      * @param contentHeightForFitToContents - the exact height of the content, e.g. React content calculated by Yoga.
      * Used exclusively when the sheet is in `fitToContents` mode.
-     * @param nativeContainerPaddingBottom - the bottom system inset (navigation bar or keyboard). In `fitToContents` mode,
-     * this is added to the BottomSheet's height to extend its background behind the system bars / keyboard, while the inner
-     * content remains within the safe area. For fractional detents it is subtracted from the collapsed peek height, which 
-     * Material resolves above the inset, so the lowest detent lands at its fraction of [sheetAvailableSpace] like the other ones.
+     * @param nativeContainerPaddingBottom - the bottom system inset. In `fitToContents` mode, this is added to the
+     * BottomSheet's height to extend its background behind the system bars, while the inner content remains within
+     * the safe area. For fractional detents it is subtracted from the collapsed peek height, which Material resolves
+     * above the inset, so the lowest detent lands at its fraction of [sheetAvailableSpace] like the other ones.
+     * @param keyboardLift - the part of the keyboard inset above [nativeContainerPaddingBottom]. Every resting position
+     * is extended by it so the sheet is pushed above the keyboard as far as [sheetAvailableSpace] allows,
+     * see [FormSheetDetents].
      * @param initialDetentIndex - the index of the detent the sheet should snap to while opening.
      * @param applyInitialDetent - whether the sheet should forcefully snap to the initial detent state.
      * This should typically be `true` only when the sheet transitions from closed to open.
@@ -91,6 +94,7 @@ internal class FormSheetBehaviorController(
         sheetAvailableSpace: Int,
         contentHeightForFitToContents: Int = 0,
         nativeContainerPaddingBottom: Int = 0,
+        keyboardLift: Int = 0,
         initialDetentIndex: Int = 0,
         applyInitialDetent: Boolean = false,
     ) {
@@ -101,15 +105,22 @@ internal class FormSheetBehaviorController(
         }
 
         if (detents.isFitToContents) {
-            configureFitToContents(detents, sheetAvailableSpace, contentHeightForFitToContents, nativeContainerPaddingBottom)
+            configureFitToContents(
+                detents,
+                sheetAvailableSpace,
+                contentHeightForFitToContents,
+                nativeContainerPaddingBottom,
+                keyboardLift,
+            )
         } else {
             when (detents.count) {
-                1 -> configureSingleDetent(detents, sheetAvailableSpace)
+                1 -> configureSingleDetent(detents, sheetAvailableSpace, keyboardLift)
                 2 ->
                     configureTwoDetents(
                         detents,
                         sheetAvailableSpace,
                         nativeContainerPaddingBottom,
+                        keyboardLift,
                         initialDetentIndex,
                         applyInitialDetent,
                     )
@@ -118,6 +129,7 @@ internal class FormSheetBehaviorController(
                         detents,
                         sheetAvailableSpace,
                         nativeContainerPaddingBottom,
+                        keyboardLift,
                         initialDetentIndex,
                         applyInitialDetent,
                     )
@@ -133,20 +145,22 @@ internal class FormSheetBehaviorController(
         sheetAvailableSpace: Int,
         contentHeight: Int,
         bottomInset: Int,
+        keyboardLift: Int,
     ) = behavior.apply {
         skipCollapsed = true
         isFitToContents = true
-        maxHeight = detents.maxAllowedHeightForFitToContents(sheetAvailableSpace, contentHeight, bottomInset)
+        maxHeight = detents.maxAllowedHeightForFitToContents(sheetAvailableSpace, contentHeight, bottomInset, keyboardLift)
         state = BottomSheetBehavior.STATE_EXPANDED
     }
 
     private fun configureSingleDetent(
         detents: FormSheetDetents,
         sheetAvailableSpace: Int,
+        keyboardLift: Int,
     ) = behavior.apply {
         skipCollapsed = true
         isFitToContents = true
-        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace, keyboardLift)
         state = BottomSheetBehavior.STATE_EXPANDED
     }
 
@@ -154,13 +168,14 @@ internal class FormSheetBehaviorController(
         detents: FormSheetDetents,
         sheetAvailableSpace: Int,
         bottomInset: Int,
+        keyboardLift: Int,
         initialDetentIndex: Int,
         applyInitialDetent: Boolean,
     ) = behavior.apply {
         skipCollapsed = false
         isFitToContents = true
-        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset)
-        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset, keyboardLift)
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace, keyboardLift)
         if (applyInitialDetent) {
             state = resolveStateFromIndex(initialDetentIndex, detents.count)
         }
@@ -170,15 +185,16 @@ internal class FormSheetBehaviorController(
         detents: FormSheetDetents,
         sheetAvailableSpace: Int,
         bottomInset: Int,
+        keyboardLift: Int,
         initialDetentIndex: Int,
         applyInitialDetent: Boolean,
     ) = behavior.apply {
         skipCollapsed = false
         isFitToContents = false
-        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset)
-        halfExpandedRatio = detents.halfExpandedRatio()
-        expandedOffset = detents.expandedOffsetFromTop(sheetAvailableSpace)
-        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
+        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset, keyboardLift)
+        halfExpandedRatio = detents.halfExpandedRatio(sheetAvailableSpace, keyboardLift)
+        expandedOffset = detents.expandedOffsetFromTop(sheetAvailableSpace, keyboardLift = keyboardLift)
+        maxHeight = detents.maxAllowedHeight(sheetAvailableSpace, keyboardLift)
         if (applyInitialDetent) {
             state = resolveStateFromIndex(initialDetentIndex, detents.count)
         }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
@@ -4,7 +4,6 @@ import android.view.ViewGroup
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
-import androidx.core.view.doOnLayout
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetAvailableHeightProvider
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetContainer
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetDialog
@@ -14,12 +13,12 @@ import com.swmansion.rnscreens.modals.formsheet.native.model.FormSheetDetents
 internal class FormSheetDimensionsCoordinator(
     private val dialog: FormSheetDialog,
     private val container: FormSheetContainer,
-    private val bottomSheetView: FrameLayout?,
     private val behaviorController: FormSheetBehaviorController?,
 ) : FormSheetContentSizeChangeDelegate,
     FormSheetAvailableHeightProvider.OnAvailableHeightMeasuredListener {
     private var lastTopInset = 0
     private var lastBottomInset = 0
+    private var lastImeInset = 0
     private var currentDetents: FormSheetDetents? = null
     private var currentInitialDetentIndex: Int = 0
     private var shouldApplyInitialDetent: Boolean = false
@@ -34,38 +33,20 @@ internal class FormSheetDimensionsCoordinator(
     internal fun setup() {
         dialog.availableHeightProvider.availableHeightListener = this
         setupWindowInsetsListener()
-
-        bottomSheetView?.let { view ->
-            disableMaterialInsetsAnimationCallback(view)
-        }
     }
 
     private fun setupWindowInsetsListener() {
         ViewCompat.setOnApplyWindowInsetsListener(container) { _, insets ->
             val topInset = getTopInset(insets)
             val bottomInset = getBottomInset(insets)
-            if (topInset != lastTopInset || bottomInset != lastBottomInset) {
+            val imeInset = getImeInset(insets)
+            if (topInset != lastTopInset || bottomInset != lastBottomInset || imeInset != lastImeInset) {
                 lastTopInset = topInset
                 lastBottomInset = bottomInset
+                lastImeInset = imeInset
                 invalidateGeometry()
             }
             insets
-        }
-    }
-
-    /**
-     * BottomSheetBehavior registers an internal `WindowInsetsAnimationCallback` on the
-     * sheet view during its first `onLayoutChild`. That callback drives `translationY` to follow
-     * animated inset changes, what interferes with our slide-in custom animation.
-     *
-     * We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
-     * clear the Material's callback to remove the conflict entirely.
-     *
-     * This method must run after the first layout pass.
-     */
-    private fun disableMaterialInsetsAnimationCallback(view: FrameLayout) {
-        view.doOnLayout {
-            ViewCompat.setWindowInsetsAnimationCallback(it, null)
         }
     }
 
@@ -116,12 +97,14 @@ internal class FormSheetDimensionsCoordinator(
      * our container are measured, so the values applied here are picked up by the very same traversal.
      */
     private fun resolveGeometry(sheetAvailableSpace: Int) {
+        val bottomInset = effectiveBottomInset
+
         currentDetents?.let { detents ->
             behaviorController?.updateSheetBehavior(
                 detents = detents,
                 sheetAvailableSpace = sheetAvailableSpace,
                 contentHeightForFitToContents = currentContentHeight,
-                nativeContainerPaddingBottom = lastBottomInset,
+                nativeContainerPaddingBottom = bottomInset,
                 initialDetentIndex = currentInitialDetentIndex,
                 applyInitialDetent = shouldApplyInitialDetent,
             )
@@ -129,8 +112,8 @@ internal class FormSheetDimensionsCoordinator(
         }
 
         val sheetContainerHeight =
-            currentDetents?.sheetContainerHeight(sheetAvailableSpace, lastTopInset, lastBottomInset, currentContentHeight)
-                ?: (sheetAvailableSpace - lastTopInset - lastBottomInset).coerceAtLeast(0)
+            currentDetents?.sheetContainerHeight(sheetAvailableSpace, lastTopInset, bottomInset, currentContentHeight)
+                ?: (sheetAvailableSpace - lastTopInset - bottomInset).coerceAtLeast(0)
 
         val layoutParams =
             container.layoutParams
@@ -142,6 +125,11 @@ internal class FormSheetDimensionsCoordinator(
             container.layoutParams = layoutParams
         }
     }
+
+    private val effectiveBottomInset: Int
+        get() = maxOf(lastBottomInset, lastImeInset)
+
+    private fun getImeInset(insetsCompat: WindowInsetsCompat): Int = insetsCompat.getInsets(WindowInsetsCompat.Type.ime()).bottom
 
     private fun getTopInset(insetsCompat: WindowInsetsCompat): Int =
         insetsCompat

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetDimensionsCoordinator.kt
@@ -97,14 +97,13 @@ internal class FormSheetDimensionsCoordinator(
      * our container are measured, so the values applied here are picked up by the very same traversal.
      */
     private fun resolveGeometry(sheetAvailableSpace: Int) {
-        val bottomInset = effectiveBottomInset
-
         currentDetents?.let { detents ->
             behaviorController?.updateSheetBehavior(
                 detents = detents,
                 sheetAvailableSpace = sheetAvailableSpace,
                 contentHeightForFitToContents = currentContentHeight,
-                nativeContainerPaddingBottom = bottomInset,
+                nativeContainerPaddingBottom = lastBottomInset,
+                keyboardLift = keyboardLift,
                 initialDetentIndex = currentInitialDetentIndex,
                 applyInitialDetent = shouldApplyInitialDetent,
             )
@@ -112,8 +111,13 @@ internal class FormSheetDimensionsCoordinator(
         }
 
         val sheetContainerHeight =
-            currentDetents?.sheetContainerHeight(sheetAvailableSpace, lastTopInset, bottomInset, currentContentHeight)
-                ?: (sheetAvailableSpace - lastTopInset - bottomInset).coerceAtLeast(0)
+            currentDetents?.sheetContainerHeight(
+                sheetAvailableSpace,
+                lastTopInset,
+                lastBottomInset,
+                currentContentHeight,
+                keyboardLift,
+            ) ?: (sheetAvailableSpace - lastTopInset - lastBottomInset - keyboardLift).coerceAtLeast(0)
 
         val layoutParams =
             container.layoutParams
@@ -126,8 +130,13 @@ internal class FormSheetDimensionsCoordinator(
         }
     }
 
-    private val effectiveBottomInset: Int
-        get() = maxOf(lastBottomInset, lastImeInset)
+    /**
+     * The part of the keyboard inset that sticks out above the bottom system inset. Material pads the sheet by
+     * the larger of the two, so this is exactly how much the sheet has to be extended to keep its detent-sized
+     * part above the keyboard.
+     */
+    private val keyboardLift: Int
+        get() = (lastImeInset - lastBottomInset).coerceAtLeast(0)
 
     private fun getImeInset(insetsCompat: WindowInsetsCompat): Int = insetsCompat.getInsets(WindowInsetsCompat.Type.ime()).bottom
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetKeyboardCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetKeyboardCoordinator.kt
@@ -1,0 +1,101 @@
+package com.swmansion.rnscreens.modals.formsheet.native.coordinator
+
+import android.widget.FrameLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsAnimationCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.doOnLayout
+
+internal class FormSheetKeyboardCoordinator(
+    private val bottomSheetView: FrameLayout,
+) {
+    /**
+     * Whether the sheet should track the keyboard animation. Kept `false` while an enter / exit
+     * transition owns `translationY`. Tracking the keyboard (`true`) should be allowed only when
+     * the sheet is in PRESENTED state.
+     */
+    internal var isTrackingEnabled: Boolean = false
+
+    private val insetsAnimationCallback = KeyboardInsetsAnimationCallback()
+
+    internal fun setup() {
+        // BottomSheetBehavior registers an internal `WindowInsetsAnimationCallback` on the
+        // sheet view during its first `onLayoutChild`. That callback drives `translationY` to track
+        // animated inset changes, what interferes with our slide-in custom animation.
+        //
+        // We manage insets ourselves by setting a fixed height for FormSheetContainer, so we can
+        // clear the Material's callback to remove the conflict entirely.
+        //
+        // This method must run after the first layout pass.
+        bottomSheetView.doOnLayout {
+            ViewCompat.setWindowInsetsAnimationCallback(it, insetsAnimationCallback)
+        }
+    }
+
+    internal fun destroy() {
+        ViewCompat.setWindowInsetsAnimationCallback(bottomSheetView, null)
+    }
+
+    private inner class KeyboardInsetsAnimationCallback : WindowInsetsAnimationCompat.Callback(DISPATCH_MODE_STOP) {
+        private var startTop = 0
+        private var startTranslationY = 0f
+
+        // Decided once per keyboard animation, in `onPrepare`. Tracking can't be picked up mid-animation
+        // because of no start position to translate from.
+        private var isTracking = false
+
+        private val isActive: Boolean
+            get() = isTracking && isTrackingEnabled
+
+        override fun onPrepare(animation: WindowInsetsAnimationCompat) {
+            if (!animation.isKeyboardAnimation() || !isTrackingEnabled) {
+                return
+            }
+
+            // Saving sheet's position before applying keyboard insets.
+            startTop = bottomSheetView.top
+            isTracking = true
+        }
+
+        override fun onStart(
+            animation: WindowInsetsAnimationCompat,
+            bounds: WindowInsetsAnimationCompat.BoundsCompat,
+        ): WindowInsetsAnimationCompat.BoundsCompat {
+            if (!animation.isKeyboardAnimation() || !isActive) {
+                return bounds
+            }
+
+            // The end sheet position is known - move the sheet and let the animation progress 
+            // bring it to the new position.
+            startTranslationY = (startTop - bottomSheetView.top).toFloat()
+            bottomSheetView.translationY = startTranslationY
+            return bounds
+        }
+
+        override fun onProgress(
+            insets: WindowInsetsCompat,
+            runningAnimations: List<WindowInsetsAnimationCompat>,
+        ): WindowInsetsCompat {
+            if (!isActive) {
+                return insets
+            }
+
+            val keyboardAnimation = runningAnimations.firstOrNull { it.isKeyboardAnimation() } ?: return insets
+            bottomSheetView.translationY = startTranslationY * (1f - keyboardAnimation.interpolatedFraction)
+            return insets
+        }
+
+        override fun onEnd(animation: WindowInsetsAnimationCompat) {
+            if (!animation.isKeyboardAnimation()) {
+                return
+            }
+
+            if (isActive) {
+                bottomSheetView.translationY = 0f
+            }
+            isTracking = false
+        }
+
+        private fun WindowInsetsAnimationCompat.isKeyboardAnimation(): Boolean = typeMask and WindowInsetsCompat.Type.ime() != 0
+    }
+}

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetKeyboardCoordinator.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetKeyboardCoordinator.kt
@@ -65,7 +65,7 @@ internal class FormSheetKeyboardCoordinator(
                 return bounds
             }
 
-            // The end sheet position is known - move the sheet and let the animation progress 
+            // The end sheet position is known - move the sheet and let the animation progress
             // bring it to the new position.
             startTranslationY = (startTop - bottomSheetView.top).toFloat()
             bottomSheetView.translationY = startTranslationY

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -60,8 +60,9 @@ internal class FormSheetDetents(
     ): Int {
         /*
          * We add the `bottomInset` to the `contentHeight` so that the Material BottomSheet
-         * is laid out behind the system navigation bar. The sheet's container covers the insets,
-         * while the RN content is strictly constrained to `contentHeight`.
+         * is laid out behind the system navigation bar or the keyboard (the sheet grows by
+         * the keyboard height and gets pushed above it, following iOS approach). The sheet's
+         * container covers the insets, while the RN content is strictly constrained to `contentHeight`.
          */
         if (contentHeight <= 0) {
             // Avoid collapsing the sheet before the React content has been laid out and measured.
@@ -102,7 +103,8 @@ internal class FormSheetDetents(
             if (contentHeight <= 0) {
                 return (containerHeight - topInset - bottomInset).coerceAtLeast(0)
             }
-            return contentHeight.coerceAtMost(containerHeight)
+            // Content taller than the safe area is aligned with it.
+            return contentHeight.coerceAtMost((containerHeight - topInset - bottomInset).coerceAtLeast(0))
         }
 
         // Bottom inset is always fully subtracted because the sheet is in its dedicated window and it's

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -92,6 +92,7 @@ internal class FormSheetDetents(
         val middleDetentHeight =
             heightAt(1, containerHeight, keyboardLift)
                 .coerceAtMost(maxAllowedHeight(containerHeight, keyboardLift) - MIDDLE_DETENT_MIN_GAP)
+                .coerceAtLeast(1)
         return middleDetentHeight.toFloat() / containerHeight
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -33,59 +33,82 @@ internal class FormSheetDetents(
 
     private fun heightFractionAt(index: Int): Double = detents[index]
 
+    // Height of the sheet resting at the given detent, measured down to the bottom edge of the container.
     private fun heightAt(
         index: Int,
         containerHeight: Int,
-    ): Int = (heightFractionAt(index) * containerHeight).roundToInt()
-
-    private fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
+        keyboardLift: Int,
+    ): Int = ((heightFractionAt(index) * containerHeight).roundToInt() + keyboardLift).coerceAtMost(containerHeight)
 
     /**
      * Height handed to Material as `peekHeight`. Material treats the peek height as the content height above
-     * the bottom system inset and adds that inset back (`BottomSheetBehavior.calculatePeekHeight`), while every
+     * the bottom inset and adds that inset back (`BottomSheetBehavior.calculatePeekHeight`), while every
      * other metric (`maxHeight`, `halfExpandedRatio`) describes the sheet down to the screen edge. The inset is
      * subtracted here so the lowest detent is resolved against the same reference as the other ones.
+     * Material's inset covers the keyboard as well, so the lift is subtracted along with the system inset.
      */
     internal fun peekHeight(
         containerHeight: Int,
         bottomInset: Int,
-    ): Int = (firstHeight(containerHeight) - bottomInset).coerceAtLeast(0)
+        keyboardLift: Int = 0,
+    ): Int = (heightAt(0, containerHeight, keyboardLift) - bottomInset - keyboardLift).coerceAtLeast(0)
 
-    internal fun maxAllowedHeight(containerHeight: Int): Int = heightAt(count - 1, containerHeight)
+    internal fun maxAllowedHeight(
+        containerHeight: Int,
+        keyboardLift: Int = 0,
+    ): Int = heightAt(count - 1, containerHeight, keyboardLift)
 
     internal fun maxAllowedHeightForFitToContents(
         containerHeight: Int,
         contentHeight: Int,
         bottomInset: Int,
+        keyboardLift: Int = 0,
     ): Int {
         /*
-         * We add the `bottomInset` to the `contentHeight` so that the Material BottomSheet
-         * is laid out behind the system navigation bar or the keyboard (the sheet grows by
-         * the keyboard height and gets pushed above it, following iOS approach). The sheet's
-         * container covers the insets, while the RN content is strictly constrained to `contentHeight`.
+         * We add the `bottomInset` and the `keyboardLift` to the `contentHeight` so that the Material BottomSheet
+         * is laid out behind the system navigation bar or the keyboard. The sheet's container covers the insets,
+         * while the RN content is strictly constrained to `contentHeight`.
          */
         if (contentHeight <= 0) {
             // Avoid collapsing the sheet before the React content has been laid out and measured.
             return containerHeight
         }
-        return (contentHeight + bottomInset).coerceAtMost(containerHeight)
+        return (contentHeight + bottomInset + keyboardLift).coerceAtMost(containerHeight)
     }
 
-    internal fun halfExpandedRatio(): Float {
+    /**
+     * Ratio of the middle detent's sheet height to the container height, handed to Material as `halfExpandedRatio`.
+     * Material resolves the half-expanded position from it as `(int) (parentHeight * (1 - ratio))`.
+     *
+     * The keyboard lift can push both the middle and the largest detent to the top of the container. Material needs
+     * the half-expanded position strictly below the expanded one so the middle detent is kept at least
+     * [MIDDLE_DETENT_MIN_GAP] px shorter than the largest one.
+     */
+    internal fun halfExpandedRatio(
+        containerHeight: Int,
+        keyboardLift: Int = 0,
+    ): Float {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for halfExpandedRatio." }
-        return heightFractionAt(1).toFloat()
+        val middleDetentHeight =
+            heightAt(1, containerHeight, keyboardLift)
+                .coerceAtMost(maxAllowedHeight(containerHeight, keyboardLift) - MIDDLE_DETENT_MIN_GAP)
+        return middleDetentHeight.toFloat() / containerHeight
     }
 
     internal fun expandedOffsetFromTop(
         containerHeight: Int,
         topInset: Int = 0,
+        keyboardLift: Int = 0,
     ): Int {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for expandedOffsetFromTop." }
-        return largestDetentTopOffset(containerHeight) + topInset
+        return largestDetentTopOffset(containerHeight, keyboardLift) + topInset
     }
 
     // Distance from the top of the window to the top of the largest detent's surface.
-    private fun largestDetentTopOffset(containerHeight: Int): Int = containerHeight - maxAllowedHeight(containerHeight)
+    private fun largestDetentTopOffset(
+        containerHeight: Int,
+        keyboardLift: Int,
+    ): Int = containerHeight - maxAllowedHeight(containerHeight, keyboardLift)
 
     /**
      * Material's BottomSheetDialog dynamically applies padding when its content overlaps
@@ -97,25 +120,32 @@ internal class FormSheetDetents(
         topInset: Int,
         bottomInset: Int,
         contentHeight: Int = 0,
+        keyboardLift: Int = 0,
     ): Int {
+        val bottomPadding = bottomInset + keyboardLift
+
         if (isFitToContents) {
             // Until we have a measured content height, fall back to a safe-area height so Yoga can lay out.
             if (contentHeight <= 0) {
-                return (containerHeight - topInset - bottomInset).coerceAtLeast(0)
+                return (containerHeight - topInset - bottomPadding).coerceAtLeast(0)
             }
             // Content taller than the safe area is aligned with it.
-            return contentHeight.coerceAtMost((containerHeight - topInset - bottomInset).coerceAtLeast(0))
+            return contentHeight.coerceAtMost((containerHeight - topInset - bottomPadding).coerceAtLeast(0))
         }
 
-        // Bottom inset is always fully subtracted because the sheet is in its dedicated window and it's
+        // Bottom padding is always fully subtracted because the sheet is in its dedicated window and it's
         // anchored to the bottom.
         // Top inset is subtracted only by the amount the sheet actually overlaps it.
-        val topOverlap = (topInset - largestDetentTopOffset(containerHeight)).coerceAtLeast(0)
-        return (maxAllowedHeight(containerHeight) - topOverlap - bottomInset).coerceAtLeast(0)
+        val topOverlap = (topInset - largestDetentTopOffset(containerHeight, keyboardLift)).coerceAtLeast(0)
+        return (maxAllowedHeight(containerHeight, keyboardLift) - topOverlap - bottomPadding).coerceAtLeast(0)
     }
 
     companion object {
         const val MAX_DETENTS = 3
         const val FIT_TO_CONTENTS_DETENT_VALUE = -1.0
+
+        // Material resolves the half-expanded position in float precision and the truncation to int can eat 1 px
+        // which would put the middle detent back on the expanded position.
+        private const val MIDDLE_DETENT_MIN_GAP = 2
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
@@ -42,7 +42,9 @@ internal class FormSheetAnimatorFactory(
         view: View,
         isInterrupting: Boolean = false,
     ): Animator {
-        val startY = if (isInterrupting) view.translationY else 0f
+        // Always leave from the current translation: besides an interrupted enter animation, the sheet
+        // may be mid-way through tracking the keyboard animation when the dismissal starts.
+        val startY = view.translationY
         val startAlpha = if (isInterrupting) dimmingManager.dimmingAlpha else dimmingManager.maxAlpha
 
         val slideAnimator =

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentation.kt
@@ -8,6 +8,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetAppearanceCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetBehaviorController
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetDimensionsCoordinator
+import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetKeyboardCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.coordinator.FormSheetNativeDismissCoordinator
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetContainer
 import com.swmansion.rnscreens.modals.formsheet.native.core.FormSheetDialog
@@ -55,9 +56,13 @@ internal class FormSheetPresentation(
         FormSheetDimensionsCoordinator(
             dialog = dialog,
             container = container,
-            bottomSheetView = bottomSheetView,
             behaviorController = behaviorController,
         )
+
+    private val keyboardCoordinator =
+        bottomSheetView?.let {
+            FormSheetKeyboardCoordinator(bottomSheetView = it)
+        }
 
     private val nativeDismissCoordinator =
         FormSheetNativeDismissCoordinator(
@@ -71,7 +76,16 @@ internal class FormSheetPresentation(
         nativeDismissCoordinator.setup()
         appearanceCoordinator.setup()
         dimensionsCoordinator.setup()
+        keyboardCoordinator?.setup()
         behaviorController?.setup()
+    }
+
+    /**
+     * Enables tracking the keyboard animation. Expected to be on only while the sheet rests in the
+     * PRESENTED state - the enter / exit animators own `translationY` otherwise.
+     */
+    internal fun setKeyboardTrackingEnabled(enabled: Boolean) {
+        keyboardCoordinator?.isTrackingEnabled = enabled
     }
 
     internal fun onContentHeightChanged(height: Int) {
@@ -126,6 +140,7 @@ internal class FormSheetPresentation(
         behaviorController?.destroy()
         nativeDismissCoordinator.destroy()
         dimensionsCoordinator.destroy()
+        keyboardCoordinator?.destroy()
 
         dialog.setOnShowListener(null)
         dialog.dismiss()

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -109,7 +109,7 @@ internal class FormSheetPresentationManager(
         }
 
         state = FormSheetPresentationState.DISMISSING
-        presentation?.setKeyboardTrackingEnabled(false)
+        currentPresentation?.setKeyboardTrackingEnabled(false)
         dismissSheetsAbove()
         // Leaving the stack immediately is deliberate, if another sheet is presented during this exit animation,
         // it must stack on a "stable" sheet - the one we don't intend to dismiss. This window is about to be
@@ -247,7 +247,7 @@ internal class FormSheetPresentationManager(
     private fun onPresentationComplete() {
         if (state == FormSheetPresentationState.PRESENTING) {
             state = FormSheetPresentationState.PRESENTED
-            presentation?.setKeyboardTrackingEnabled(true)
+            currentPresentation?.setKeyboardTrackingEnabled(true)
             appearanceEventEmitter?.emitOnDidAppear()
             // ensure state hasn't updated during presentation
             resolvePresentationState()

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetPresentationManager.kt
@@ -109,6 +109,7 @@ internal class FormSheetPresentationManager(
         }
 
         state = FormSheetPresentationState.DISMISSING
+        presentation?.setKeyboardTrackingEnabled(false)
         dismissSheetsAbove()
         // Leaving the stack immediately is deliberate, if another sheet is presented during this exit animation,
         // it must stack on a "stable" sheet - the one we don't intend to dismiss. This window is about to be
@@ -246,6 +247,7 @@ internal class FormSheetPresentationManager(
     private fun onPresentationComplete() {
         if (state == FormSheetPresentationState.PRESENTING) {
             state = FormSheetPresentationState.PRESENTED
+            presentation?.setKeyboardTrackingEnabled(true)
             appearanceEventEmitter?.emitOnDidAppear()
             // ensure state hasn't updated during presentation
             resolvePresentationState()

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -9,6 +9,7 @@ import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
 import TestFormSheetFractionalDetents from './test-form-sheet-fractional-detents';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
+import TestFormSheetKeyboard from './test-form-sheet-keyboard';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
 import TestFormSheetLifecycleEvents from './test-form-sheet-lifecycle-events';
 import TestFormSheetNativeContainerStyle from './test-form-sheet-native-container-style';
@@ -28,6 +29,7 @@ export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-
 export { default as TestFormSheetFractionalDetents } from './test-form-sheet-fractional-detents';
 export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
 export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
+export { default as TestFormSheetKeyboard } from './test-form-sheet-keyboard';
 export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
 export { default as TestFormSheetLifecycleEvents } from './test-form-sheet-lifecycle-events';
 export { default as TestFormSheetNativeContainerStyle } from './test-form-sheet-native-container-style';
@@ -46,6 +48,7 @@ const scenarios = {
   TestFormSheetFractionalDetents,
   TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
+  TestFormSheetKeyboard,
   TestFormSheetLargestUndimmedDetentIndex,
   TestFormSheetLifecycleEvents,
   TestFormSheetNativeContainerStyle,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/index.tsx
@@ -1,0 +1,141 @@
+import React, { useState } from 'react';
+import { Button, StyleSheet, Text, TextInput, View } from 'react-native';
+import { FormSheet } from 'react-native-screens';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+function SheetContent({
+  fitToContents,
+  onDismiss,
+}: {
+  fitToContents: boolean;
+  onDismiss: () => void;
+}) {
+  return (
+    <View
+      style={[
+        styles.sheetContent,
+        fitToContents ? styles.sheetContentWrap : styles.sheetContentFill,
+      ]}>
+      <Text style={styles.sheetTitle}>FormSheet content</Text>
+      <Text style={styles.description}>
+        Focus the inputs to check how the sheet reacts to the keyboard.
+      </Text>
+      <TextInput
+        style={styles.input}
+        placeholder="Top input"
+        placeholderTextColor={Colors.cardBorder}
+      />
+      <View style={fitToContents ? styles.spacing : styles.spacer} />
+      <TextInput
+        style={styles.input}
+        placeholder="Bottom input"
+        placeholderTextColor={Colors.cardBorder}
+      />
+      <Button
+        title="Dismiss from JS"
+        color={Colors.primary}
+        onPress={onDismiss}
+      />
+    </View>
+  );
+}
+
+function TestFormSheetKeyboard() {
+  const [isDetentsSheetOpen, setIsDetentsSheetOpen] = useState(false);
+  const [isFitToContentsSheetOpen, setIsFitToContentsSheetOpen] =
+    useState(false);
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>FormSheet Test</Text>
+      <Button
+        title="Open FormSheet (detents)"
+        color={Colors.primary}
+        onPress={() => setIsDetentsSheetOpen(true)}
+      />
+      <View style={styles.spacing} />
+      <Button
+        title="Open FormSheet (fitToContents)"
+        color={Colors.primary}
+        onPress={() => setIsFitToContentsSheetOpen(true)}
+      />
+      <FormSheet
+        isOpen={isDetentsSheetOpen}
+        onNativeDismiss={() => setIsDetentsSheetOpen(false)}
+        detents={[0.6, 1.0]}>
+        <SheetContent
+          fitToContents={false}
+          onDismiss={() => setIsDetentsSheetOpen(false)}
+        />
+      </FormSheet>
+      <FormSheet
+        isOpen={isFitToContentsSheetOpen}
+        onNativeDismiss={() => setIsFitToContentsSheetOpen(false)}
+        detents="fitToContents">
+        <SheetContent
+          fitToContents
+          onDismiss={() => setIsFitToContentsSheetOpen(false)}
+        />
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: Colors.offBackground,
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 20,
+    color: Colors.text,
+  },
+  sheetContent: {
+    backgroundColor: Colors.background,
+    padding: 24,
+  },
+  sheetContentFill: {
+    flex: 1,
+  },
+  sheetContentWrap: {
+    paddingBottom: 48,
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '600',
+    marginBottom: 12,
+    color: Colors.text,
+    textAlign: 'center',
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    color: Colors.text,
+    paddingHorizontal: 16,
+    marginBottom: 12,
+  },
+  input: {
+    height: 44,
+    borderWidth: 1,
+    borderColor: Colors.cardBorder,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    marginBottom: 12,
+    color: Colors.text,
+    backgroundColor: Colors.cardBackground,
+  },
+  spacer: {
+    flex: 1,
+  },
+  spacing: {
+    height: 32,
+  },
+});
+
+export default createScenario(TestFormSheetKeyboard, scenarioDescription);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/index.tsx
@@ -43,7 +43,9 @@ function SheetContent({
 }
 
 function TestFormSheetKeyboard() {
-  const [isDetentsSheetOpen, setIsDetentsSheetOpen] = useState(false);
+  const [isSingleDetentSheetOpen, setIsSingleDetentSheetOpen] = useState(false);
+  const [isTwoDetentsSheetOpen, setIsTwoDetentsSheetOpen] = useState(false);
+  const [isThreeDetentsSheetOpen, setIsThreeDetentsSheetOpen] = useState(false);
   const [isFitToContentsSheetOpen, setIsFitToContentsSheetOpen] =
     useState(false);
 
@@ -51,9 +53,21 @@ function TestFormSheetKeyboard() {
     <View style={styles.container}>
       <Text style={styles.title}>FormSheet Test</Text>
       <Button
-        title="Open FormSheet (detents)"
+        title="Open FormSheet (single detent)"
         color={Colors.primary}
-        onPress={() => setIsDetentsSheetOpen(true)}
+        onPress={() => setIsSingleDetentSheetOpen(true)}
+      />
+      <View style={styles.spacing} />
+      <Button
+        title="Open FormSheet (two detents)"
+        color={Colors.primary}
+        onPress={() => setIsTwoDetentsSheetOpen(true)}
+      />
+      <View style={styles.spacing} />
+      <Button
+        title="Open FormSheet (three detents)"
+        color={Colors.primary}
+        onPress={() => setIsThreeDetentsSheetOpen(true)}
       />
       <View style={styles.spacing} />
       <Button
@@ -62,12 +76,30 @@ function TestFormSheetKeyboard() {
         onPress={() => setIsFitToContentsSheetOpen(true)}
       />
       <FormSheet
-        isOpen={isDetentsSheetOpen}
-        onNativeDismiss={() => setIsDetentsSheetOpen(false)}
+        isOpen={isSingleDetentSheetOpen}
+        onNativeDismiss={() => setIsSingleDetentSheetOpen(false)}
+        detents={[0.4]}>
+        <SheetContent
+          fitToContents={false}
+          onDismiss={() => setIsSingleDetentSheetOpen(false)}
+        />
+      </FormSheet>
+      <FormSheet
+        isOpen={isTwoDetentsSheetOpen}
+        onNativeDismiss={() => setIsTwoDetentsSheetOpen(false)}
         detents={[0.6, 1.0]}>
         <SheetContent
           fitToContents={false}
-          onDismiss={() => setIsDetentsSheetOpen(false)}
+          onDismiss={() => setIsTwoDetentsSheetOpen(false)}
+        />
+      </FormSheet>
+      <FormSheet
+        isOpen={isThreeDetentsSheetOpen}
+        onNativeDismiss={() => setIsThreeDetentsSheetOpen(false)}
+        detents={[0.3, 0.6, 1.0]}>
+        <SheetContent
+          fitToContents={false}
+          onDismiss={() => setIsThreeDetentsSheetOpen(false)}
         />
       </FormSheet>
       <FormSheet

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario-description.ts
@@ -1,0 +1,11 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Keyboard Integration',
+  key: 'test-form-sheet-keyboard',
+  details:
+    'Text inputs inside a two-detent sheet and a fitToContents sheet: keyboard show / hide, focused input visibility, dismissal with the keyboard shown.',
+  platforms: ['android', 'ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Keyboard Integration',
   key: 'test-form-sheet-keyboard',
   details:
-    'Text inputs inside a two-detent sheet and a fitToContents sheet: keyboard show / hide, focused input visibility, dismissal with the keyboard shown.',
+    'Text inputs inside sheets with 1, 2, 3 detents and fitToContents: keyboard show / hide, focused input visibility, dismissal with the keyboard shown.',
   platforms: ['android', 'ios'],
   e2eCoverage: 'tbd',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
@@ -1,0 +1,138 @@
+# Test Scenario: Keyboard Integration
+
+## Details
+
+**Description:** Verify how a `FormSheet` reacts to the system keyboard when a TextInput inside it gets focused. Two sheets are covered: one with two detents (`[0.6, 1.0]`) and one with `detents="fitToContents"`. Each has a text input at the top and at the bottom of its content.
+
+**OS test creation version:** iOS: 26.5, Android: API Level 36.
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iPhone: device or simulator. On the simulator make sure the software keyboard is shown.
+- Android: phone device or emulator. The emulator has to use the on-screen keyboard.
+
+## Note
+
+- Keyboard handling differs between platforms and both behaviors are expected:
+  - **iOS:** UIKit handles it. A sheet resting at a detent smaller than the largest one grows to the largest detent while the keyboard is shown. A sheet resting at its largest detent (including `fitToContents`) is pushed up so that it sits above the keyboard; its view becomes taller by the keyboard height, the extra area is hidden behind the keyboard. Content laid out at the bottom of a sheet resting at the largest detent might end up under the keyboard.
+  - **Android:** the sheet reacts to the keyboard insets. At a lower detent the sheet moves up by the keyboard height, at the largest detent the content box shrinks so that it stays above the keyboard, a `fitToContents` sheet moves up as a whole. The sheet moves together with the keyboard animation.
+
+## Steps - iPhone
+
+### Baseline
+
+1. Launch the app and navigate to the **Keyboard Integration** screen.
+
+- [ ] The host screen shows the "FormSheet Test" title, the "Open FormSheet (detents)" and "Open FormSheet (fitToContents)" buttons.
+
+---
+
+### Detents – keyboard at the lower detent
+
+2. Tap "Open FormSheet (detents)".
+
+- [ ] The sheet presents at the lower detent (0.6). "Top input" is at the top of the sheet, "Bottom input" and "Dismiss from JS" at its bottom.
+
+3. Tap "Top input".
+
+- [ ] The keyboard slides in and the sheet grows to the largest detent (1.0) at the same time. "Top input" is focused and visible. The content is laid out for the taller sheet, "Bottom input" ends up under the keyboard.
+
+4. Press the Return key on the keyboard.
+
+- [ ] The keyboard hides and the sheet returns to the lower detent (0.6). The content is laid out for the smaller sheet again, nothing is clipped and no empty space is left.
+
+---
+
+### Detents – keyboard at the largest detent
+
+5. Drag the sheet up to the largest detent (1.0), then tap "Bottom input".
+
+- [ ] The keyboard slides in, the sheet stays at 1.0. "Bottom input" is focused but covered by the keyboard – this matches the native sheet behavior.
+
+6. With the keyboard shown, swipe the sheet down past the lower detent.
+
+- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and both "Open FormSheet" buttons are pressable again.
+
+---
+
+### fitToContents
+
+7. Tap "Open FormSheet (fitToContents)".
+
+- [ ] The sheet presents with a height matching its content.
+
+8. Tap "Bottom input".
+
+- [ ] The keyboard slides in and the sheet moves up so that its whole content sits above the keyboard. "Bottom input" is focused and visible.
+
+9. Press the Return key on the keyboard.
+
+- [ ] The keyboard hides and the sheet returns to its resting position at the bottom of the screen.
+
+10. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+## Steps - Android
+
+### Baseline
+
+1. Launch the app and navigate to the **Keyboard Integration** screen.
+
+- [ ] The host screen shows the "FormSheet Test" title, the "Open FormSheet (detents)" and "Open FormSheet (fitToContents)" buttons.
+
+---
+
+### Detents – keyboard at the lower detent
+
+2. Tap "Open FormSheet (detents)".
+
+- [ ] The sheet presents at the lower detent (0.6). "Top input" is visible at the top of the sheet; "Bottom input" and "Dismiss from JS" are not visible yet (the content box is laid out to the largest detent).
+
+3. Tap "Top input".
+
+- [ ] The keyboard slides in and the sheet moves up by the keyboard height, following the keyboard animation – no jump before or after it. "Top input" is focused and visible.
+
+4. Press the system back button (or use the back gesture).
+
+- [ ] The keyboard hides and the sheet moves back down together with it, settling at the lower detent (0.6). The sheet stays presented.
+
+---
+
+### Detents – keyboard at the largest detent
+
+5. Drag the sheet up to the largest detent (1.0), then tap "Bottom input".
+
+- [ ] The keyboard slides in and the content box shrinks to the area above the keyboard. "Bottom input" is focused and visible right above the keyboard, together with "Dismiss from JS".
+
+6. Press the system back button.
+
+- [ ] The keyboard hides, the content box grows back to the full sheet height and "Bottom input" moves back to the bottom of the sheet. The sheet stays at 1.0.
+
+7. Tap "Top input", then – with the keyboard shown – swipe the sheet down past the lower detent.
+
+- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and both "Open FormSheet" buttons are pressable again.
+
+---
+
+### fitToContents
+
+8. Tap "Open FormSheet (fitToContents)".
+
+- [ ] The sheet presents with a height matching its content.
+
+9. Tap "Bottom input".
+
+- [ ] The keyboard slides in and the whole sheet moves up above the keyboard, following the keyboard animation. "Bottom input" is focused and visible.
+
+10. Press the system back button.
+
+- [ ] The keyboard hides and the sheet moves back down to its resting position at the bottom of the screen.
+
+11. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
@@ -95,11 +95,11 @@ TBD: Planned, but will be implemented separately.
 
 3. Tap "Top input".
 
-- [ ] The keyboard slides in and the sheet moves up by the keyboard height, following the keyboard animation – no jump before or after it. "Top input" is focused and visible.
+- [ ] The keyboard slides in and the sheet moves up by the keyboard height, following the keyboard animation – no jump before or after it. "Top input" is focused and visible. On Android, the "Bottom input" and "Dismiss from JS" are moved to the visible area.
 
 4. Press the system back button (or use the back gesture).
 
-- [ ] The keyboard hides and the sheet moves back down together with it, settling at the lower detent (0.6). The sheet stays presented.
+- [ ] The keyboard hides and the sheet moves back down together with it, settling at the lower detent (0.6). The sheet stays presented. On Android, the "Bottom input" and "Dismiss from JS" are moved outside the visible area.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** Verify how a `FormSheet` reacts to the system keyboard when a TextInput inside it gets focused. Two sheets are covered: one with two detents (`[0.6, 1.0]`) and one with `detents="fitToContents"`. Each has a text input at the top and at the bottom of its content.
+**Description:** Verify how a `FormSheet` reacts to the system keyboard when a TextInput inside it gets focused. Four sheets are covered: a single detent (`[0.4]`), two detents (`[0.6, 1.0]`), three detents (`[0.3, 0.6, 1.0]`), and `detents="fitToContents"`. Each has a text input at the top and at the bottom of its content.
 
 **OS test creation version:** iOS: 26.5, Android: API Level 36.
 
@@ -19,7 +19,7 @@ TBD: Planned, but will be implemented separately.
 
 - Keyboard handling differs between platforms and both behaviors are expected:
   - **iOS:** UIKit handles it. A sheet resting at a detent smaller than the largest one grows to the largest detent while the keyboard is shown. A sheet resting at its largest detent (including `fitToContents`) is pushed up so that it sits above the keyboard; its view becomes taller by the keyboard height, the extra area is hidden behind the keyboard. Content laid out at the bottom of a sheet resting at the largest detent might end up under the keyboard.
-  - **Android:** the sheet reacts to the keyboard insets. At a lower detent the sheet moves up by the keyboard height, at the largest detent the content box shrinks so that it stays above the keyboard, a `fitToContents` sheet moves up as a whole. The sheet moves together with the keyboard animation.
+  - **Android:** the sheet reacts to the keyboard insets. Whichever detent it rests at, the sheet is pushed up by the keyboard height as far as the screen allows, so its detent-sized part stays above the keyboard (the extra area is hidden behind the keyboard, like on iOS). Only the part that can't be pushed above the keyboard shrinks the content box - a sheet resting at the full-height detent stays in place and its content box shrinks by the keyboard height. A `fitToContents` sheet moves up as a whole. The sheet moves together with the keyboard animation.
 
 ## Steps - iPhone
 
@@ -27,11 +27,11 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Keyboard Integration** screen.
 
-- [ ] The host screen shows the "FormSheet Test" title, the "Open FormSheet (detents)" and "Open FormSheet (fitToContents)" buttons.
+- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: detents, three detents, single detent, fitToContents.
 
 ---
 
-### Detents – keyboard at the lower detent
+### Two detents – keyboard at the lower detent
 
 2. Tap "Open FormSheet (detents)".
 
@@ -47,7 +47,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Detents – keyboard at the largest detent
+### Two detents – keyboard at the largest detent
 
 5. Drag the sheet up to the largest detent (1.0), then tap "Bottom input".
 
@@ -77,17 +77,49 @@ TBD: Planned, but will be implemented separately.
 
 - [ ] The sheet dismisses and the host screen is undimmed.
 
+---
+
+### Three detents – keyboard at the middle detent
+
+11. Tap "Open FormSheet (three detents)", drag the sheet up to the middle detent (0.6), then tap "Top input".
+
+- [ ] The keyboard slides in and the sheet grows to the largest detent (1.0). "Top input" is focused and visible.
+
+12. Press the Return key on the keyboard.
+
+- [ ] The keyboard hides and the sheet returns to the middle detent (0.6).
+
+13. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+---
+
+### Single detent
+
+14. Tap "Open FormSheet (single detent)", then tap "Top input".
+
+- [ ] The keyboard slides in and the sheet is pushed up so that it sits above the keyboard; its content keeps its height. "Top input" is focused and visible.
+
+15. Press the Return key on the keyboard.
+
+- [ ] The keyboard hides and the sheet returns to its resting position at the bottom of the screen.
+
+16. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
 ## Steps - Android
 
 ### Baseline
 
 1. Launch the app and navigate to the **Keyboard Integration** screen.
 
-- [ ] The host screen shows the "FormSheet Test" title, the "Open FormSheet (detents)" and "Open FormSheet (fitToContents)" buttons.
+- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: detents, three detents, single detent, fitToContents.
 
 ---
 
-### Detents – keyboard at the lower detent
+### Two detents – keyboard at the lower detent
 
 2. Tap "Open FormSheet (detents)".
 
@@ -103,7 +135,7 @@ TBD: Planned, but will be implemented separately.
 
 ---
 
-### Detents – keyboard at the largest detent
+### Two detents – keyboard at the largest detent
 
 5. Drag the sheet up to the largest detent (1.0), then tap "Bottom input".
 
@@ -134,5 +166,37 @@ TBD: Planned, but will be implemented separately.
 - [ ] The keyboard hides and the sheet moves back down to its resting position at the bottom of the screen.
 
 11. Tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+---
+
+### Three detents – keyboard at the middle detent
+
+12. Tap "Open FormSheet (three detents)", drag the sheet up to the middle detent (0.6), then tap "Top input".
+
+- [ ] The keyboard slides in and the sheet moves up by the keyboard height, following the keyboard animation. "Top input" is focused and visible.
+
+13. Press the system back button.
+
+- [ ] The keyboard hides and the sheet moves back down together with it, settling at the middle detent (0.6).
+
+14. Drag the sheet up to the largest detent (1.0), then tap "Dismiss from JS".
+
+- [ ] The sheet dismisses and the host screen is undimmed.
+
+---
+
+### Single detent
+
+15. Tap "Open FormSheet (single detent)", then tap "Top input".
+
+- [ ] The keyboard slides in and the sheet moves up by the keyboard height, following the keyboard animation. The content box keeps its height, "Top input" is focused and visible.
+
+16. Press the system back button.
+
+- [ ] The keyboard hides and the sheet moves back down together with it, settling at 0.4.
+
+17. Tap "Dismiss from JS".
 
 - [ ] The sheet dismisses and the host screen is undimmed.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-keyboard/scenario.md
@@ -27,13 +27,13 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Keyboard Integration** screen.
 
-- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: detents, three detents, single detent, fitToContents.
+- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: single detent, two detents, three detents, fitToContents.
 
 ---
 
 ### Two detents – keyboard at the lower detent
 
-2. Tap "Open FormSheet (detents)".
+2. Tap "Open FormSheet (two detents)".
 
 - [ ] The sheet presents at the lower detent (0.6). "Top input" is at the top of the sheet, "Bottom input" and "Dismiss from JS" at its bottom.
 
@@ -55,7 +55,7 @@ TBD: Planned, but will be implemented separately.
 
 6. With the keyboard shown, swipe the sheet down past the lower detent.
 
-- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and both "Open FormSheet" buttons are pressable again.
+- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and all "Open FormSheet" buttons are pressable again.
 
 ---
 
@@ -115,13 +115,13 @@ TBD: Planned, but will be implemented separately.
 
 1. Launch the app and navigate to the **Keyboard Integration** screen.
 
-- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: detents, three detents, single detent, fitToContents.
+- [ ] The host screen shows the "FormSheet Test" title and the four "Open FormSheet" buttons: single detent, two detents, three detents, fitToContents.
 
 ---
 
 ### Two detents – keyboard at the lower detent
 
-2. Tap "Open FormSheet (detents)".
+2. Tap "Open FormSheet (two detents)".
 
 - [ ] The sheet presents at the lower detent (0.6). "Top input" is visible at the top of the sheet; "Bottom input" and "Dismiss from JS" are not visible yet (the content box is laid out to the largest detent).
 
@@ -147,7 +147,7 @@ TBD: Planned, but will be implemented separately.
 
 7. Tap "Top input", then – with the keyboard shown – swipe the sheet down past the lower detent.
 
-- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and both "Open FormSheet" buttons are pressable again.
+- [ ] Both the keyboard and the sheet are dismissed. The host screen is undimmed and all "Open FormSheet" buttons are pressable again.
 
 ---
 


### PR DESCRIPTION
## Description

`FormSheet` on Android has ignored the software keyboard so far. The sheet now follows the keyboard: whichever detent it rests at, it is pushed up by the keyboard height as far as the screen allows, and only the part that can't be pushed above the keyboard shrinks the content box. The sheet moves together with the keyboard animation.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1276

## Changes

- `FormSheetDimensionsCoordinator` tracks the IME inset and derives `keyboardLift = max(0, ime.bottom - systemBars.bottom)`, the part of the keyboard that sticks out above the navigation bar.
- `FormSheetDetents` extends every resting height by the lift, capped at the container height. The peek height accounts for Material adding the keyboard inset back on its own, **the middle detent is kept at least 2 px below the largest one so Material can still tell the two states apart**, and the content box keeps its size while the sheet rises and shrinks only once the sheet hits the top of the screen.
- `FormSheetKeyboardCoordinator` defines our own `WindowInsetsAnimationCompat.Callback` in place of Material's. It records the sheet's layout `top` before the keyboard insets are applied, translates the sheet back there once the end-state layout is in place and drives `translationY` to zero along the keyboard animation. Tracking is enabled by `FormSheetPresentationManager` only while the sheet rests in `PRESENTED`; otherwise the enter/exit animators own the translation.

## Before & after - visual documentation

| Android | iOS |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/325f98f8-f2e5-4fa8-9a48-773209c4d106" /> | <video src="https://github.com/user-attachments/assets/fc39516a-b7fe-462d-b67e-9680fc99e4a0" /> |

## Test plan

Added a dedicated SFT (maybe it should be CIT 🤔).

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
