### PR TITLE
chore(test): update tabs and stack scenarios after 4.27.0 / 5.0.0-alpha.2 release tests

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/scenario.md
@@ -73,7 +73,7 @@ qualities that Detox cannot assert reliably. This scenario is manual only.
 1. Launch the app directly via `App.tsx` (see Android launch) so the **Home**
    screen is shown.
 
-- [ ] **Home** is shown with a solid **yellow** background and **Push Blue** /
+- [ ] **Home** is shown with **Push Blue** /
       **Push Red** / **Push NestedHost** buttons. No **Pop** button is shown.
 
 ### Push animation
@@ -128,11 +128,11 @@ qualities that Detox cannot assert reliably. This scenario is manual only.
 
 9. Pop/navigate back to **Home**, then tap **Push NestedHost**.
 
-- [ ] The nested host slides in and shows **NestedHome** (yellow) with **Push
+- [ ] The nested host slides in and shows **NestedHome** with **Push
       NestedBlue** / **Push NestedRed** / **Pop** buttons. The push is
       animated with the same quality as the outer stack.
 
-10. On **NestedHome**, tap **Push NestedBlue**, then on **NestedBlue** tap
+10.  On **NestedHome**, tap **Push NestedBlue**, then on **NestedBlue** tap
     **Push NestedRed**.
 
 - [ ] Each push inside the **nested** stack slides in smoothly, with visible  

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-animation-android/scenario.md
@@ -132,7 +132,7 @@ qualities that Detox cannot assert reliably. This scenario is manual only.
       NestedBlue** / **Push NestedRed** / **Pop** buttons. The push is
       animated with the same quality as the outer stack.
 
-10.  On **NestedHome**, tap **Push NestedBlue**, then on **NestedBlue** tap
+10. On **NestedHome**, tap **Push NestedBlue**, then on **NestedBlue** tap
     **Push NestedRed**.
 
 - [ ] Each push inside the **nested** stack slides in smoothly, with visible  

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
@@ -211,7 +211,7 @@ text on a green background.
 - [ ] Tab1 becomes selected (label changes to "Tab1").
 - [ ] The tab bar background reverts to dark navy, item colors
   revert to the Tab1 configuration, and the active indicator
-  reverts to green.
+  reverts to the light green shared with the selected title.
 - [ ] The result is identical to tapping Tab1 in the native tab bar.
 
 ---

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
@@ -170,10 +170,10 @@ icons and titles are blue.
   four "Select tab N" buttons.
 - [ ] Four tabs are visible in the tab bar: Tab1, Tab2, Tab3, Tab4.
 - [ ] The tab bar background is dark navy.
-- [ ] The selected Tab1 icon and title are green.
+- [ ] The selected Tab1 icon is green and its title is a lighter green.
 - [ ] Unselected tab icons and titles are blue.
-- [ ] A persistent green pill-shaped active indicator is visible
-  behind the Tab1 icon.
+- [ ] A persistent pill-shaped active indicator is visible behind the Tab1
+  icon, in the same light green as the selected title.
 - [ ] The Tab3 badge displays the value "123" in white text on a green background.
 - [ ] The Tab4 badge displays the value "Platform" in white text on a green
   background.
@@ -222,10 +222,10 @@ text on a green background.
 
 - [ ] The screen label changes to "Tab3".
 - [ ] The tab bar background is dark navy (same as Tab1).
-- [ ] The active indicator pill is green.
 - [ ] Icon and title colors for normal, selected, and focused states
   match Tab1's configuration (blue normal, green selected,
-  yellow focused).
+  yellow focused): the selected icon is green and its title a lighter green.
+- [ ] The active indicator pill is the same light green as the selected title.
 - [ ] The badge backgrounds for Tab3 and Tab4 change to red, while their values
   remain "123" and "Platform" with green text.
 
@@ -236,13 +236,15 @@ text on a green background.
 7. Tap **Tab4** in the native tab bar.
 
 - [ ] The screen label changes to "Tab4".
