### PR TITLE
fix(Android, Stack v5): scope header back button to its own stack

### DIFF
--- a/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
+++ b/FabricExample/e2e/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack.e2e.ts
@@ -21,11 +21,12 @@ import {
  * the scenario for what is automated vs. manual, and for the direct-`App.tsx`
  * launch Android needs.
  *
- * Interception survives software-mansion/react-native-screens-labs#1459:
- * `StackScreenFragment` registers its `PreventNativeDismissCallback` after the
- * outer navigator's, and `OnBackPressedDispatcher` runs enabled callbacks in
- * reverse order — so the chevron is swallowed here even though an unintercepted
- * back press would navigate out of the example app's own navigation.
+ * Interception survives software-mansion/react-native-screens-labs#1459: the
+ * chevron never reaches the activity `OnBackPressedDispatcher` — the press is
+ * routed to the owning `StackContainer`, which resolves `preventNativeDismiss`
+ * itself (`wantsToPreventStackNativeDismiss`) before popping its own stack. Only
+ * the system back / gesture-back still relies on dispatcher callback ordering
+ * (`PreventNativeDismissCallback` registered after the outer navigator's).
  */
 
 // Matchers are built fresh on each call, never shared: on Android `atIndex`

--- a/android/src/main/java/com/swmansion/rnscreens/common/container/Container.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/container/Container.kt
@@ -9,4 +9,12 @@ interface Container {
      * (if any).
      */
     fun resolveCurrentContentScrollView(): ViewGroup?
+
+    /**
+     * Asked when this container's whole subtree is about to be natively dismissed,
+     * e.g. the screen hosting this container is popped. Returns the item that
+     * vetoes the dismissal via `preventNativeDismiss`, or null when nothing
+     * in the subtree does.
+     */
+    fun wantsToPreventStackNativeDismiss(): ContainerItem?
 }

--- a/android/src/main/java/com/swmansion/rnscreens/common/container/ContainerItem.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/common/container/ContainerItem.kt
@@ -2,7 +2,7 @@ package com.swmansion.rnscreens.common.container
 
 import android.view.ViewGroup
 
-internal interface ContainerItem {
+interface ContainerItem {
     // region Nested Container handling
 
     /**
@@ -25,6 +25,18 @@ internal interface ContainerItem {
      * @return Content scroll view associated with this container item.
      */
     fun findContentScrollView(): ViewGroup?
+
+    // endregion
+
+    // region Native dismissal
+
+    /**
+     * Asked when this item (screen) is about to be natively dismissed together
+     * with its subtree. The nested container (if any) is consulted first; its
+     * non-null answer wins, otherwise the item answers for itself, returning
+     * itself when it vetoes the dismissal or null otherwise.
+     */
+    fun wantsToPreventStackNativeDismiss(): ContainerItem?
 
     // endregion
 }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderBackPressHandler.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderBackPressHandler.kt
@@ -1,0 +1,11 @@
+package com.swmansion.rnscreens.stack.header
+
+import com.swmansion.rnscreens.stack.screen.StackScreen
+
+/**
+ * Receives presses of the native header back button. Implemented by the object
+ * managing the navigation state of the stack the pressed header belongs to.
+ */
+internal fun interface StackHeaderBackPressHandler {
+    fun handleHeaderBackButtonPress(pressedScreen: StackScreen)
+}

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -243,11 +243,9 @@ internal class StackHeaderCoordinatorLayout(
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // No onConfigurationChanged override is needed: this view never sets its own colorScheme,
     // so resolution always delegates to the parent provider, which does handle system changes.

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -7,10 +7,8 @@ import android.os.Parcelable
 import android.util.SparseArray
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
-import androidx.activity.OnBackPressedDispatcherOwner
 import androidx.appcompat.view.ContextThemeWrapper
 import androidx.coordinatorlayout.widget.CoordinatorLayout
-import com.facebook.react.bridge.ReactContext
 import com.google.android.material.R
 import com.google.android.material.appbar.AppBarLayout
 import com.swmansion.rnscreens.common.colorscheme.ColorSchemeCoordinator
@@ -35,6 +33,7 @@ internal class StackHeaderCoordinatorLayout(
     context: Context,
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
+    private val backPressHandler: StackHeaderBackPressHandler,
 ) : CoordinatorLayout(context),
     ColorSchemeProviding {
     // region Config attach / detach
@@ -140,10 +139,7 @@ internal class StackHeaderCoordinatorLayout(
     private var appBarLayout: StackHeaderAppBarLayout? = null
 
     private val onNavigationIconClick: () -> Unit = {
-        val activity =
-            (stackScreen.context as? ReactContext)?.currentActivity
-                as? OnBackPressedDispatcherOwner
-        activity?.onBackPressedDispatcher?.onBackPressed()
+        backPressHandler.handleHeaderBackButtonPress(stackScreen)
     }
 
     private fun processUpdate(
@@ -247,9 +243,11 @@ internal class StackHeaderCoordinatorLayout(
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // No onConfigurationChanged override is needed: this view never sets its own colorScheme,
     // so resolution always delegates to the parent provider, which does handle system changes.

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -13,10 +13,12 @@ import com.swmansion.rnscreens.common.colorscheme.ColorSchemeCoordinator
 import com.swmansion.rnscreens.common.colorscheme.ColorSchemeListener
 import com.swmansion.rnscreens.common.colorscheme.ColorSchemeProviding
 import com.swmansion.rnscreens.common.container.Container
+import com.swmansion.rnscreens.common.container.ContainerItem
 import com.swmansion.rnscreens.common.container.ParentContainerItemRegistry
 import com.swmansion.rnscreens.ext.isMeasured
 import com.swmansion.rnscreens.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.helpers.ViewIdGenerator
+import com.swmansion.rnscreens.stack.header.StackHeaderBackPressHandler
 import com.swmansion.rnscreens.stack.screen.StackScreen
 import com.swmansion.rnscreens.stack.screen.StackScreenFragment
 import com.swmansion.rnscreens.stack.screen.StackScreenFragmentDelegate
@@ -31,6 +33,7 @@ internal class StackContainer(
     Container,
     FragmentManager.OnBackStackChangedListener,
     ColorSchemeProviding,
+    StackHeaderBackPressHandler,
     StackScreenFragmentDelegate {
     private var fragmentManager: FragmentManager? = null
 
@@ -40,7 +43,8 @@ internal class StackContainer(
     /**
      * Will crash in case parent does not implement StackContainerParent interface.
      */
-    private fun containerParentOrNull(): StackContainerParent? = this.parent as StackContainerParent?
+    private fun containerParentOrNull(): StackContainerParent? =
+        this.parent as StackContainerParent?
 
     private val parentContainerRegistry = ParentContainerItemRegistry()
 
@@ -67,9 +71,11 @@ internal class StackContainer(
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // endregion
 
@@ -198,7 +204,8 @@ internal class StackContainer(
         }
 
         pendingPushOperations.forEach { operation ->
-            val newFragment = createFragmentForScreen(operation.screen, canNavigateBack = stackModel.isNotEmpty())
+            val newFragment =
+                createFragmentForScreen(operation.screen, canNavigateBack = stackModel.isNotEmpty())
 
             fragmentOps.add(
                 AddAndSetAsPrimaryOp(
@@ -239,7 +246,7 @@ internal class StackContainer(
         screen: StackScreen,
         canNavigateBack: Boolean,
     ): StackScreenFragment =
-        StackScreenFragment(screen, canNavigateBack, WeakReference(this)).also {
+        StackScreenFragment(screen, canNavigateBack, WeakReference(this), backPressHandler = this).also {
             Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
         }
 
@@ -323,6 +330,62 @@ internal class StackContainer(
         determineTopFragment()
             ?.stackScreen
             ?.findContentScrollView()
+
+    // Asked when this container's whole subtree is about to be dismissed (the screen
+    // hosting this container is popped) - every item gets a vote, back-to-front, so
+    // the deepest preventing screen wins.
+    override fun wantsToPreventStackNativeDismiss(): ContainerItem? =
+        stackModel.asReversed()
+            .firstNotNullOfOrNull { it.stackScreen.wantsToPreventStackNativeDismiss() }
+
+    // endregion
+
+    // region Header back button
+
+    override fun handleHeaderBackButtonPress(pressedScreen: StackScreen) {
+        val fragmentManager = fragmentManager
+        if (fragmentManager == null) {
+            Log.w(TAG, "[RNScreens] Ignoring header back button press - container is detached")
+            return
+        }
+
+        val topScreen = stackModel.lastOrNull()?.stackScreen
+        if (topScreen !== pressedScreen || stackModel.size <= 1) {
+            Log.w(
+                TAG,
+                "[RNScreens] Ignoring header back button press for non-top screen ${pressedScreen.screenKey}"
+            )
+            return
+        }
+
+        // This pop dismisses only the top screen (together with its subtree), therefore
+        // only the top item is asked - screens below the top get no vote at this level.
+        val vetoingItem = topScreen.wantsToPreventStackNativeDismiss()
+        if (vetoingItem != null) {
+            // Only a StackScreen can veto - TabsScreen has no own flag and only forwards.
+            val vetoingScreen = vetoingItem as? StackScreen
+            if (vetoingScreen != null) {
+                vetoingScreen.onNativeDismissPrevented()
+            } else {
+                Log.w(
+                    TAG,
+                    "[RNScreens] Unexpected vetoing item type: ${vetoingItem.javaClass.simpleName}"
+                )
+            }
+            return
+        }
+
+        // Mirrors FragmentManager's internal OnBackPressedCallback, which also runs
+        // popBackStackImmediate. The synchronous pop makes the top-screen guard above
+        // reliable against double taps: onBackStackChangeCommitted -> onNativeFragmentPop
+        // updates stackModel before this call returns.
+        fragmentManager.popBackStackImmediate(
+            // key MUST BE present, otherwise the navigation action will be delegated to child primary navigation
+            // fragment.
+            checkNotNull(pressedScreen.screenKey) { "[RNScreens] Screen key is required" },
+            FragmentManager.POP_BACK_STACK_INCLUSIVE
+        )
+    }
 
     // endregion
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -43,8 +43,7 @@ internal class StackContainer(
     /**
      * Will crash in case parent does not implement StackContainerParent interface.
      */
-    private fun containerParentOrNull(): StackContainerParent? =
-        this.parent as StackContainerParent?
+    private fun containerParentOrNull(): StackContainerParent? = this.parent as StackContainerParent?
 
     private val parentContainerRegistry = ParentContainerItemRegistry()
 
@@ -71,11 +70,9 @@ internal class StackContainer(
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // endregion
 
@@ -335,7 +332,8 @@ internal class StackContainer(
     // hosting this container is popped) - every item gets a vote, back-to-front, so
     // the deepest preventing screen wins.
     override fun wantsToPreventStackNativeDismiss(): ContainerItem? =
-        stackModel.asReversed()
+        stackModel
+            .asReversed()
             .firstNotNullOfOrNull { it.stackScreen.wantsToPreventStackNativeDismiss() }
 
     // endregion
@@ -353,7 +351,7 @@ internal class StackContainer(
         if (topScreen !== pressedScreen || stackModel.size <= 1) {
             Log.w(
                 TAG,
-                "[RNScreens] Ignoring header back button press for non-top screen ${pressedScreen.screenKey}"
+                "[RNScreens] Ignoring header back button press for non-top screen ${pressedScreen.screenKey}",
             )
             return
         }
@@ -369,7 +367,7 @@ internal class StackContainer(
             } else {
                 Log.w(
                     TAG,
-                    "[RNScreens] Unexpected vetoing item type: ${vetoingItem.javaClass.simpleName}"
+                    "[RNScreens] Unexpected vetoing item type: ${vetoingItem.javaClass.simpleName}",
                 )
             }
             return
@@ -383,7 +381,7 @@ internal class StackContainer(
             // key MUST BE present, otherwise the navigation action will be delegated to child primary navigation
             // fragment.
             checkNotNull(pressedScreen.screenKey) { "[RNScreens] Screen key is required" },
-            FragmentManager.POP_BACK_STACK_INCLUSIVE
+            FragmentManager.POP_BACK_STACK_INCLUSIVE,
         )
     }
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackContainer.kt
@@ -243,7 +243,12 @@ internal class StackContainer(
         screen: StackScreen,
         canNavigateBack: Boolean,
     ): StackScreenFragment =
-        StackScreenFragment(screen, canNavigateBack, WeakReference(this), backPressHandler = this).also {
+        StackScreenFragment(
+            screen,
+            canNavigateBack,
+            WeakReference(this),
+            backPressHandler = WeakReference(this),
+        ).also {
             Log.d(TAG, "Created Fragment $it for screen ${screen.screenKey}")
         }
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
@@ -175,4 +175,8 @@ class StackScreen(
     override fun resolveNestedContainer(): Container? = containerItemSupport.resolveNestedContainer()
 
     override fun findContentScrollView(): ViewGroup? = containerItemSupport.findContentScrollView(this)
+
+    override fun wantsToPreventStackNativeDismiss(): ContainerItem? =
+        resolveNestedContainer()?.wantsToPreventStackNativeDismiss()
+            ?: takeIf { isPreventNativeDismissEnabled }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -2,12 +2,14 @@ package com.swmansion.rnscreens.stack.screen
 
 import android.content.res.Configuration
 import android.os.Bundle
+import android.util.Log
 import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
 import androidx.transition.Slide
+import com.swmansion.rnscreens.stack.header.StackHeaderBackPressHandler
 import com.swmansion.rnscreens.stack.header.StackHeaderCoordinatorLayout
 import java.lang.ref.WeakReference
 
@@ -15,7 +17,11 @@ internal class StackScreenFragment(
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
     private val delegate: WeakReference<StackScreenFragmentDelegate>,
+    backPressHandler: StackHeaderBackPressHandler,
 ) : Fragment() {
+    // Weakly held so that a fragment retained by FragmentManager past container teardown
+    // does not keep the container view subtree alive.
+    private val backPressHandler: WeakReference<StackHeaderBackPressHandler> = WeakReference(backPressHandler)
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
     /**
@@ -48,7 +54,11 @@ internal class StackScreenFragment(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
-    ): View = StackHeaderCoordinatorLayout(requireContext(), stackScreen, canNavigateBack)
+    ): View =
+        StackHeaderCoordinatorLayout(requireContext(), stackScreen, canNavigateBack) { pressedScreen ->
+            backPressHandler.get()?.handleHeaderBackButtonPress(pressedScreen)
+                ?: Log.w(TAG, "[RNScreens] Header back button press dropped - handler is gone")
+        }
 
     override fun onViewCreated(
         view: View,
@@ -116,5 +126,9 @@ internal class StackScreenFragment(
     private fun teardownPreventNativeDismissCallback() {
         requireNativeDismissBackPressedCallback.remove()
         preventNativeDismissBackPressedCallback = null
+    }
+
+    companion object {
+        private const val TAG = "StackScreenFragment"
     }
 }

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -19,8 +19,6 @@ internal class StackScreenFragment(
     private val delegate: WeakReference<StackScreenFragmentDelegate>,
     backPressHandler: StackHeaderBackPressHandler,
 ) : Fragment() {
-    // Weakly held so that a fragment retained by FragmentManager past container teardown
-    // does not keep the container view subtree alive.
     private val backPressHandler: WeakReference<StackHeaderBackPressHandler> = WeakReference(backPressHandler)
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreenFragment.kt
@@ -17,9 +17,8 @@ internal class StackScreenFragment(
     internal val stackScreen: StackScreen,
     private val canNavigateBack: Boolean,
     private val delegate: WeakReference<StackScreenFragmentDelegate>,
-    backPressHandler: StackHeaderBackPressHandler,
+    private val backPressHandler: WeakReference<StackHeaderBackPressHandler>,
 ) : Fragment() {
-    private val backPressHandler: WeakReference<StackHeaderBackPressHandler> = WeakReference(backPressHandler)
     private var screenLifecycleEventEmitter: StackScreenAppearanceEventsEmitter? = null
 
     /**

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
@@ -24,6 +24,7 @@ import com.swmansion.rnscreens.common.colorscheme.ColorSchemeCoordinator
 import com.swmansion.rnscreens.common.colorscheme.ColorSchemeListener
 import com.swmansion.rnscreens.common.colorscheme.ColorSchemeProviding
 import com.swmansion.rnscreens.common.container.Container
+import com.swmansion.rnscreens.common.container.ContainerItem
 import com.swmansion.rnscreens.common.container.ParentContainerItemRegistry
 import com.swmansion.rnscreens.helpers.FragmentManagerHelper
 import com.swmansion.rnscreens.helpers.ViewFinder
@@ -778,6 +779,10 @@ class TabsContainer internal constructor(
         // We assume here that the selectedTab actually corresponds to whats in FragmentManager
         return selectedTab.tabsScreen.findContentScrollView()
     }
+
+    // Only the active item is consulted - a preventing screen inside an inactive tab
+    // does not veto the dismissal.
+    override fun wantsToPreventStackNativeDismiss(): ContainerItem? = selectedTab.tabsScreen.wantsToPreventStackNativeDismiss()
 
     // endregion
 

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
@@ -215,11 +215,9 @@ class TabsContainer internal constructor(
         }
     }
 
-    fun addNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean =
-        observerRegistry.add(observer)
+    fun addNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.add(observer)
 
-    fun removeNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean =
-        observerRegistry.remove(observer)
+    fun removeNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.remove(observer)
 
     // endregion
 
@@ -390,16 +388,13 @@ class TabsContainer internal constructor(
         }
     }
 
-    override fun getInterfaceInsets(): EdgeInsets =
-        EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
+    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
-        colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // endregion
 
@@ -430,7 +425,7 @@ class TabsContainer internal constructor(
     override fun getFragmentForTabsScreen(tabsScreen: TabsScreen): TabsScreenFragment? =
         tabsModel.find {
             it.tabsScreen ===
-                    tabsScreen
+                tabsScreen
         }
 
     override fun onFragmentConfigurationChange(
@@ -501,7 +496,7 @@ class TabsContainer internal constructor(
         if (pendingStateUpdateRequest == null) {
             RNSLog.w(
                 TAG,
-                "TabsContainer::performSelectedTabUpdate called w/o pending operation; skipping update"
+                "TabsContainer::performSelectedTabUpdate called w/o pending operation; skipping update",
             )
             return
         }
@@ -528,7 +523,7 @@ class TabsContainer internal constructor(
             // This triggers on OnMenuItemClicked callback, where we perform actual update from
             bottomNavigationView.setSelectedItemIdWithActionOrigin(
                 nextSelectedMenuItemId,
-                stateUpdateRequest.actionOrigin
+                stateUpdateRequest.actionOrigin,
             )
             isInExternalOperationContext = false
         } else {
@@ -546,9 +541,9 @@ class TabsContainer internal constructor(
         val menu = bottomNavigationView.menu
         val isMenuInSync =
             menu.size == tabsModel.size &&
-                    tabsModel.withIndex().all { (index, fragment) ->
-                        menu.getItem(index).itemId == fragment.menuItemId
-                    }
+                tabsModel.withIndex().all { (index, fragment) ->
+                    menu.getItem(index).itemId == fragment.menuItemId
+                }
 
         if (isMenuInSync) {
             return
@@ -590,7 +585,7 @@ class TabsContainer internal constructor(
         progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
         applyNextSelectedFragmentToFragmentManagerSync(
             currentSelectedFragment,
-            nextSelectedFragment
+            nextSelectedFragment,
         )
         return true
     }
@@ -737,8 +732,7 @@ class TabsContainer internal constructor(
         appearanceCoordinator.updateTabAppearance(themedContext, this)
     }
 
-    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? =
-        tabsModel.find { it.menuItemId == itemId }
+    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? = tabsModel.find { it.menuItemId == itemId }
 
     private fun getMenuItemIdForFragment(tabsScreenFragment: TabsScreenFragment): Int? =
         tabsScreenFragment.menuItemId.takeIf { tabsModel.any { it === tabsScreenFragment } }
@@ -755,8 +749,7 @@ class TabsContainer internal constructor(
                 bottomNavigationView.menu.findItem(fragment.menuItemId)
             }
 
-    private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? =
-        tabsModel.find { it.requireScreenKey == screenKey }
+    private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? = tabsModel.find { it.requireScreenKey == screenKey }
 
     private fun requireFragmentForScreenKey(screenKey: String): TabsScreenFragment =
         checkNotNull(getFragmentForScreenKey(screenKey)) {
@@ -801,7 +794,12 @@ class TabsContainer internal constructor(
 
     // Only the active item is consulted - a preventing screen inside an inactive tab
     // does not veto the dismissal.
-    override fun wantsToPreventStackNativeDismiss(): ContainerItem? = selectedTab.tabsScreen.wantsToPreventStackNativeDismiss()
+    override fun wantsToPreventStackNativeDismiss(): ContainerItem? =
+        if (navState.isNotEmpty()) {
+            selectedTab.tabsScreen.wantsToPreventStackNativeDismiss()
+        } else {
+            null
+        }
 
     // endregion
 
@@ -815,8 +813,7 @@ internal class TabsContainerInvalidationFlags(
     var isNavigationMenuAppearanceInvalidated: Boolean = false,
     var isNavigationMenuStructureInvalidated: Boolean = false,
 ) {
-    internal fun any(): Boolean =
-        isSelectedTabInvalidated || isNavigationMenuAppearanceInvalidated || isNavigationMenuStructureInvalidated
+    internal fun any(): Boolean = isSelectedTabInvalidated || isNavigationMenuAppearanceInvalidated || isNavigationMenuStructureInvalidated
 
     internal fun invalidateAll() {
         isSelectedTabInvalidated = true

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/container/TabsContainer.kt
@@ -68,7 +68,8 @@ class TabsContainer internal constructor(
             val selectedTabScreen = this@TabsContainer.selectedTab.tabsScreen
 
             if (selectedTabScreen.shouldUseRepeatedTabSelectionPopToRootSpecialEffect) {
-                val screenStack = ViewFinder.findScreenStackInFirstDescendantChain(selectedTabScreen)
+                val screenStack =
+                    ViewFinder.findScreenStackInFirstDescendantChain(selectedTabScreen)
                 if (screenStack != null && screenStack.popToRoot()) {
                     return true
                 }
@@ -214,9 +215,11 @@ class TabsContainer internal constructor(
         }
     }
 
-    fun addNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.add(observer)
+    fun addNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean =
+        observerRegistry.add(observer)
 
-    fun removeNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean = observerRegistry.remove(observer)
+    fun removeNavigationStateObserver(observer: TabsNavigationStateObserver): Boolean =
+        observerRegistry.remove(observer)
 
     // endregion
 
@@ -387,13 +390,16 @@ class TabsContainer internal constructor(
         }
     }
 
-    override fun getInterfaceInsets(): EdgeInsets = EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
+    override fun getInterfaceInsets(): EdgeInsets =
+        EdgeInsets(0.0f, 0.0f, 0.0f, bottomNavigationView.height.toFloat())
 
     override fun getResolvedUiNightMode() = colorSchemeCoordinator.getResolvedUiNightMode()
 
-    override fun addColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.addColorSchemeListener(listener)
+    override fun addColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.addColorSchemeListener(listener)
 
-    override fun removeColorSchemeListener(listener: ColorSchemeListener) = colorSchemeCoordinator.removeColorSchemeListener(listener)
+    override fun removeColorSchemeListener(listener: ColorSchemeListener) =
+        colorSchemeCoordinator.removeColorSchemeListener(listener)
 
     // endregion
 
@@ -424,7 +430,7 @@ class TabsContainer internal constructor(
     override fun getFragmentForTabsScreen(tabsScreen: TabsScreen): TabsScreenFragment? =
         tabsModel.find {
             it.tabsScreen ===
-                tabsScreen
+                    tabsScreen
         }
 
     override fun onFragmentConfigurationChange(
@@ -493,7 +499,10 @@ class TabsContainer internal constructor(
 
     private fun performSelectedTabUpdate() {
         if (pendingStateUpdateRequest == null) {
-            RNSLog.w(TAG, "TabsContainer::performSelectedTabUpdate called w/o pending operation; skipping update")
+            RNSLog.w(
+                TAG,
+                "TabsContainer::performSelectedTabUpdate called w/o pending operation; skipping update"
+            )
             return
         }
 
@@ -517,7 +526,10 @@ class TabsContainer internal constructor(
         if (bottomNavigationView.selectedItemId != nextSelectedMenuItemId || navState.isEmpty()) {
             isInExternalOperationContext = true
             // This triggers on OnMenuItemClicked callback, where we perform actual update from
-            bottomNavigationView.setSelectedItemIdWithActionOrigin(nextSelectedMenuItemId, stateUpdateRequest.actionOrigin)
+            bottomNavigationView.setSelectedItemIdWithActionOrigin(
+                nextSelectedMenuItemId,
+                stateUpdateRequest.actionOrigin
+            )
             isInExternalOperationContext = false
         } else {
             observerRegistry.emitOnNavigationStateUpdateRejected(
@@ -534,9 +546,9 @@ class TabsContainer internal constructor(
         val menu = bottomNavigationView.menu
         val isMenuInSync =
             menu.size == tabsModel.size &&
-                tabsModel.withIndex().all { (index, fragment) ->
-                    menu.getItem(index).itemId == fragment.menuItemId
-                }
+                    tabsModel.withIndex().all { (index, fragment) ->
+                        menu.getItem(index).itemId == fragment.menuItemId
+                    }
 
         if (isMenuInSync) {
             return
@@ -576,7 +588,10 @@ class TabsContainer internal constructor(
         }
 
         progressNavigationState(nextSelectedFragment.requireScreenKey, actionOrigin)
-        applyNextSelectedFragmentToFragmentManagerSync(currentSelectedFragment, nextSelectedFragment)
+        applyNextSelectedFragmentToFragmentManagerSync(
+            currentSelectedFragment,
+            nextSelectedFragment
+        )
         return true
     }
 
@@ -646,7 +661,8 @@ class TabsContainer internal constructor(
             return false
         }
 
-        val stateChanged = updateNavigationStateAndSelectedFragment(nextSelectedFragment, actionOrigin)
+        val stateChanged =
+            updateNavigationStateAndSelectedFragment(nextSelectedFragment, actionOrigin)
 
         val hasTriggeredSpecialEffect =
             if (isRepeated) specialEffectsHandler.handleRepeatedTabSelection() else false
@@ -691,7 +707,8 @@ class TabsContainer internal constructor(
 
         // We expect at most a single fragment added (detached fragments are not returned from
         // FragmentManager.getFragments call) and it being the currently selected tab.
-        val isInUpToDateState = currentFragments.size == 1 && currentFragments.first() === selectedTab
+        val isInUpToDateState =
+            currentFragments.size == 1 && currentFragments.first() === selectedTab
         if (isInUpToDateState) {
             return
         } else if (currentFragments.isEmpty()) {
@@ -720,7 +737,8 @@ class TabsContainer internal constructor(
         appearanceCoordinator.updateTabAppearance(themedContext, this)
     }
 
-    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? = tabsModel.find { it.menuItemId == itemId }
+    private fun getFragmentForMenuItemId(itemId: Int): TabsScreenFragment? =
+        tabsModel.find { it.menuItemId == itemId }
 
     private fun getMenuItemIdForFragment(tabsScreenFragment: TabsScreenFragment): Int? =
         tabsScreenFragment.menuItemId.takeIf { tabsModel.any { it === tabsScreenFragment } }
@@ -737,7 +755,8 @@ class TabsContainer internal constructor(
                 bottomNavigationView.menu.findItem(fragment.menuItemId)
             }
 
-    private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? = tabsModel.find { it.requireScreenKey == screenKey }
+    private fun getFragmentForScreenKey(screenKey: String): TabsScreenFragment? =
+        tabsModel.find { it.requireScreenKey == screenKey }
 
     private fun requireFragmentForScreenKey(screenKey: String): TabsScreenFragment =
         checkNotNull(getFragmentForScreenKey(screenKey)) {
@@ -796,7 +815,8 @@ internal class TabsContainerInvalidationFlags(
     var isNavigationMenuAppearanceInvalidated: Boolean = false,
     var isNavigationMenuStructureInvalidated: Boolean = false,
 ) {
-    internal fun any(): Boolean = isSelectedTabInvalidated || isNavigationMenuAppearanceInvalidated || isNavigationMenuStructureInvalidated
+    internal fun any(): Boolean =
+        isSelectedTabInvalidated || isNavigationMenuAppearanceInvalidated || isNavigationMenuStructureInvalidated
 
     internal fun invalidateAll() {
         isSelectedTabInvalidated = true

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
@@ -189,6 +189,10 @@ class TabsScreen(
 
     override fun findContentScrollView(): ViewGroup? = containerItemSupport.findContentScrollView(this)
 
+    // TabsScreen has no `preventNativeDismiss` flag of its own - it only forwards
+    // the question to its nested container.
+    override fun wantsToPreventStackNativeDismiss(): ContainerItem? = resolveNestedContainer()?.wantsToPreventStackNativeDismiss()
+
     // endregion
 
     companion object {

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-lifecycle-events/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-lifecycle-events/scenario.md
@@ -93,15 +93,19 @@ Incomplete.
   gesture / system back) must **not** change which events fire - all three
   produce the same pop event set for the same transition. This holds at every
   level: the top-level stack, the inner nested stack, and the container
-  boundary.
+  boundary. Note that the **outer** header back button triggers the
+  container-pop transition even while a deeper nested screen is active,
+  whereas the Android system back / gesture-back from that same screen pops
+  the innermost screen - those are different transitions, each with its own
+  event set (see step 14).
 
 - The pushed `NestedStack` route keeps its own header, so inside the
-  nested stack there are **two back buttons**. On iOS the **inner** one (in the active
-  nested screen's header) pops within the nested stack, while the **outer** one
-  (in the `NestedStack` header) pops the **whole container**
-  back to `Home` in a single step - even from `NestedA`, skipping `NestedHome`.
-  On Android there is no such shortcut: the toolbar back arrow (like the system
-  back) always pops the **innermost** screen first, one level at a time.
+  nested stack there are **two back buttons**. On both platforms the **inner**
+  one (in the active nested screen's header) pops within the nested stack,
+  while the **outer** one (in the `NestedStack` header) pops the **whole
+  container** back to `Home` in a single step - even from `NestedA`. The
+  Android system back / gesture-back has no such shortcut: it always pops the
+  **innermost** screen first, one level at a time.
 
 - Toasts stack and dismiss automatically. To dismiss a toast manually, tap
   it. Toast background colors by event type: `onWillAppear` - green,
@@ -215,8 +219,8 @@ Incomplete.
 - [ ] Screen **NestedA** (header title "NestedA") is pushed **inside the
   nested stack**. **Two stacked headers** remain visible - the outer
   **NestedStack** header above the inner **NestedA**
-  header - so NestedA shows **two back buttons**;
-  on Android the toolbar back arrow always pops the innermost screen first.
+  header - so NestedA shows **two back buttons** (the inner one pops within
+  the nested stack, the outer one pops the whole container - see step 14).
   Only the inner screens fire - the outer `NestedStack` route and `Home` stay
   silent - so this behaves exactly like a top-level push (step 2):
 
@@ -354,12 +358,16 @@ Incomplete.
   5. `NestedA: onDidDisappear`
   6. `Home: onDidAppear`
 
-- [ ] **Android** - there is **no boundary shortcut**: the toolbar back arrow
-  always pops the **innermost** screen first, so tapping it on `NestedA` pops
-  **only NestedA → NestedHome** and does **not** dismiss the container. The
-  event set is identical to the inner pop in step 8 - two toasts:
-  1. `NestedA: onWillDisappear`
-  2. `NestedA: onDidDisappear`
-
-  To then pop the whole container on Android, press back again from
-  **NestedHome** (the container-pop event set of step 11).
+- [ ] **Android** - the outer back arrow likewise pops the **whole NestedStack
+  container** in one step, going **NestedA → Home**. Unlike iOS, `NestedHome`
+  **does** fire its disappear events here: it never fired them when `NestedA`
+  was pushed (on Android a covered screen stays silent), so the container
+  teardown emits them now. All `onWillDisappear`s fire first (inner screens in
+  push order, then the outer route), then the `onDidDisappear`s in the same
+  order - six toasts, `Home` fires nothing:
+  1. `NestedHome: onWillDisappear`
+  2. `NestedA: onWillDisappear`
+  3. `NestedStack: onWillDisappear`
+  4. `NestedHome: onDidDisappear`
+  5. `NestedA: onDidDisappear`
+  6. `NestedStack: onDidDisappear`

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/scenario.md
@@ -89,6 +89,14 @@ Manual only (not automated):
   once (e.g. **B**, then **NestedStack** → **NestedHome**), only the current
   top screen intercepts native dismissal; ancestors further down are not
   reached until the current screen stops intercepting.
+- The two dismissal triggers resolve interception differently, though in this
+  scenario the observable outcomes coincide. The **system back / gesture-back**
+  goes through the activity-level back dispatcher, where the top screen's
+  callback intercepts. The **header back chevron** is resolved within the
+  pressed header's own stack container: any screen the pop would natively
+  dismiss - the container's top screen, or (for a screen hosting a nested
+  stack) any screen of that nested subtree, consulted deepest-first - can veto
+  the pop, and the vetoing screen fires `onNativeDismissPrevented`.
 
 ## Steps
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack/scenario.md
@@ -12,7 +12,9 @@ stack. When the flag is **Disabled**, native back pops normally: a non-root
 screen pops within its stack, and the nested root pops the whole nested
 stack back into the parent. The on-screen **Pop** button always pops
 regardless of the flag. Also verifies that when several ancestors prevent at
-once, only the current top screen intercepts. See the Notes for `routeKey`
+once, only the current top screen intercepts, and that system-back
+interception survives the app being backgrounded and foregrounded (an
+activity stop/start cycle, issue #1775). See the Notes for `routeKey`
 behavior and how Android is launched directly to work around issue #1459.
 
 **OS test creation version:** Android API Level 36.
@@ -40,6 +42,7 @@ Manual only (not automated):
 - Pop actions triggered by the system back gesture (edge swipe).
 - Pop actions triggered by the header back chevron when `preventNativeDismiss`
   is Disabled.
+- Interception after the app is backgrounded and foregrounded (issue #1775).
 - Screen and toast colors, and that **NestedHome** shows no header at all.
 
 ## Prerequisites
@@ -89,14 +92,24 @@ Manual only (not automated):
   once (e.g. **B**, then **NestedStack** → **NestedHome**), only the current
   top screen intercepts native dismissal; ancestors further down are not
   reached until the current screen stops intercepting.
-- The two dismissal triggers resolve interception differently, though in this
-  scenario the observable outcomes coincide. The **system back / gesture-back**
-  goes through the activity-level back dispatcher, where the top screen's
-  callback intercepts. The **header back chevron** is resolved within the
-  pressed header's own stack container: any screen the pop would natively
-  dismiss - the container's top screen, or (for a screen hosting a nested
-  stack) any screen of that nested subtree, consulted deepest-first - can veto
-  the pop, and the vetoing screen fires `onNativeDismissPrevented`.
+- Both dismissal triggers resolve interception per stack container with the
+  same rule: any screen the pop would natively dismiss - the container's top
+  screen, or (for a screen hosting a nested stack) any screen of that nested
+  subtree, consulted deepest-first - can veto the pop, and the vetoing screen
+  fires `onNativeDismissPrevented`. The **header back chevron** asks the
+  pressed header's own container. The **system back / gesture-back** goes
+  through the activity's back dispatcher, where every stack container keeps a
+  veto callback that is enabled only while its subtree has a vetoing screen.
+  Whichever container's callback runs, the vetoing screen is looked up
+  deepest-first, so the nested top screen's toast fires rather than an outer
+  ancestor's.
+- The system-back veto is re-registered together with the container's
+  `FragmentManager` on every activity start, so it keeps priority over the
+  framework's own pop handling after the app is backgrounded and foregrounded
+  (home, app switch, lock screen). Issue
+  [#1775](https://github.com/software-mansion/react-native-screens-labs/issues/1775)
+  tracks the regression where it did not: after one stop/start cycle the
+  first system back popped the preventing screen natively, with no toast.
 
 ## Steps
 
@@ -284,3 +297,48 @@ Manual only (not automated):
 26. On **B**, tap the on-screen **Pop** button.
 
 - [ ] App pops back to screen **A** normally. No toast is shown.
+
+### Interception survives an activity restart (issue #1775)
+
+27. From **A**, tap **Push NestedStack**. On **NestedHome** (prevent
+    Enabled), send the app to the background (swipe up from the bottom edge
+    to the launcher, or press **Home**), then bring it back to the foreground
+    (recents or the app icon).
+
+- [ ] The app resumes on **NestedHome** with the same `Key` as before
+      backgrounding and **Prevent native dismiss: Enabled**.
+
+28. On **NestedHome**, perform a system gesture-back.
+
+- [ ] The gesture is intercepted: the "Native dismiss prevented - NestedHome"
+      toast appears and the app stays on **NestedHome**; it does **not** exit
+      the nested stack back to **A**. This is the regression from issue
+      #1775: before the fix, the first system back after a
+      background/foreground cycle popped the whole **NestedStack** with no
+      toast.
+
+29. Background and foreground the app a second time, then perform a system
+    gesture-back on **NestedHome** again.
+
+- [ ] Still intercepted with the same toast; the app stays on **NestedHome**.
+      Repeated restarts do not degrade interception.
+
+30. On **NestedHome**, tap **Push NestedB**. Background and foreground the
+    app, then on **NestedB** (prevent Enabled) perform a system gesture-back.
+
+- [ ] The gesture is intercepted: the "Native dismiss prevented - NestedB"
+      toast appears and the app stays on **NestedB** — a non-root nested
+      screen keeps intercepting after the restart as well.
+
+31. On **NestedB**, tap **Push NestedA**. Background and foreground the app,
+    then on **NestedA** (prevent Disabled) perform a system gesture-back.
+
+- [ ] The gesture pops normally back to **NestedB**, whose `Key` is unchanged
+      from step 30. No toast is shown — the preventing screens below
+      (**NestedB**, **NestedHome**) do not over-block after the restart.
+
+32. On **NestedB** (top screen again, prevent Enabled), perform a system
+    gesture-back.
+
+- [ ] The gesture is intercepted: the "Native dismiss prevented - NestedB"
+      toast appears and the app stays on **NestedB**.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -168,3 +168,15 @@ is Disabled - including the pop expected after toggling **B** to Disabled.
 - [ ] The most recent toggle takes effect before the back press: since
       prevent is Enabled at press time, back is intercepted (toast shown, app
       stays on **B**).
+
+### Android: prevent native dismiss mechanism keeps working after activity backgrounding
+
+14. From **Home**, tap **Push B**. On **B** tap back button. 
+
+    - [ ] A green toast appears and the app remains on **B**. 
+
+15. Move the app to background by moving focus to the launcher screen.
+    Open the aplication again (focus it). Screen **B** is visible.
+    Tap on the back button chevron.
+
+    - [ ] A green toast appears and the app remains on **B**.

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-single-stack/scenario.md
@@ -173,10 +173,10 @@ is Disabled - including the pop expected after toggling **B** to Disabled.
 
 14. From **Home**, tap **Push B**. On **B** tap back button. 
 
-    - [ ] A green toast appears and the app remains on **B**. 
+- [ ] A green toast appears and the app remains on **B**. 
 
 15. Move the app to background by moving focus to the launcher screen.
     Open the aplication again (focus it). Screen **B** is visible.
     Tap on the back button chevron.
 
-    - [ ] A green toast appears and the app remains on **B**.
+- [ ] A green toast appears and the app remains on **B**.


### PR DESCRIPTION
## Description

With a stack nested inside another stack, two headers are visible, each with its own back button. Pressing the **outer** header's back button is expected to pop the outer screen together with its whole nested stack (which is how iOS behaves). On Android it popped only the top screen of the **inner** stack instead.

Root cause: the header back button called `activity.onBackPressedDispatcher.onBackPressed()`, i.e. global back dispatch. The activity-level `OnBackPressedDispatcher` runs the newest enabled callback in its deque, which for a nested stack is the inner `FragmentManager`'s internal back callback — so a button with scoped ("pop *my* screen") semantics was routed through an unscoped mechanism.

The header back button press is now routed directly to the `StackContainer` that owns the pressed header, which resolves `preventNativeDismiss` itself and pops its own stack. System back / gesture-back is intentionally unchanged and still goes through the activity dispatcher (reworking that path is planned as a follow-up).

Closes software-mansion/react-native-screens-labs#1649.

## Changes

- Added internal `StackHeaderBackPressHandler` (SAM). `StackContainer` implements it and passes itself when creating `StackScreenFragment`; the fragment (holding it weakly) hands it to `StackHeaderCoordinatorLayout`, whose navigation-icon click now invokes the handler instead of the activity's `OnBackPressedDispatcher`.
- `StackContainer.handleHeaderBackButtonPress` guards against stale presses (pressed screen must be the current top, stack depth > 1, container attached), then pops via `popBackStackImmediate(screenKey, POP_BACK_STACK_INCLUSIVE)` on its own `FragmentManager`. The no-arg form must not be used here — it delegates the pop to the child primary-navigation fragment's back stack, reintroducing the bug.
- Added a recursive veto query to the `Container` / `ContainerItem` interfaces: `wantsToPreventStackNativeDismiss(): ContainerItem?`. An item consults its nested container first (non-null answer wins), otherwise answers for itself via its `preventNativeDismiss` flag. A nested `StackContainer` polls its items back-to-front (every screen dismissed with the subtree gets a vote, deepest wins); `TabsContainer` consults only its active item. On a veto, the vetoing screen fires `onNativeDismissPrevented`; otherwise the pop proceeds.
- `ContainerItem` is now public (was internal) so the public `Container` interface can reference it in the new query's signature.
- Updated `test-stack-lifecycle-events` and `test-stack-prevent-native-dismiss-nested-stack` scenarios and a stale e2e spec comment to describe the new behavior.

## Before & after - visual documentation

Setup: outer stack `Home → NestedStack`, inner stack `NestedHome → NestedA`, both headers visible, outer back button pressed on `NestedA`.

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/8ee31389-894b-4d1d-8624-8788518425f3" alt="before" /> | <video src="https://github.com/user-attachments/assets/8c14d4fe-0828-4ef6-86b8-7e2c9cac0423" alt="before" /> |

<!-- TODO: attach before/after screen recordings -->

## Test plan

Verified manually on a Pixel 9 Pro emulator (API 36), FabricExample debug build, with the test screens launched directly via `apps/App.tsx`:

- `apps/src/tests/single-feature-tests/stack-v5/test-stack-lifecycle-events` — the fixed case (step 14: outer back button on `NestedA` → `Home`, Android toast order captured empirically and written into the scenario) plus regressions: single-stack header pop, outer back button at the nested root, inner back button popping within the nested stack, system back popping innermost-first and exiting the container at the nested root. No JS-side errors from the multi-screen dismiss (`onDismiss` storm handled cleanly).
- `apps/src/tests/single-feature-tests/stack-v5/test-stack-prevent-native-dismiss-nested-stack` — steps 4, 5, 6, 7, 10, 16, 18: header-button interception on enabled screens (one toast per press, incl. rapid repeated presses), system-back interception unchanged, disabled-flag pops unchanged.
- `test-stack-prevent-native-dismiss-single-stack` — header path is identical by construction with no nesting (same code path as the B-screen checks above).
- Existing Detox specs for both prevent-dismiss scenarios need no assertion changes.

Repro of the original issue: push `NestedStack`, push `NestedA`, tap the **outer** header back button — before this change only `NestedA` pops.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes