### PR TITLE
fix(Android, FormSheet v5): Calculate detents relatively to the native container's size

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/coordinator/FormSheetBehaviorController.kt
@@ -80,7 +80,8 @@ internal class FormSheetBehaviorController(
      * Used exclusively when the sheet is in `fitToContents` mode.
      * @param nativeContainerPaddingBottom - the bottom system inset. In `fitToContents` mode, this is added to the
      * BottomSheet's height to extend its background behind the system bars, while the inner content remains within
-     * the safe area.
+     * the safe area. For fractional detents it is subtracted from the collapsed peek height, which Material resolves
+     * above the inset, so the lowest detent lands at its fraction of [sheetAvailableSpace] like the other ones.
      * @param initialDetentIndex - the index of the detent the sheet should snap to while opening.
      * @param applyInitialDetent - whether the sheet should forcefully snap to the initial detent state.
      * This should typically be `true` only when the sheet transitions from closed to open.
@@ -104,8 +105,22 @@ internal class FormSheetBehaviorController(
         } else {
             when (detents.count) {
                 1 -> configureSingleDetent(detents, sheetAvailableSpace)
-                2 -> configureTwoDetents(detents, sheetAvailableSpace, initialDetentIndex, applyInitialDetent)
-                3 -> configureThreeDetents(detents, sheetAvailableSpace, initialDetentIndex, applyInitialDetent)
+                2 ->
+                    configureTwoDetents(
+                        detents,
+                        sheetAvailableSpace,
+                        nativeContainerPaddingBottom,
+                        initialDetentIndex,
+                        applyInitialDetent,
+                    )
+                3 ->
+                    configureThreeDetents(
+                        detents,
+                        sheetAvailableSpace,
+                        nativeContainerPaddingBottom,
+                        initialDetentIndex,
+                        applyInitialDetent,
+                    )
                 else -> throw IllegalStateException(
                     "[RNScreens] Unsupported detent count ${detents.count}.",
                 )
@@ -138,12 +153,13 @@ internal class FormSheetBehaviorController(
     private fun configureTwoDetents(
         detents: FormSheetDetents,
         sheetAvailableSpace: Int,
+        bottomInset: Int,
         initialDetentIndex: Int,
         applyInitialDetent: Boolean,
     ) = behavior.apply {
         skipCollapsed = false
         isFitToContents = true
-        peekHeight = detents.firstHeight(sheetAvailableSpace)
+        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset)
         maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)
         if (applyInitialDetent) {
             state = resolveStateFromIndex(initialDetentIndex, detents.count)
@@ -153,12 +169,13 @@ internal class FormSheetBehaviorController(
     private fun configureThreeDetents(
         detents: FormSheetDetents,
         sheetAvailableSpace: Int,
+        bottomInset: Int,
         initialDetentIndex: Int,
         applyInitialDetent: Boolean,
     ) = behavior.apply {
         skipCollapsed = false
         isFitToContents = false
-        peekHeight = detents.firstHeight(sheetAvailableSpace)
+        peekHeight = detents.peekHeight(sheetAvailableSpace, bottomInset)
         halfExpandedRatio = detents.halfExpandedRatio()
         expandedOffset = detents.expandedOffsetFromTop(sheetAvailableSpace)
         maxHeight = detents.maxAllowedHeight(sheetAvailableSpace)

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -1,5 +1,7 @@
 package com.swmansion.rnscreens.modals.formsheet.native.model
 
+import kotlin.math.roundToInt
+
 internal class FormSheetDetents(
     rawDetents: List<Double>,
 ) {
@@ -34,7 +36,7 @@ internal class FormSheetDetents(
     private fun heightAt(
         index: Int,
         containerHeight: Int,
-    ): Int = (heightFractionAt(index) * containerHeight).toInt()
+    ): Int = (heightFractionAt(index) * containerHeight).roundToInt()
 
     private fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
 

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/native/model/FormSheetDetents.kt
@@ -36,7 +36,18 @@ internal class FormSheetDetents(
         containerHeight: Int,
     ): Int = (heightFractionAt(index) * containerHeight).toInt()
 
-    internal fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
+    private fun firstHeight(containerHeight: Int): Int = heightAt(0, containerHeight)
+
+    /**
+     * Height handed to Material as `peekHeight`. Material treats the peek height as the content height above
+     * the bottom system inset and adds that inset back (`BottomSheetBehavior.calculatePeekHeight`), while every
+     * other metric (`maxHeight`, `halfExpandedRatio`) describes the sheet down to the screen edge. The inset is
+     * subtracted here so the lowest detent is resolved against the same reference as the other ones.
+     */
+    internal fun peekHeight(
+        containerHeight: Int,
+        bottomInset: Int,
+    ): Int = (firstHeight(containerHeight) - bottomInset).coerceAtLeast(0)
 
     internal fun maxAllowedHeight(containerHeight: Int): Int = heightAt(count - 1, containerHeight)
 
@@ -59,7 +70,7 @@ internal class FormSheetDetents(
 
     internal fun halfExpandedRatio(): Float {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for halfExpandedRatio." }
-        return (heightFractionAt(1) / heightFractionAt(2)).toFloat()
+        return heightFractionAt(1).toFloat()
     }
 
     internal fun expandedOffsetFromTop(
@@ -67,7 +78,7 @@ internal class FormSheetDetents(
         topInset: Int = 0,
     ): Int {
         check(count == MAX_DETENTS) { "[RNScreens] Exactly $MAX_DETENTS detents are required for expandedOffsetFromTop." }
-        return ((1 - heightFractionAt(2)) * containerHeight).toInt() + topInset
+        return largestDetentTopOffset(containerHeight) + topInset
     }
 
     // Distance from the top of the window to the top of the largest detent's surface.

--- a/apps/src/tests/single-feature-tests/form-sheet/index.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/index.ts
@@ -6,6 +6,7 @@ import TestFormSheetBase from './test-form-sheet-base';
 import TestFormSheetDismissEvents from './test-form-sheet-dismiss-events';
 import TestFormSheetExpandScrollView from './test-form-sheet-expand-scroll-view-ios';
 import TestFormSheetFitToContents from './test-form-sheet-fit-to-contents';
+import TestFormSheetFractionalDetents from './test-form-sheet-fractional-detents';
 import TestFormSheetGrabberVisible from './test-form-sheet-grabber-visible';
 import TestFormSheetInitialDetentIndex from './test-form-sheet-initial-detent-index';
 import TestFormSheetLargestUndimmedDetentIndex from './test-form-sheet-largest-undimmed-detent-index-ios';
@@ -24,6 +25,7 @@ export { default as TestFormSheetBase } from './test-form-sheet-base';
 export { default as TestFormSheetDismissEvents } from './test-form-sheet-dismiss-events';
 export { default as TestFormSheetExpandScrollView } from './test-form-sheet-expand-scroll-view-ios';
 export { default as TestFormSheetFitToContents } from './test-form-sheet-fit-to-contents';
+export { default as TestFormSheetFractionalDetents } from './test-form-sheet-fractional-detents';
 export { default as TestFormSheetGrabberVisible } from './test-form-sheet-grabber-visible';
 export { default as TestFormSheetInitialDetentIndex } from './test-form-sheet-initial-detent-index';
 export { default as TestFormSheetLargestUndimmedDetentIndex } from './test-form-sheet-largest-undimmed-detent-index-ios';
@@ -41,6 +43,7 @@ const scenarios = {
   TestFormSheetDismissEvents,
   TestFormSheetExpandScrollView,
   TestFormSheetFitToContents,
+  TestFormSheetFractionalDetents,
   TestFormSheetGrabberVisible,
   TestFormSheetInitialDetentIndex,
   TestFormSheetLargestUndimmedDetentIndex,

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/index.tsx
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/index.tsx
@@ -1,0 +1,176 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  type LayoutChangeEvent,
+  Platform,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { FormSheet } from 'react-native-screens';
+import { scenarioDescription } from './scenario-description';
+import { createScenario } from '@apps/tests/shared/helpers';
+import { Colors } from '@apps/shared/styling';
+
+const DETENT_PRESETS: number[][] = [
+  [0.5],
+  [1.0],
+  [0.3, 0.6],
+  [0.5, 1.0],
+  [0.3, 0.6, 1.0],
+  [0.25, 0.5, 0.75],
+  [0.3, 0.55, 0.8],
+  [0.5, 0.65, 0.8],
+  [0.2, 0.9, 1.0],
+];
+
+const formatDetent = (detent: number) =>
+  Number.isInteger(detent) ? detent.toFixed(1) : String(detent);
+
+const formatDetents = (detents: number[]) =>
+  `[${detents.map(formatDetent).join(', ')}]`;
+
+function TestFormSheetFractionalDetents() {
+  const [isOpen, setIsOpen] = useState(false);
+  const [presetIndex, setPresetIndex] = useState(0);
+  const [hostHeight, setHostHeight] = useState(0);
+
+  const detents = DETENT_PRESETS[presetIndex];
+
+  const selectPreset = (index: number) => {
+    setPresetIndex(index);
+  };
+
+  const handleOpen = () => {
+    setIsOpen(true);
+  };
+
+  const handleHostLayout = (event: LayoutChangeEvent) => {
+    setHostHeight(event.nativeEvent.layout.height);
+  };
+
+  return (
+    <View style={styles.container} onLayout={handleHostLayout}>
+      {Platform.OS === 'android' && hostHeight > 0 && (
+        <View style={StyleSheet.absoluteFill} pointerEvents="none">
+          {detents.map(detent => (
+            <View
+              key={detent}
+              style={[styles.guide, { top: hostHeight * (1 - detent) }]}>
+              <Text style={styles.guideLabel}>{formatDetent(detent)}</Text>
+            </View>
+          ))}
+        </View>
+      )}
+
+      <View style={styles.topSection}>
+        <Text style={styles.title}>Fractional Detents</Text>
+        <Text style={styles.subtitle}>Detents: {formatDetents(detents)}</Text>
+        <View style={styles.buttonGroup}>
+          {DETENT_PRESETS.map((preset, index) => (
+            <Button
+              key={formatDetents(preset)}
+              title={formatDetents(preset)}
+              color={index === presetIndex ? Colors.primary : undefined}
+              onPress={() => selectPreset(index)}
+            />
+          ))}
+        </View>
+
+        <View style={styles.spacing} />
+        <Button
+          title="Open FormSheet"
+          color={Colors.primary}
+          onPress={handleOpen}
+        />
+      </View>
+
+      <FormSheet
+        isOpen={isOpen}
+        onNativeDismiss={() => setIsOpen(false)}
+        detents={detents}
+        preferredCornerRadius={0}
+        nativeContainerStyle={{ backgroundColor: '#ffffff80' }}>
+        <View style={styles.sheetContent}>
+          <View style={styles.header} />
+          <View style={styles.footer} />
+        </View>
+      </FormSheet>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: Colors.offBackground,
+  },
+  topSection: {
+    paddingTop: 80,
+    paddingHorizontal: 16,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 20,
+    fontWeight: 'bold',
+    marginBottom: 8,
+    color: Colors.text,
+  },
+  subtitle: {
+    marginBottom: 12,
+    color: Colors.text,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  buttonGroup: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 8,
+  },
+  guide: {
+    position: 'absolute',
+    left: 0,
+    right: 0,
+    height: 1,
+    backgroundColor: Colors.primary,
+  },
+  guideLabel: {
+    position: 'absolute',
+    right: 8,
+    bottom: 2,
+    fontSize: 12,
+    color: Colors.primary,
+  },
+  sheetContent: {
+    flex: 1,
+    backgroundColor: 'transparent',
+    padding: 24,
+    justifyContent: Platform.OS === 'ios' ? 'center' : 'flex-start',
+    alignItems: 'center',
+  },
+  spacing: {
+    height: 24,
+  },
+  header: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    height: 40,
+    backgroundColor: Colors.RedDark100,
+  },
+  footer: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+    height: 40,
+    backgroundColor: Colors.RedDark100,
+  },
+});
+
+export default createScenario(
+  TestFormSheetFractionalDetents,
+  scenarioDescription,
+);

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario-description.ts
@@ -1,0 +1,10 @@
+import type { ScenarioDescription } from '@apps/tests/shared/helpers';
+
+export const scenarioDescription: ScenarioDescription = {
+  name: 'Fractional Detents',
+  key: 'test-form-sheet-fractional-detents',
+  details: 'testing different setups for one, two and three fractional detents',
+  platforms: ['android', 'ios'],
+  e2eCoverage: 'tbd',
+  smokeTest: false,
+};

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario.md
@@ -1,0 +1,120 @@
+# Test Scenario: Fractional Detents
+
+## Details
+
+**Description:** Verify the geometry of `FormSheet` fractional `detents` for different detent counts and for different spreads: narrow (`[0.3, 0.55, 0.8]`), evenly spaced (`[0.25, 0.5, 0.75]`), reaching the top (`[0.3, 0.6, 1.0]`, `[0.2, 0.9, 1.0]`) and a middle detent close to the largest one (`[0.5, 0.65, 0.8]`). For each preset the sheet must rest at the requested fraction of the screen at every detent, every detent must be reachable by dragging in both directions, and the sheet must always end at the bottom edge of the screen.
+
+The sheet is drawn as a translucent white surface without corner radius, and its React content box is transparent with two red strips: one at the top and one at the bottom of the content box. This makes the sheet's edges and the content box boundaries measurable against the host screen.
+
+**OS test creation version:** iOS: 26.5, Android: API Level 36.
+
+## E2E test
+
+TBD: Planned, but will be implemented separately.
+
+## Prerequisites
+
+- iPhone: device or simulator.
+- iPad: device or simulator, app in full-screen mode (regular width and regular height size classes).
+- Android: phone device or emulator.
+
+## Note
+
+- **Android guides:** the host screen draws a thin horizontal line for every detent of the selected preset, at the detent's fraction of the host height measured from the bottom edge of the screen. A resting sheet must align its top edge – the top edge of the red header strip – with the guide of its current detent. This holds for every detent, including the lowest one. Because the sheet is translucent, the guides of the lower detents stay visible through the sheet body.
+- **Android, `1.0` detent:** the sheet itself starts at the very top of the screen, but the content box is padded below the status bar, so the red header strip sits just under the status bar. There is no guide for `1.0` (it would be the top edge of the screen).
+- **iOS:** Fractions are resolved against the sheet's maximum height (the screen below the status bar), so relative checks apply: the visible height must grow with the detent value, `1.0` reaches the top just below the status bar, and every detent must be distinct and reachable. The content box follows the current detent, so the red footer strip is visible at the bottom of the sheet at every detent.
+- The sheet always opens at the lowest detent of the selected preset. There is no dismiss button inside the sheet: dismiss it by swiping it down past the lowest detent or by tapping the dimmed area above it.
+
+## Steps
+
+### Single detent
+
+1. Launch the app and navigate to the **Fractional Detents** screen.
+
+- [ ] The host shows "Detents: [0.5]", the preset buttons and the "Open FormSheet" button. Android: a single guide labeled `0.5` is drawn at half of the screen.
+
+2. Tap "Open FormSheet".
+
+- [ ] The sheet rests at half of the screen; the red header strip is at its top edge and the sheet ends at the bottom edge of the screen. Android: the header's top edge aligns with the `0.5` guide; the footer strip is visible right above the navigation bar.
+
+3. Dismiss the sheet.
+
+- [ ] The host is undimmed and "Open FormSheet" is pressable again.
+
+4. Tap "[1.0]", then "Open FormSheet".
+
+- [ ] The sheet reaches the top of the screen. Android: the sheet slides behind the status bar, the red header strip sits just under the status bar and the footer strip right above the navigation bar. iOS: the sheet's top edge sits just below the status bar.
+
+5. Dismiss the sheet.
+
+---
+
+### Two detents
+
+6. Tap "[0.3, 0.6]", then "Open FormSheet".
+
+- [ ] The sheet rests at the lowest detent. Android: the header's top edge aligns with the `0.3` guide; the `0.6` guide is above the sheet; no footer strip is visible.
+
+7. Drag the sheet up.
+
+- [ ] The sheet settles at the larger detent. Android: the header's top edge aligns with the `0.6` guide, the `0.3` guide is visible through the sheet body, and the footer strip is visible right above the navigation bar.
+
+8. Drag the sheet down.
+
+- [ ] The sheet settles back at the lowest detent, aligned with the `0.3` guide on Android.
+
+9. Dismiss the sheet. Tap "[0.5, 1.0]", then "Open FormSheet".
+
+- [ ] The sheet rests at half of the screen, at exactly the same position as the single `[0.5]` detent from step 2 (Android: header's top edge on the `0.5` guide).
+
+10. Drag the sheet up, then down, then dismiss it.
+
+- [ ] Up: the sheet reaches the top like in step 4. Down: it settles back at `0.5`.
+
+---
+
+### Three detents, reaching the top
+
+11. Tap "[0.3, 0.6, 1.0]", then "Open FormSheet". Drag the sheet up twice, then down twice.
+
+- [ ] The sheet visits the detents in order: `0.3` → `0.6` → `1.0` → `0.6` → `0.3`. Android: the header's top edge aligns with the corresponding guide at every stop (`1.0`: header just under the status bar), the guides of the lower detents show through the sheet body, and the footer strip appears only at `1.0`.
+
+12. Dismiss the sheet. Tap "[0.2, 0.9, 1.0]" and repeat step 11.
+
+- [ ] The lowest detent shows only a small strip of the sheet, the middle detent is close to the top, and the largest reaches the top. All three are distinct stops of the drag.
+
+---
+
+### Three detents, evenly spaced
+
+13. Dismiss the sheet. Tap "[0.25, 0.5, 0.75]" and repeat step 11.
+
+- [ ] The three stops are evenly spaced (a quarter of the screen apart). Android: the header's top edge aligns with the `0.25`, `0.5` and `0.75` guides; at `0.75` the sheet ends exactly at the bottom edge of the screen, with no dimmed strip below it, and the footer strip is visible right above the navigation bar.
+
+---
+
+### Middle detent close to the largest one
+
+14. Dismiss the sheet. Tap "[0.5, 0.65, 0.8]", then "Open FormSheet".
+
+- [ ] The sheet rests at `0.5`, at the same position as in steps 2 and 9.
+
+15. Drag the sheet up.
+
+- [ ] The sheet settles at `0.65`. Android: the header's top edge aligns with the `0.65` guide, **below** the `0.8` guide, and the sheet ends at the bottom edge of the screen – there is no strip of dimmed background between the sheet and the bottom of the screen.
+
+16. Drag the sheet up again.
+
+- [ ] The sheet moves **up** to `0.8`. Android: the header's top edge aligns with the `0.8` guide, the sheet still ends exactly at the bottom edge, and the footer strip is visible right above the navigation bar.
+
+17. Drag the sheet down twice.
+
+- [ ] The sheet stops at `0.65` and then at `0.5`.
+
+18. Dismiss the sheet. Tap "[0.3, 0.55, 0.8]", then "Open FormSheet". Drag the sheet up twice, then down twice.
+
+- [ ] The stops are `0.3` → `0.55` → `0.8` → `0.55` → `0.3`. Android: at `0.55` the header's top edge aligns with the `0.55` guide (previously the sheet rested noticeably higher, at about 0.69 of the screen).
+
+19. Dismiss the sheet.
+
+- [ ] The host screen is undimmed and "Open FormSheet" is pressable again.

--- a/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario.md
+++ b/apps/src/tests/single-feature-tests/form-sheet/test-form-sheet-fractional-detents/scenario.md
@@ -21,7 +21,7 @@ TBD: Planned, but will be implemented separately.
 ## Note
 
 - **Android guides:** the host screen draws a thin horizontal line for every detent of the selected preset, at the detent's fraction of the host height measured from the bottom edge of the screen. A resting sheet must align its top edge – the top edge of the red header strip – with the guide of its current detent. This holds for every detent, including the lowest one. Because the sheet is translucent, the guides of the lower detents stay visible through the sheet body.
-- **Android, `1.0` detent:** the sheet itself starts at the very top of the screen, but the content box is padded below the status bar, so the red header strip sits just under the status bar. There is no guide for `1.0` (it would be the top edge of the screen).
+- **Android, `1.0` detent:** the sheet itself starts at the very top of the screen, but the top edge of the red header strip starts immediately below the bottom edge of the status bar; it does not overlap or extend behind the status bar. There is no guide for `1.0` (it would be the top edge of the screen).
 - **iOS:** Fractions are resolved against the sheet's maximum height (the screen below the status bar), so relative checks apply: the visible height must grow with the detent value, `1.0` reaches the top just below the status bar, and every detent must be distinct and reachable. The content box follows the current detent, so the red footer strip is visible at the bottom of the sheet at every detent.
 - The sheet always opens at the lowest detent of the selected preset. There is no dismiss button inside the sheet: dismiss it by swiping it down past the lowest detent or by tapping the dimmed area above it.
 


### PR DESCRIPTION
## Description

1. `halfExpandedRatio` returned `d1 / d2`, but Material resolves the half-expanded rest position against the parent height and the parent is always the full-height CoordinatorLayout. The middle detent therefore rested at `d1 / d2` of the screen instead of `d1`. For most triples this only makes the middle detent too tall ([0.3, 0.55, 0.8] rested at 0.69 instead of 0.55), but whenever `d1 > d2*d2` (e.g. [0.5, 0.65, 0.8]) the middle rest position lands above the largest one. The sheet, sized to the largest detent, then floats above the bottom edge with a strip of dimmed background under it, and the largest detent becomes unreachable by dragging.
2. Lowest detent measured against a different reference than the other ones. Material's `calculatePeekHeight()` adds the bottom system inset to `peekHeight` (the peek is defined as content above the navigation bar), while `maxHeight` and `halfExpandedRatio` describe the sheet down to the screen edge. With our "fraction of the window height" semantics, the lowest detent of a 2- or 3-detent sheet rested one inset higher than the same value used as a single detent. The inset is now subtracted from the peek height, so every detent is resolved against the same reference, which also matches iOS.

> [!NOTE]
> The legacy v4 sheet might carry the first two bugs because of using the same formulas; this PR is scoped only to v5.

## Changes

- `FormSheetDetents.halfExpandedRatio()` returns the raw middle fraction.
- `FormSheetDetents.expandedOffsetFromTop()` is derived from `largestDetentTopOffset()`.
- `FormSheetDetents.peekHeight()` subtracts the bottom inset that Material adds back; `FormSheetBehaviorController` passes the inset for two and three detents.

## Before & after - visual documentation

| Before | After |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/29ed2bdc-85b3-495e-ae7e-a31e80f16c1a" /> | <video src="https://github.com/user-attachments/assets/723512b5-fe4a-4c9e-be07-38d881058729" /> |

## Test plan

Added a dedicated SFT.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
