### PR TITLE
fix(Android, Stack v5): handle forceLayout to ensure Stack is properly laid out on configuration change

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
@@ -122,6 +122,16 @@ class StackHost(
         refreshLayout()
     }
 
+    // On window configuration changes ViewRootImpl calls forceLayout() recursively on every view
+    // in the hierarchy, bypassing requestLayout(). React views never lay out their children during
+    // framework traversals, so nothing would clear the force-layout flags in our subtree — and once
+    // they are set, any subsequent requestLayout() from a descendant short-circuits before reaching
+    // the override above, permanently disabling the manual pass. Schedule it from here as well.
+    override fun forceLayout() {
+        super.forceLayout()
+        refreshLayout()
+    }
+
     private fun refreshLayout() {
         if (!isLayoutEnqueued) {
             isLayoutEnqueued = true


### PR DESCRIPTION
## Description

With React Native's JS color-scheme override active (`Appearance.setColorScheme('light' | 'dark')`), toggling the **device** dark mode a few times permanently freezes native layout inside `StackHost`'s subtree. After the third toggle the header disappears (`AppBarLayout`/`Toolbar` stuck at `0×0`) and newly pushed screens are mounted but never laid out.

This PR fixes the freeze by overriding `forceLayout()` in `StackHost` to schedule the same manual measure-and-layout pass that `requestLayout()` already schedules.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/1771.

### Details

**Background — why rnscreens needs a manual layout pass at all.** React Native deliberately suppresses native Android layout: `ReactViewGroup.requestLayout()` is a no-op and React views don't measure or lay out their children during framework traversals — Fabric sets child frames directly via mount instructions. A `requestLayout()` originating inside the stack subtree therefore can't propagate to `ViewRootImpl` the way it would in a plain Android app. `StackHost` works around this by overriding `requestLayout()` to post a coalesced `forceSubtreeMeasureAndLayoutPass()` (measure with `EXACTLY` specs + `layout()`), guarded by `isLayoutEnqueued`. That override is the **single point** that turns layout requests from the subtree (header rebuilds, screen pushes) into an actual measure/layout pass.

**The hole: `forceLayout()` bypasses that single point.** On any window configuration change, `ViewRootImpl.handleResized` recursively calls `forceLayout()` on **every** view in the window and then relies on the next traversal to service the flags. `View.forceLayout()` sets `PFLAG_FORCE_LAYOUT | PFLAG_INVALIDATED` directly — it does **not** go through anyone's `requestLayout()` override and does not propagate anywhere. The framework's follow-up traversal never descends below the React views (they don't lay out their children), so the flags on `StackHost` and everything beneath it are set and left set. This matters because of how `View.requestLayout()` walks up the tree: it stops the moment it reaches a parent that already has a layout request pending (`if (mParent != null && !mParent.isLayoutRequested()) mParent.requestLayout()`). Once an ancestor is stuck in the "layout requested" state, every later `requestLayout()` from a descendant is swallowed before it can reach `StackHost`'s override.

**Why a device toggle reaches rnscreens at all — the double dispatch.** Intuitively, with the JS override pinning the appearance, device dark-mode toggles should be invisible to rnscreens — and in the end state they are, but not during dispatch. RN's `Appearance.setColorScheme` maps to `AppCompatDelegate.setDefaultNightMode`, and because the activity declares `uiMode` in `android:configChanges`, AppCompat cannot recreate the activity to re-apply the override — it has to fix the configuration up after the fact. So when the device toggles **away from** the pinned value, the activity and its fragments first receive `onConfigurationChanged` with the raw **device** configuration (`AppCompatActivity` runs `super.onConfigurationChanged`, which dispatches to fragments, before `getDelegate().onConfigurationChanged`), and only afterwards does `AppCompatDelegateImpl` re-impose the override on the resources and synthesize a **second**, re-entrant `onConfigurationChanged` carrying the overridden value. rnscreens therefore transiently observes the device value and re-themes to it, then re-themes back — two header rebuilds per such toggle (wasteful, but as shown below not itself the cause of the freeze). When the device toggles **back to** the pinned value, the effective configuration doesn't change, so a single callback arrives carrying the value that is already applied — and rnscreens correctly does nothing with it. Both cases matter below.

**Step by step — what the three toggles do.** Start with the device in light mode and the override set to `light` (so the last applied night mode is light):

1. **Toggle 1 (device → dark — the away-from-pinned case).** The first callback delivers the device value (`NIGHT_YES`): `ColorSchemeCoordinator` resolves a night mode different from `lastAppliedUiNightMode`, so `StackHeaderCoordinatorLayout.applyUiNightMode()` rebuilds the `AppBarLayout`/`Toolbar` in the dark theme (a rebuild is necessary because `MaterialToolbar` snapshots its theme at construction). The synthesized second callback then delivers the overridden `NIGHT_NO` and rebuilds back to light. Each rebuild calls `requestLayout()`, which reaches `StackHost` and posts the (coalesced) manual pass. `ViewRootImpl`'s recursive `forceLayout()` also runs for this window configuration change, but the already-posted pass then measures the whole subtree and clears every flag. This toggle survives only by ordering luck — a pass happened to be pending.
2. **Toggle 2 (device → light — the back-to-pinned case).** The device returns to the value the JS override already pins, so a single callback arrives and `ColorSchemeCoordinator` resolves the same night mode as last applied and **dedupes**: it returns early without touching any view. No `requestLayout()`, no pass posted. But the OS still delivered a genuine window configuration change, so `ViewRootImpl` still runs its recursive `forceLayout()`, setting `PFLAG_FORCE_LAYOUT` on `StackHost` and its entire subtree — with **nothing scheduled to clear it**. This is the silent poisoning step: the dedupe is correct in itself (there is genuinely nothing to re-theme), but it means rnscreens posts no pass on exactly the toggle where the framework still force-flags the tree.
3. **Toggle 3 (device → dark — away-from-pinned again).** Both callbacks arrive and the header rebuilds just like in toggle 1, calling `requestLayout()` — but the parents are already `isLayoutRequested() == true` from toggle 2, so the request short-circuits before reaching `StackHost` and no pass is posted. The freshly created `AppBarLayout` is never measured, `StackHeaderFrameSynchronizer` publishes a `0×0` frame to the header-config shadow state, and the header vanishes. From here on, every `requestLayout()` from the subtree (header-type changes, pushes, pops) is swallowed the same way — the subtree is frozen for good.

This is also why the JS override is a required ingredient: without it, every device toggle is a real change, so every toggle posts a pass that cleans up the framework's flags and they never accumulate.

**The fix.** Schedule the manual measure-and-layout pass from `forceLayout()` too:

```kotlin
override fun forceLayout() {
    super.forceLayout()
    refreshLayout()
}
```

`ViewRootImpl`'s recursion visits the host on every window config change, so the pass is now always scheduled exactly when the framework sets the flags. The posted pass measures the subtree with `EXACTLY` specs — `View.measure()` honors this even with unchanged specs because `PFLAG_FORCE_LAYOUT` is set — and `View.layout()` clears the flags everywhere below. The single host-level override is sufficient for the whole subtree, and it's harmless for any other `forceLayout()` caller: the pass is coalesced via the existing `isLayoutEnqueued` guard.

The same mechanism affects Tabs (`TabsHost` also schedules its manual measure-and-layout pass from `requestLayout()` only) — that will be addressed in a separate PR (https://github.com/software-mansion/react-native-screens/pull/4582).

## Changes

- override `forceLayout()` in `StackHost` to schedule the manual measure-and-layout pass, mirroring the existing `requestLayout()` override

## Before & after - visual documentation

| Before | After |
| ------ | ----- |
| <video src="https://github.com/user-attachments/assets/283ee0b4-6992-444d-ab19-89aef9a8ae76" /> | <video src="https://github.com/user-attachments/assets/8fd1c71a-b739-40c0-aad0-970ada1905ea" /> |

## Test plan

Run `TestStackColorScheme` in FabricExample:

1. Start with the device in **light** mode; set React Native's color scheme override to **light** using the on-screen picker (leave the host color scheme at `inherit`).
2. Toggle the device dark mode three times: **dark → light → dark** (quick-settings tile, or `adb shell "cmd uimode night yes"` / `no` / `yes`).
3. Before the fix: after the third toggle the header disappears and the screen freezes — changing the header type or pushing a screen has no visible effect (rotating the device unfreezes it).
4. After the fix: the header re-themes on every effective change and header-type changes and push/pop keep working after any number of toggles.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes
