### PR TITLE
feat(iOS, Stack v5): Add `menuRepresentation` prop to header items

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -13,6 +13,7 @@ import {
 import { StackHeaderConfigProps } from 'react-native-screens';
 import type {
   StackHeaderConfigRef,
+  StackHeaderMenuIOS,
   StackHeaderMenuItemOptionsIOS,
   StackHeaderMenuOptionsIOS,
 } from 'react-native-screens';
@@ -99,10 +100,43 @@ function TestStackHeaderMenuIOS() {
   );
 }
 
+function buildMenuRepresentation(
+  index: number,
+  showToast: (text: string) => void,
+): StackHeaderMenuIOS {
+  return {
+    type: 'menu',
+    id: `repr-${index}`,
+    title: `Repr ${index}`,
+    singleSelection: true,
+    onSelectionChange: selection =>
+      showToast(`Repr ${index} selected "${selection}"`),
+    children: [
+      {
+        id: `repr-radio-${index}-1`,
+        type: 'menuItem',
+        title: `Repr ${index} Radio 1`,
+        initialToggleState: true,
+      },
+      {
+        id: `repr-radio-${index}-2`,
+        type: 'menuItem',
+        title: `Repr ${index} Radio 2`,
+      },
+      {
+        id: `repr-radio-${index}-3`,
+        type: 'menuItem',
+        title: `Repr ${index} Radio 3`,
+      },
+    ],
+  };
+}
+
 function buildHeaderConfig(
   trailingItemsCount: number,
   showToast: (text: string) => void,
   keepsMenuPresented: boolean,
+  representationEnabled: boolean,
 ): StackHeaderConfigProps {
   const trailingItems: NonNullable<
     StackHeaderConfigProps['ios']
@@ -116,6 +150,9 @@ function buildHeaderConfig(
         render: () => (
           <PressableWithFeedback style={{ width: 30, height: 30 }} />
         ),
+      }),
+      ...(representationEnabled && {
+        menuRepresentation: buildMenuRepresentation(i, showToast),
       }),
       menu: {
         type: 'menu',
@@ -225,6 +262,7 @@ function ConfigScreen() {
     DEFAULT_TRAILING_ITEMS_COUNT,
   );
   const [keepsMenuPresented, setKeepsMenuPresented] = useState(false);
+  const [representationEnabled, setRepresentationEnabled] = useState(false);
 
   const showToast = useCallback(
     (text: string) => {
@@ -237,8 +275,14 @@ function ConfigScreen() {
 
   const { setRouteOptions, routeKey } = navigation;
   const headerConfig = useMemo(
-    () => buildHeaderConfig(trailingItemsCount, showToast, keepsMenuPresented),
-    [trailingItemsCount, showToast, keepsMenuPresented],
+    () =>
+      buildHeaderConfig(
+        trailingItemsCount,
+        showToast,
+        keepsMenuPresented,
+        representationEnabled,
+      ),
+    [trailingItemsCount, showToast, keepsMenuPresented, representationEnabled],
   );
 
   useLayoutEffect(() => {
@@ -292,6 +336,10 @@ function ConfigScreen() {
       <Button
         title={`keepsMenuPresented: ${keepsMenuPresented}`}
         onPress={() => setKeepsMenuPresented(prev => !prev)}
+      />
+      <Button
+        title={`menuRepresentation: ${representationEnabled}`}
+        onPress={() => setRepresentationEnabled(prev => !prev)}
       />
 
       <Text style={styles.heading}>setMenuItemOptions (Menu 1)</Text>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/index.tsx
@@ -32,12 +32,21 @@ const ACTION_IDS = [
   'radio-1-1',
   'radio-1-2',
   'radio-1-3',
+  'repr-radio-1-1',
+  'repr-radio-1-2',
+  'repr-radio-1-3',
   'title-action-1',
   'title-action-2',
 ] as const;
 type ActionId = (typeof ACTION_IDS)[number];
 
-const MENU_IDS = ['menu-1', 'submenu-1', 'subsubmenu-1', 'title-menu'] as const;
+const MENU_IDS = [
+  'menu-1',
+  'submenu-1',
+  'subsubmenu-1',
+  'repr-menu-1',
+  'title-menu',
+] as const;
 type MenuId = (typeof MENU_IDS)[number];
 
 const TITLE_OPTIONS = [
@@ -106,7 +115,7 @@ function buildMenuRepresentation(
 ): StackHeaderMenuIOS {
   return {
     type: 'menu',
-    id: `repr-${index}`,
+    id: `repr-menu-${index}`,
     title: `Repr ${index}`,
     singleSelection: true,
     onSelectionChange: selection =>

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario-description.ts
@@ -4,8 +4,9 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Stack Header Menu (iOS)',
   key: 'test-stack-header-menu-ios',
   details:
-    'Tests header item menus and title menu: action items, toggle items, singleSelection, and nested menus.',
+    'Tests header item menus and title menu: action items, toggle items, singleSelection, ' +
+    'nested menus, and menu representation in the overflow menu.',
   platforms: ['ios'],
-  e2eCoverage: 'full',
+  e2eCoverage: 'incomplete',
   smokeTest: false,
 };

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -8,7 +8,7 @@
 
 ## E2E test
 
-Full: Covers all manual scenario steps.
+Partial: Covers all manual scenario steps except the **Menu representation** section.
 
 ## Prerequisites
 
@@ -17,6 +17,7 @@ Full: Covers all manual scenario steps.
 ## Note
 
 - For now, menus don't appear on items with custom views
+- Menu representation section requires iOS >= 16
 
 ## Steps on iPhone
 
@@ -51,6 +52,23 @@ Full: Covers all manual scenario steps.
 10. Click on screen title
   - [ ] The title should transform into a menu with two actions
   - [ ] Clicking either actions should display a toast
+
+### Menu representation
+
+1. Relaunch the app and navigate to the **Stack Header Menu (iOS)** screen.
+2. Toggle `menuRepresentation`
+3. Click `Toggle trailing items count` to get 4 items present
+  - [ ] Two items moved to overflow menu
+4. Open the overflow menu
+  - [ ] Overflowed items appear as **Repr #** submenus
+  - [ ] Custom items are represented in the same way
+5. Open Repr 1
+  - [ ] It contains three radio items, Repr 1 Radio 1 is selected by default
+6. Click Repr 1 Radio 2
+  - [ ] A toast "Repr 1 selected "repr-radio-1-2"" is displayed
+  - [ ] When reopened, Repr 1 Radio 2 is checked and Radio 1 is not
+7. Open Repr 2
+  - [ ] It contains three radio items, Repr 2 Radio 1 is selected by default
 
 ### setMenuItemOptions view command
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -18,6 +18,8 @@ Incomplete: Covers all manual scenario steps except the **Menu representation** 
 
 - For now, menus don't appear on items with custom views
 - Menu representation section requires iOS >= 16
+- There is a bug present when you send change item command, and change the number of items
+  before displaying the menu, then the checkmark doesn't change despite the toast showing.
 
 ## Steps on iPhone
 
@@ -64,11 +66,12 @@ Incomplete: Covers all manual scenario steps except the **Menu representation** 
   - [ ] Custom items are present and represented in the same way as regular items
 5. Open Repr 1
   - [ ] It contains three radio items, Repr 1 Radio 1 is selected by default
-6. Click Repr 1 Radio 2
-  - [ ] A toast "Repr 1 selected "repr-radio-1-2"" is displayed
-  - [ ] When reopened, Repr 1 Radio 2 is checked and Radio 1 is not
-7. Open Repr 0
-  - [ ] It contains three radio items, Repr 0 Radio 1 is selected by default
+6. Click Repr 0 Radio 2
+  - [ ] A toast "Repr 0 selected "repr-radio-0-2"" is displayed
+  - [ ] When reopened, Repr 0 Radio 2 is checked and Radio 1 is not
+6. Under `setMenuItemOptions`, select "repr-radio-1-3", `title`: "New Title", `toggleState`: "true". Click "Send setMenuItemOptions". Open Repr 1.
+  - [ ] It contains three radio items: "Repr 1 Radio 1", "Repr 1 Radio 2", "New Title"
+  - [ ] "New Title" item is selected
 
 ### setMenuItemOptions view command
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-header-menu-ios/scenario.md
@@ -8,11 +8,11 @@
 
 ## E2E test
 
-Partial: Covers all manual scenario steps except the **Menu representation** section.
+Incomplete: Covers all manual scenario steps except the **Menu representation** section.
 
 ## Prerequisites
 
-- iOS / iPadOS emulator
+- iOS simulator or device
 
 ## Note
 
@@ -53,22 +53,22 @@ Partial: Covers all manual scenario steps except the **Menu representation** sec
   - [ ] The title should transform into a menu with two actions
   - [ ] Clicking either actions should display a toast
 
-### Menu representation
+### Menu representation (iOS 26)
 
 1. Relaunch the app and navigate to the **Stack Header Menu (iOS)** screen.
 2. Toggle `menuRepresentation`
 3. Click `Toggle trailing items count` to get 4 items present
   - [ ] Two items moved to overflow menu
 4. Open the overflow menu
-  - [ ] Overflowed items appear as **Repr #** submenus
-  - [ ] Custom items are represented in the same way
+  - [ ] Overflowed regular items appear as **Repr #** submenus
+  - [ ] Custom items are present and represented in the same way as regular items
 5. Open Repr 1
   - [ ] It contains three radio items, Repr 1 Radio 1 is selected by default
 6. Click Repr 1 Radio 2
   - [ ] A toast "Repr 1 selected "repr-radio-1-2"" is displayed
   - [ ] When reopened, Repr 1 Radio 2 is checked and Radio 1 is not
-7. Open Repr 2
-  - [ ] It contains three radio items, Repr 2 Radio 1 is selected by default
+7. Open Repr 0
+  - [ ] It contains three radio items, Repr 0 Radio 1 is selected by default
 
 ### setMenuItemOptions view command
 

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -304,7 +304,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
       [static_cast<RNSStackHeaderItemComponentView *>(locator.headerItem)
           updateMenuElementWithId:menuItemId
                       withElement:newItemData
-                       parentMenu:locator.searchResult.parentMenu];
+                       parentMenu:locator.searchResult.parentMenu
+             inMenuRepresentation:locator.inMenuRepresentation];
       break;
     case RNSMenuElementPositionTitle:
       if (locator.searchResult.parentMenu != nil) {
@@ -350,7 +351,8 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
       [static_cast<RNSStackHeaderItemComponentView *>(locator.headerItem)
           updateMenuElementWithId:menuElementId
                       withElement:newMenuItem
-                       parentMenu:locator.searchResult.parentMenu];
+                       parentMenu:locator.searchResult.parentMenu
+             inMenuRepresentation:locator.inMenuRepresentation];
       break;
     case RNSMenuElementPositionTitle:
       if (locator.searchResult.parentMenu == nil) {

--- a/ios/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderIconData *icon;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menuRepresentation;
 @property (nonatomic, readonly, nullable) UIView *customView;
 @property (nonatomic, readonly) BOOL respondsToOnPress;
 @property (nonatomic, readonly) BOOL hidesSharedBackground;
@@ -23,6 +24,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, nullable) NSString *titleProp;
 @property (nonatomic, nullable) RNSStackHeaderIconData *iconProp;
 @property (nonatomic, nullable) RNSStackHeaderMenuData *menuProp;
+@property (nonatomic, nullable) RNSStackHeaderMenuData *menuRepresentationProp;
 
 @property (nonatomic, weak, nullable) id<RNSStackHeaderItemInvalidationDelegate> invalidationDelegate;
 

--- a/ios/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.h
@@ -31,12 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)emitOnPress;
 
 /**
- * Replaces a menu element in the item's menu tree with a new element constructed from command options.
+ * Replaces a menu element in the item's menu or menuRepresentation tree with a new element
+ * constructed from command options.
  * If parentMenu is nil, the element is the root menu and is replaced directly.
  */
 - (void)updateMenuElementWithId:(NSString *)elementId
                     withElement:(id<RNSStackHeaderMenuElement>)newElement
-                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu;
+                     parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
+           inMenuRepresentation:(BOOL)inMenuRepresentation;
 
 @end
 

--- a/ios/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.mm
@@ -49,6 +49,7 @@ namespace react = facebook::react;
   [self setTitleProp:nil];
   [self setIconProp:nil];
   [self setMenuProp:nil];
+  [self setMenuRepresentationProp:nil];
   _placement = RNSHeaderItemPlacementTrailing;
   _didSetHeaderItemPlacement = NO;
   _respondsToOnPress = NO;
@@ -71,6 +72,12 @@ namespace react = facebook::react;
 {
   _menuProp = menuProp;
   _menu = menuProp;
+}
+
+- (void)setMenuRepresentationProp:(RNSStackHeaderMenuData *)menuRepresentationProp
+{
+  _menuRepresentationProp = menuRepresentationProp;
+  _menuRepresentation = menuRepresentationProp;
 }
 
 - (void)emitOnPress
@@ -213,6 +220,15 @@ RNS_IGNORE_SUPER_CALL_END
   if (oldItemProps.menu != newItemProps.menu) {
     [self setMenuProp:[RNSStackHeaderMenuMapper
                           menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(newItemProps.menu)]];
+    menuDidChange = YES;
+  }
+
+  if (oldItemProps.menuRepresentation != newItemProps.menuRepresentation) {
+    [self setMenuRepresentationProp:[RNSStackHeaderMenuMapper
+                                        menuFromDictionary:rnscreens::conversion::RNSConvertFollyDynamicToId(
+                                                               newItemProps.menuRepresentation)]];
+    // menu representation is applied together with the menu & shares its toggle state tracker,
+    // so it follows the same invalidation path
     menuDidChange = YES;
   }
 

--- a/ios/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.mm
@@ -88,11 +88,22 @@ namespace react = facebook::react;
 - (void)updateMenuElementWithId:(NSString *)elementId
                     withElement:(id<RNSStackHeaderMenuElement>)newElement
                      parentMenu:(nullable RNSStackHeaderMenuData *)parentMenu
+           inMenuRepresentation:(BOOL)inMenuRepresentation
 {
-  if (parentMenu == nil) {
-    _menu = (RNSStackHeaderMenuData *)newElement;
+  if (inMenuRepresentation) {
+    if (parentMenu == nil) {
+      _menuRepresentation = (RNSStackHeaderMenuData *)newElement;
+    } else {
+      _menuRepresentation = [RNSStackHeaderMenuCoordinator menu:_menuRepresentation
+                                           replacingChildWithId:elementId
+                                                    withElement:newElement];
+    }
   } else {
-    _menu = [RNSStackHeaderMenuCoordinator menu:_menu replacingChildWithId:elementId withElement:newElement];
+    if (parentMenu == nil) {
+      _menu = (RNSStackHeaderMenuData *)newElement;
+    } else {
+      _menu = [RNSStackHeaderMenuCoordinator menu:_menu replacingChildWithId:elementId withElement:newElement];
+    }
   }
   [_invalidationDelegate headerItemMenuDidUpdateFromCommandWithId:_itemId];
 }

--- a/ios/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderItemDataProviding.h
@@ -16,6 +16,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *title;
 @property (nonatomic, readonly, nullable) RNSStackHeaderIconData *icon;
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
+@property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menuRepresentation;
 @property (nonatomic, readonly, nullable) UIView *customView;
 @property (nonatomic, readonly) BOOL respondsToOnPress;
 @property (nonatomic, readonly) BOOL hidesSharedBackground;

--- a/ios/stack/header/RNSStackHeaderMenuCoordinator.h
+++ b/ios/stack/header/RNSStackHeaderMenuCoordinator.h
@@ -26,6 +26,19 @@ NS_ASSUME_NONNULL_BEGIN
      menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated;
 
 /**
+ * Applies menu representation to the item - a menu element substituting the item
+ * when it is displayed in a menu (e.g. the navigation bar overflow menu).
+ * Passing nil `data` clears the representation. Works like regular `applyMenu`.
+ * No-op below iOS 16 and on tvOS, where `UIBarButtonItem.menuRepresentation` is unavailable.
+ */
++ (void)applyMenuRepresentation:(nullable RNSStackHeaderMenuData *)data
+                toBarButtonItem:(UIBarButtonItem *)item
+       withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
+                   stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                withImageLoader:(id<RNSImageLoading>)imageLoader
+        menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated;
+
+/**
  * Collects IDs of all toggle items in a single selection hierarchy rooted at the given menu.
  */
 + (NSArray<NSString *> *)getAllToggleItemsIdsInSingleSelectionHierarchy:(RNSStackHeaderMenuData *)menu;

--- a/ios/stack/header/RNSStackHeaderMenuCoordinator.mm
+++ b/ios/stack/header/RNSStackHeaderMenuCoordinator.mm
@@ -26,6 +26,30 @@
 #endif // !TARGET_OS_TV || __TV_OS_VERSION_MAX_ALLOWED >= 170000
 }
 
++ (void)applyMenuRepresentation:(nullable RNSStackHeaderMenuData *)data
+                toBarButtonItem:(UIBarButtonItem *)item
+       withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
+                   stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker
+                withImageLoader:(id<RNSImageLoading>)imageLoader
+        menuInvalidatedCallback:(nullable void (^)(void))onMenuInvalidated
+{
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) && !TARGET_OS_TV
+  if (@available(iOS 16.0, *)) {
+    if (data == nil) {
+      item.menuRepresentation = nil;
+      return;
+    }
+    item.menuRepresentation = [self buildMenuFromData:data
+                             withHeaderEventsDelegate:delegate
+                                         stateTracker:tracker
+                                  singleSelectionRoot:nil
+                   initialSingleSelectionStateClaimed:NULL
+                                      withImageLoader:imageLoader
+                              menuInvalidatedCallback:onMenuInvalidated];
+  }
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(16_0) && !TARGET_OS_TV
+}
+
 + (UIMenu *)buildMenuFromData:(RNSStackHeaderMenuData *)data
               withHeaderEventsDelegate:(id<RNSStackHeaderEventsDelegate>)delegate
                           stateTracker:(RNSStackHeaderMenuToggleStateTracker *)tracker

--- a/ios/stack/header/RNSStackHeaderMenuFinder.h
+++ b/ios/stack/header/RNSStackHeaderMenuFinder.h
@@ -41,11 +41,18 @@ typedef NS_ENUM(NSInteger, RNSMenuElementPosition) {
  */
 @property (nonatomic, copy, readonly, nullable) NSString *trackerItemId;
 
+/**
+ * Whether the element was found in the header item's menuRepresentation tree
+ * rather than its menu tree.
+ */
+@property (nonatomic, readonly) BOOL inMenuRepresentation;
+
 - (instancetype)initWithSearchResult:(RNSStackHeaderMenuElementSearchResult *)searchResult
                             position:(RNSMenuElementPosition)position
                           headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem
                             rootMenu:(nullable RNSStackHeaderMenuData *)rootMenu
-                       trackerItemId:(nullable NSString *)trackerItemId;
+                       trackerItemId:(nullable NSString *)trackerItemId
+                inMenuRepresentation:(BOOL)inMenuRepresentation;
 
 @end
 

--- a/ios/stack/header/RNSStackHeaderMenuFinder.mm
+++ b/ios/stack/header/RNSStackHeaderMenuFinder.mm
@@ -25,6 +25,7 @@
                           headerItem:(nullable id<RNSStackHeaderItemDataProviding>)headerItem
                             rootMenu:(nullable RNSStackHeaderMenuData *)rootMenu
                        trackerItemId:(nullable NSString *)trackerItemId
+                inMenuRepresentation:(BOOL)inMenuRepresentation
 {
   if (self = [super init]) {
     _searchResult = searchResult;
@@ -32,6 +33,7 @@
     _headerItem = headerItem;
     _rootMenu = rootMenu;
     _trackerItemId = [trackerItemId copy];
+    _inMenuRepresentation = inMenuRepresentation;
   }
   return self;
 }
@@ -47,16 +49,30 @@
                                                 titleMenu:(nullable RNSStackHeaderMenuData *)titleMenu
 {
   for (id<RNSStackHeaderItemDataProviding> item in items) {
-    if (item.menu == nil || item.itemId == nil) {
+    if (item.itemId == nil) {
       continue;
     }
-    RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId inMenu:item.menu];
-    if (result != nil) {
-      return [[RNSMenuElementLocator alloc] initWithSearchResult:result
-                                                        position:RNSMenuElementPositionItem
-                                                      headerItem:item
-                                                        rootMenu:item.menu
-                                                   trackerItemId:item.itemId];
+    if (item.menu != nil) {
+      RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId inMenu:item.menu];
+      if (result != nil) {
+        return [[RNSMenuElementLocator alloc] initWithSearchResult:result
+                                                          position:RNSMenuElementPositionItem
+                                                        headerItem:item
+                                                          rootMenu:item.menu
+                                                     trackerItemId:item.itemId
+                                              inMenuRepresentation:NO];
+      }
+    }
+    if (item.menuRepresentation != nil) {
+      RNSStackHeaderMenuElementSearchResult *result = [self findElementWithId:elementId inMenu:item.menuRepresentation];
+      if (result != nil) {
+        return [[RNSMenuElementLocator alloc] initWithSearchResult:result
+                                                          position:RNSMenuElementPositionItem
+                                                        headerItem:item
+                                                          rootMenu:item.menuRepresentation
+                                                     trackerItemId:item.itemId
+                                              inMenuRepresentation:YES];
+      }
     }
   }
 
@@ -67,7 +83,8 @@
                                                         position:RNSMenuElementPositionTitle
                                                       headerItem:nil
                                                         rootMenu:titleMenu
-                                                   trackerItemId:RNSTitleMenuTrackerItemId];
+                                                   trackerItemId:RNSTitleMenuTrackerItemId
+                                            inMenuRepresentation:NO];
     }
   }
 

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -371,19 +371,52 @@
 
   if (item.menu == nil) {
     barButtonItem.menu = nil;
+  } else {
+    RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:itemId];
+    __weak auto weakSelf = self;
+    [RNSStackHeaderMenuCoordinator applyMenu:item.menu
+                             toBarButtonItem:barButtonItem
+                    withHeaderEventsDelegate:_eventsDelegate
+                                stateTracker:tracker
+                             withImageLoader:_imageLoader
+                     menuInvalidatedCallback:^{
+                       [weakSelf reapplyMenuForItemWithId:itemId];
+                     }];
+  }
+
+  [self reapplyMenuRepresentationForItemWithId:itemId];
+}
+
+/**
+ Finds an existing barButtonItem and its corresponding config, then applies the menu
+ representation again. If the config is missing, it clears the representation.
+ */
+- (void)reapplyMenuRepresentationForItemWithId:(NSString *)itemId
+{
+  if (_configDataProvider == nil || itemId == nil) {
+    return;
+  }
+
+  UIBarButtonItem *barButtonItem = _barButtonItemsByItemId[itemId];
+  if (barButtonItem == nil) {
+    return;
+  }
+
+  id<RNSStackHeaderItemDataProviding> item = [self findItemWithId:itemId];
+  if (item == nil) {
     return;
   }
 
   RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:itemId];
   __weak auto weakSelf = self;
-  [RNSStackHeaderMenuCoordinator applyMenu:item.menu
-                           toBarButtonItem:barButtonItem
-                  withHeaderEventsDelegate:_eventsDelegate
-                              stateTracker:tracker
-                           withImageLoader:_imageLoader
-                   menuInvalidatedCallback:^{
-                     [weakSelf reapplyMenuForItemWithId:itemId];
-                   }];
+  [RNSStackHeaderMenuCoordinator applyMenuRepresentation:item.menuRepresentation
+                                         toBarButtonItem:barButtonItem
+                                withHeaderEventsDelegate:_eventsDelegate
+                                            stateTracker:tracker
+                                         withImageLoader:_imageLoader
+                                 menuInvalidatedCallback:^{
+                                   [weakSelf reapplyMenuRepresentationForItemWithId:itemId];
+                                 }];
 }
 
 - (nullable id<RNSStackHeaderItemDataProviding>)findItemWithId:(NSString *)itemId
@@ -565,6 +598,20 @@
                      menuInvalidatedCallback:^{
                        [weakSelf reapplyMenuForItemWithId:capturedItemId];
                      }];
+  }
+
+  if (item.menuRepresentation != nil && item.itemId != nil) {
+    RNSStackHeaderMenuToggleStateTracker *tracker = [_trackerRegistry trackerForItemId:item.itemId];
+    __weak auto weakSelf = self;
+    NSString *capturedItemId = item.itemId;
+    [RNSStackHeaderMenuCoordinator applyMenuRepresentation:item.menuRepresentation
+                                           toBarButtonItem:barButtonItem
+                                  withHeaderEventsDelegate:_eventsDelegate
+                                              stateTracker:tracker
+                                           withImageLoader:_imageLoader
+                                   menuInvalidatedCallback:^{
+                                     [weakSelf reapplyMenuRepresentationForItemWithId:capturedItemId];
+                                   }];
   }
 
   if (item.itemId != nil) {

--- a/src/components/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/stack/header/StackHeaderConfig.ios.tsx
@@ -110,10 +110,10 @@ function StackHeaderConfig(
       [
         ...(leadingItems ?? [])
           .filter(it => it && it.type === 'item')
-          .map(it => it.menu),
+          .flatMap(it => [it.menu, it.menuRepresentation]),
         ...(trailingItems ?? [])
           .filter(it => it && it.type === 'item')
-          .map(it => it.menu),
+          .flatMap(it => [it.menu, it.menuRepresentation]),
         titleMenu,
       ].filter(it => !!it),
     [leadingItems, trailingItems, titleMenu],

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -93,6 +93,19 @@ export interface SupportsMenuIOS {
    * @platform iOS
    */
   menu?: StackHeaderMenuIOS | undefined;
+  /**
+   * @summary Menu definition substituting the item when it is displayed in a menu.
+   *
+   * @description
+   * When the system moves the item into a menu (e.g. the navigation bar
+   * overflow menu), this menu is displayed in its place. Useful for custom items
+   * ({@link StackHeaderInlineCustomItemIOS.render | render}), which iOS doesn't display in the overflow menu otherwise.
+   *
+   * @platform iOS
+   *
+   * @supported iOS 16 and higher
+   */
+  menuRepresentation?: StackHeaderMenuIOS | undefined;
 }
 
 export interface SupportsSharedBackgroundIOS {

--- a/src/components/stack/header/ios/StackHeaderItem.ios.tsx
+++ b/src/components/stack/header/ios/StackHeaderItem.ios.tsx
@@ -6,7 +6,7 @@ import { NativeSyntheticEvent, StyleSheet } from 'react-native';
 import { resolveIconAssetSources, resolveMenuIcons } from './iconUtils.ios';
 
 export default function StackHeaderItem(props: StackHeaderItemProps) {
-  const { render, onPress, icon, menu, ...rest } = props;
+  const { render, onPress, icon, menu, menuRepresentation, ...rest } = props;
 
   // `rest.menu` includes some JS callback within nested menu specification
   // codegen strips JS functions and replaces them with NULLT and keys of such type
@@ -24,12 +24,20 @@ export default function StackHeaderItem(props: StackHeaderItemProps) {
     () => (menu != null ? resolveMenuIcons(menu) : undefined),
     [menu],
   );
+  const resolvedMenuRepresentation = useMemo(
+    () =>
+      menuRepresentation != null
+        ? resolveMenuIcons(menuRepresentation)
+        : undefined,
+    [menuRepresentation],
+  );
 
   return (
     <StackHeaderItemIOSNativeComponent
       {...rest}
       icon={resolvedIcon}
       menu={resolvedMenu}
+      menuRepresentation={resolvedMenuRepresentation}
       // We need to tell iOS that we want the handler to be attached only when we actually require it
       // because doing so makes the menu appear on long press instead of tap
       respondsToOnPress={!!onPress}

--- a/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
+++ b/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
@@ -18,5 +18,6 @@ export type StackHeaderItemProps = {
   icon?: PlatformIconIOS | undefined;
   render?: (() => ReactElement) | undefined;
   menu?: StackHeaderMenuIOS | undefined;
+  menuRepresentation?: StackHeaderMenuIOS | undefined;
   onPress?: (() => void) | undefined;
 };

--- a/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
@@ -75,6 +75,7 @@ export interface NativeProps extends ViewProps {
   title?: string | undefined;
   icon?: UnsafeMixed<PlatformIconIOS> | undefined;
   menu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
+  menuRepresentation?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
   respondsToOnPress?: CT.WithDefault<boolean, false>;
   onHeaderItemPress?: CT.DirectEventHandler<HeaderItemPressEvent> | undefined;
 }


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1179

## Description

This PR adds `menuRepresentation` prop to leading and trailing header items. This allows for specifying different menu definition for when the item is moved to the overflow menu.

Without this prop:
- for regular items, UIKit takes the `menu` (if specified) and `onPress` action (if specified) and combines them. This may break UI if, for instance, the menu consists only of radio buttons - the `onPress` action would be added nonetheless
- custom items are not present at all. What's more, if the header has only custom items, the overflow menu button will render but won't show anything on press

> [!important]
> The feature is testable on iOS 26+. Below this version, items never go into overflow menu, unless the overflow menu is already present, or other conditions are met (interface style + specific item groups setup - not supported in foreseeable future)

## Changes

- added `menuRepresentation` prop and wired it the same as `menu`

## Before & after - visual documentation

https://github.com/user-attachments/assets/caad7fef-f74b-425a-9e93-d5b603c18c06

## Test plan

Use Stack Header Menu (iOS) SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
