### PR TITLE
fix(Android, FormSheet v5): Prevent translation to be overridden by `doOnStart` callback

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/presentation/FormSheetAnimatorFactory.kt
@@ -4,7 +4,6 @@ import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ValueAnimator
 import android.view.View
-import androidx.core.animation.doOnStart
 
 internal class FormSheetAnimatorFactory(
     private val dimmingManager: FormSheetDimmingManager,
@@ -36,7 +35,6 @@ internal class FormSheetAnimatorFactory(
         return AnimatorSet().apply {
             playTogether(slideAnimator, alphaAnimator)
             duration = animationDuration
-            doOnStart { view.translationY = startY }
         }
     }
 


### PR DESCRIPTION
## Description

With system animations disabled, the FormSheet stayed off-screen. The root cause was the `doOnStart` listener attached to the entering `AnimatorSet`. It relied on start listeners running before the child animators produce any value, which is not the case when the duration scale is 0.
```kt
// android.animation.AnimatorSet#start(boolean inReverse, boolean selfPulse)
boolean isEmptySet = isEmptySet(this);
if (!isEmptySet) {
  startAnimation();
}
notifyStartListeners(inReverse);
```

`startAnimation` pulses every child, but with a zero duration, `ValueAnimator` treats the animator as already finished, so the children synchronously apply their end values. After that, `notifyStartListeners` runs our `doOnStart`, which moves the sheet back to `translationY = height`.

The listener is also redundant. The `keepOffscreenUntilEnterAnimation` applies `translationY` in the first pre-draw of the sheet, i.e. before `OnShowListener` starts the animator.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/1764

## Changes

- removed the `doOnStart` listener that re-applied the translation

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/06da2454-d001-4d7f-a5f9-f058a9b07e9e" /> | <video src="https://github.com/user-attachments/assets/2fa3dea3-6cab-4705-aa6d-2ec9506c63b5" /> |

## Test plan

Disable animations in device settings, launch any FormSheet v5 example.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