-- [ ] The selected Tab4 icon and title is green.
-- [ ] Unselected tab icons and titles are blue.
+- [ ] The selected Tab4 icon and title are both the same green — a darker,
+  system-resolved shade than Tab1/Tab3's green.
+- [ ] Unselected tab icons and titles are both the same blue,
+  likewise a different shade than Tab1/Tab3's blue.
 - [ ] The active indicator pill uses the system accent color.
 - [ ] The badge backgrounds for Tab3 and Tab4 change to orange, while their values
   remain "123" and "Platform" with white text.
 
-8. With Tab4 selected, toggle the emulator between light and dark appearance and back.
+1. With Tab4 selected, toggle the emulator between light and dark appearance and back.
 
 - [ ] The tab bar background adapts to
   the system theme — light/near-white in light mode, near-black in dark

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-appearance-defined-by-selected-tab/scenario.md
@@ -244,7 +244,7 @@ text on a green background.
 - [ ] The badge backgrounds for Tab3 and Tab4 change to orange, while their values
   remain "123" and "Platform" with white text.
 
-1. With Tab4 selected, toggle the emulator between light and dark appearance and back.
+8. With Tab4 selected, toggle the emulator between light and dark appearance and back.
 
 - [ ] The tab bar background adapts to
   the system theme — light/near-white in light mode, near-black in dark

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
@@ -98,11 +98,11 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 
 4. Disable **standardAppearance** and enable **scrollEdgeAppearance**.
 
-- [ ] The tab bar shows a semi-transparent dark purple background with a bright purple shadow line.
-- [ ] The system default blur applied.
 - [ ] The final appearance is a light gray, milky tab bar with a bright purple
       shadow line — a blend of the `scrollEdgeAppearance` configuration and the
       system default blur.
+- [ ] The tab bar shows a semi-transparent dark purple background with a bright purple shadow line.
+- [ ] The system default blur applied.
 
 ---
 
@@ -110,11 +110,11 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 
 5. Enable **standardAppearance** (both toggles now true).
 
+- [ ] The tab bar looks the same as in step 4: a light gray, milky bar with a
+      bright purple shadow line.
 - [ ] Both appearances are set.
 - [ ] The tab bar shows a semi-transparent dark purple background and a bright purple shadow line from `scrollEdgeAppearance`.
 - [ ] System default blur is applied as `tabBarBlurEffect` is not set.
-- [ ] The tab bar looks the same as in step 4: a light gray, milky bar with a
-      bright purple shadow line.
 
 6. Disable both toggles to restore default state before moving to Tab2.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
@@ -98,11 +98,10 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 
 4. Disable **standardAppearance** and enable **scrollEdgeAppearance**.
 
-- [ ] The final appearance is a light gray, milky tab bar with a bright purple
-      shadow line — a blend of the `scrollEdgeAppearance` configuration and the
-      system default blur.
-- [ ] The tab bar shows a semi-transparent dark purple background with a bright purple shadow line.
-- [ ] The system default blur applied.
+- [ ] `scrollEdgeAppearance` is configured with a semi-transparent dark purple
+      background and a bright purple shadow line; with the system default blur
+      applied over it, the tab bar renders as a light gray, milky bar with a
+      bright purple shadow line.
 
 ---
 
@@ -110,11 +109,13 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 
 5. Enable **standardAppearance** (both toggles now true).
 
-- [ ] The tab bar looks the same as in step 4: a light gray, milky bar with a
-      bright purple shadow line.
-- [ ] Both appearances are set.
-- [ ] The tab bar shows a semi-transparent dark purple background and a bright purple shadow line from `scrollEdgeAppearance`.
-- [ ] System default blur is applied as `tabBarBlurEffect` is not set.
+- [ ] Both appearances are set, but the tab bar looks the same as in step 4:
+      the semi-transparent dark purple `scrollEdgeAppearance` background with the
+      system default blur (`tabBarBlurEffect` is not set) renders as a light
+      gray, milky bar with a bright purple shadow line.
+- [ ] `standardAppearance` has no visible effect — Tab1 has no `ScrollView`, so
+      it is always at the scroll edge and `scrollEdgeAppearance` wins (no dark
+      navy background, no red shadow line).
 
 6. Disable both toggles to restore default state before moving to Tab2.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-general-appearance-no-liquid-glass-ios/scenario.md
@@ -99,7 +99,10 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 4. Disable **standardAppearance** and enable **scrollEdgeAppearance**.
 
 - [ ] The tab bar shows a semi-transparent dark purple background with a bright purple shadow line.
-- [ ] The system default blur applied (making the background look light gray).
+- [ ] The system default blur applied.
+- [ ] The final appearance is a light gray, milky tab bar with a bright purple
+      shadow line — a blend of the `scrollEdgeAppearance` configuration and the
+      system default blur.
 
 ---
 
@@ -110,11 +113,16 @@ is always at the scroll edge, so UIKit derives `scrollEdgeAppearance` from
 - [ ] Both appearances are set.
 - [ ] The tab bar shows a semi-transparent dark purple background and a bright purple shadow line from `scrollEdgeAppearance`.
 - [ ] System default blur is applied as `tabBarBlurEffect` is not set.
+- [ ] The tab bar looks the same as in step 4: a light gray, milky bar with a
+      bright purple shadow line.
 
 6. Disable both toggles to restore default state before moving to Tab2.
 
-- [ ] The tab bar returns to the UIKit system default
-  appearance (no custom color or shadow).
+- [ ] The tab bar returns to the UIKit default: no custom color or
+      shadow, and the view's green background is visible through the tab bar
+      area.
+- [ ] Titles of unselected tab bar items are darker green; the selected tab
+      title is the default blue.
 
 ---
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -34,8 +34,8 @@ Not covered:
 
 ## Note
 
-- On Android: Text color properties cannot be observed on Tab1 (empty badge) and Tab4 (icon).
-Validate background color only for these tabs.
+- On Android, validate only the background color for Tab1 (empty badge) and Tab4 (emoji) - their text color cannot be observed.
+
 
 `badgeValue`:
 
@@ -76,6 +76,8 @@ color to partially break and incorrectly inherit the selected state's background
 - [ ] Tab2: on iOS 26 badge reads **12345...**; on iOS 18 **23456789** is visible.
 - [ ] Tab3's badge reads **NEW!**.
 - [ ] Tab4's badge reads **⚠️**.
+- [ ] All four badges use the iOS system default appearance — red background,
+      white text — because the selected Tab1 defines no badge colors.
 
 ---
 
@@ -154,6 +156,8 @@ normal (purple), also Tab2 badge is affected and its badge color is partially bl
 maximum and is truncated by the system).
 - [ ] Tab3's badge reads **NEW!**.
 - [ ] Tab4's badge reads **⚠️**.
+- [ ] All badges use the Android system default appearance — red background,
+      white text; the Tab1 dot is red.
 
 ---
 
@@ -161,7 +165,7 @@ maximum and is truncated by the system).
 
 2. Confirm Tab1 is active. Observe the Tab1 badge in the tab bar.
 
-- [ ] Selected tab: Badge shows as a small dot.
+- [ ] Selected tab: Badge shows as a small **red** dot.
 - [ ] Unselected tabs: The badge renders with the Android system default: red background with white text.
 
 ---

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-badge/scenario.md
@@ -36,7 +36,6 @@ Not covered:
 
 - On Android, validate only the background color for Tab1 (empty badge) and Tab4 (emoji) - their text color cannot be observed.
 
-
 `badgeValue`:
 
 - On Android the maximum badge string length rendered verbatim is 4

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -101,7 +101,7 @@ tabBarItemTitleFontColor - it's reported native bug.
 6. Tap the **Image** tab.
 
 - [ ] The icon swaps from the outline image to the filled image. Both renders use the original PNG
-  colors - the host `tabBarTintColor` (green) have NO effect on the selected icon.
+  colors - the host `tabBarTintColor` (green) has NO effect on the selected icon.
 - [ ] Title of selected tab is **green**.
 - [ ] Unselected titles stay in the system theme color.
 - [ ] On iOS 18 the unselected icon renders in **blue**.

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-item-icon/scenario.md
@@ -102,6 +102,8 @@ tabBarItemTitleFontColor - it's reported native bug.
 
 - [ ] The icon swaps from the outline image to the filled image. Both renders use the original PNG
   colors - the host `tabBarTintColor` (green) have NO effect on the selected icon.
+- [ ] Title of selected tab is **green**.
+- [ ] Unselected titles stay in the system theme color.
 - [ ] On iOS 18 the unselected icon renders in **blue**.
 - [ ] On iOS 26 the unselected icon renders in the system theme color.
 

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-color-scheme/scenario.md
@@ -77,6 +77,8 @@ Assumption:
 
 9. Cycle through `inherit` → `light` → `dark` → `light` → `inherit`
 
+- [ ] Tab bar color scheme updates immediately with each change, no crash or layout freeze
+
 ---
 
 ### Keyboard tab — simple check

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-experimental-user-interface-style-ios/scenario.md
@@ -34,7 +34,7 @@ Occasional flashes of the back button in the header are expected behavior and ar
 
 3. On `Home` screen click `Dark` button.
 
-  - [ ] Screen is shown with a black background. A single button to push the screen with dark style is visible.
+- [ ] Screen is shown with a black background. A single button to push the screen with dark style is visible.
 
 4. Tap **"Push screen with style: dark"** and observe tab bar.
 
@@ -44,7 +44,7 @@ Occasional flashes of the back button in the header are expected behavior and ar
 
 - [ ] Both tabs maintain the dark interface style. No flash, flicker, or reversion to light style on tab switch.
 
-1. Pop back to previous `Dark` screen and then pop back to the `Home` screen.
+6. Pop back to previous `Dark` screen and then pop back to the `Home` screen.
 
 - [ ] `Home` screen is shown with two buttons `Dark` and `Light`.
 
@@ -52,11 +52,11 @@ Occasional flashes of the back button in the header are expected behavior and ar
 
 7. Set system appearance to **dark**. Click `Light` button.
 
-  - [ ] Screen is shown with a white background. A single button to push the screen with light style is visible.
+- [ ] Screen is shown with a white background. A single button to push the screen with light style is visible.
 
 8. Push **"Push screen with style: light"** and observe tab bar.
 
-- [ ] `LightScreen` is pushed. The tab bar reflects a **light** style and appears without flash, flicker, or reversion to light style.
+- [ ] `LightScreen` is pushed. The tab bar reflects a **light** style and appears without flash, flicker, or reversion to dark style.
 
 9. Switch between **Tab1** and **Tab2** on the pushed screen.
 


### PR DESCRIPTION
## Description

Scenario corrections collected during the 4.27.0 and 5.0.0-alpha.2 release tests (tabs and Stack v5 Android). Each change either adds an expected result that was missing, states the actually observed color where the scenario only listed the configured one, or fixes a numbering/formatting slip. No test screens or e2e specs are touched.

Part of https://github.com/software-mansion/react-native-screens-labs/issues/1726 (the form-sheet items are handled in #4568; the test-split suggestions remain open).

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1726
## Changes

- `test-tabs-general-appearance-no-liquid-glass-ios`: steps 4–6 now describe the perceived tab bar color (light gray, milky bar with a purple shadow line — the `scrollEdgeAppearance` colors blended with the system default blur) and, after restoring defaults, the green view background visible through the bar plus the title colors.
- `test-tabs-item-icon`: iOS step 6 (Image tab) gains the title-color expectations — selected title green from the host `tabBarTintColor`, unselected titles in the system theme color.
- `test-tabs-tab-bar-experimental-user-interface-style-ios`: the "Pop back" step is numbered 6 (was 1); step 8 says "reversion to dark style" to match its dark-system section; checkbox indentation in steps 3 and 7 aligned with the rest.
- `test-tabs-appearance-defined-by-selected-tab` (Android): steps 1 and 6 distinguish the green icon from the lighter-green title and note that the active indicator shares the title's shade; step 7 notes that Tab4's `PlatformColor` green/blue are different, system-resolved shades from Tab1/Tab3.
- `test-tabs-tab-bar-color-scheme`: step 9 gets its missing expected result.
- `test-tabs-item-badge`: Android note reordered ("validate only the background color for Tab1 and Tab4 — their text color cannot be observed"); baseline steps on both platforms now state the badge colors (system default red/white; red dot on Android).
- `test-stack-animation-android`: background color references removed from steps 1 and 9.
