### PR TITLE
fix(iOS, Stack v4+): reapply header config once the navigation bar has a window

### DIFF
--- a/apps/src/tests/issue-tests/Test4479.tsx
+++ b/apps/src/tests/issue-tests/Test4479.tsx
@@ -1,0 +1,91 @@
+import React from 'react';
+import { Appearance, Button } from 'react-native';
+import {
+  NavigationContainer,
+  NavigationIndependentTree,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import {
+  DEFAULT_TAB_ROUTE_OPTIONS,
+  TabsContainer,
+} from '@apps/shared/containers/tabs';
+import { CenteredLayoutView } from '@apps/shared/CenteredLayoutView';
+import { ThemedText } from '@apps/shared';
+
+type RouteParamList = {
+  One: undefined;
+};
+
+const Stack = createNativeStackNavigator<RouteParamList>();
+
+function OneScreen() {
+  return (
+    <CenteredLayoutView>
+      <ThemedText>Watch the prominent + button in the header.</ThemedText>
+    </CenteredLayoutView>
+  );
+}
+
+function TabOne() {
+  return (
+    <NavigationIndependentTree>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen
+            name="One"
+            component={OneScreen}
+            options={{
+              title: 'One',
+              headerLargeTitle: true,
+              unstable_headerRightItems: () => [
+                {
+                  type: 'button',
+                  label: 'Add',
+                  icon: { type: 'sfSymbol', name: 'plus' },
+                  variant: 'prominent',
+                  tintColor: '#3B72C0',
+                  onPress: () => {},
+                },
+              ],
+            }}
+          />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </NavigationIndependentTree>
+  );
+}
+
+function TabTwo() {
+  return (
+    <CenteredLayoutView>
+      <Button
+        title="Toggle appearance, then go back to One"
+        onPress={() =>
+          Appearance.setColorScheme(
+            Appearance.getColorScheme() === 'dark' ? 'light' : 'dark',
+          )
+        }
+      />
+    </CenteredLayoutView>
+  );
+}
+
+export default function App() {
+  return (
+    <TabsContainer
+      defaultRouteName="One"
+      routeConfigs={[
+        {
+          name: 'One',
+          element: <TabOne />,
+          options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'One' },
+        },
+        {
+          name: 'Two',
+          element: <TabTwo />,
+          options: { ...DEFAULT_TAB_ROUTE_OPTIONS, title: 'Two' },
+        },
+      ]}
+    />
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as Test4479 } from './Test4479';
 export { default as Test4519 } from './Test4519';
 export { default as Test4571 } from './Test4571';
 export { default as TestScreenAnimation } from './TestScreenAnimation';

--- a/ios/legacy/RNSScreenStack.mm
+++ b/ios/legacy/RNSScreenStack.mm
@@ -283,6 +283,16 @@ RNS_IGNORE_SUPER_CALL_END
   [super didMoveToWindow];
   // for handling nested stacks
   [self maybeAddToParentAndUpdateContainer];
+
+  if (self.window != nil) {
+    // The header config of the screen shown by this stack might have been applied while our
+    // navigation bar was still outside of any window, which leaves part of the navigation item
+    // styling unrealized. Now that the bar has a window, let the config finish the job.
+    if ([_controller.topViewController isKindOfClass:RNSScreen.class]) {
+      RNSScreen *topScreen = (RNSScreen *)_controller.topViewController;
+      [[topScreen.screenView findHeaderConfig] updateViewControllerIfAppliedOutsideWindow];
+    }
+  }
 }
 
 - (void)maybeAddToParentAndUpdateContainer

--- a/ios/legacy/RNSScreenStackHeaderConfig.h
+++ b/ios/legacy/RNSScreenStackHeaderConfig.h
@@ -99,6 +99,16 @@ NS_ASSUME_NONNULL_END
  */
 - (void)updateHeaderStateInShadowTreeInContextOfNavigationBar:(nullable UINavigationBar *)navBar;
 
+/**
+ * Applies this config again if the last application landed on a navigation bar that did not belong
+ * to any window. Does nothing otherwise.
+ *
+ * Some of the navigation item styling is realized by UIKit only for a navigation bar inside a
+ * window, so an application performed before the bar is attached is incomplete and has to be
+ * repeated. Call this once the owning screen is known to be in the view hierarchy.
+ */
+- (void)updateViewControllerIfAppliedOutsideWindow;
+
 @end
 
 #pragma mark - Experimental

--- a/ios/legacy/RNSScreenStackHeaderConfig.mm
+++ b/ios/legacy/RNSScreenStackHeaderConfig.mm
@@ -59,6 +59,10 @@ static const NSNumber *const DEFAULT_TITLE_LARGE_FONT_SIZE = @34;
   /// transaction via RCTMountingTransactionObserving protocol.
   bool _addedReactSubviewsInCurrentTransaction;
   RCTImageLoader *_imageLoader;
+
+  /// Whether the navigation bar this config was last applied to was outside of any window at the time.
+  /// See `-updateViewControllerIfAppliedOutsideWindow`.
+  BOOL _appliedOutsideWindow;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -155,6 +159,30 @@ RNS_IGNORE_SUPER_CALL_END
     // returned by the `onHeaderHeightChange` event is correct.
     [self.screenView.controller calculateAndNotifyHeaderHeightChangeIsModal:NO];
   }
+}
+
+- (void)updateViewControllerIfAppliedOutsideWindow
+{
+  if (!_appliedOutsideWindow) {
+    return;
+  }
+  _appliedOutsideWindow = NO;
+
+  // The navigation bar has a window by now, but the hierarchy insertion that brought it there is
+  // still in progress and applying synchronously leaves the styling as unrealized as before. One
+  // turn of the main queue later the bar is fully attached and the application takes effect.
+  __weak RNSScreenStackHeaderConfig *weakSelf = self;
+  dispatch_async(dispatch_get_main_queue(), ^{
+    RNSScreenStackHeaderConfig *config = weakSelf;
+    if (config == nil) {
+      return;
+    }
+    UIViewController *vc = config.screenView.controller;
+    if (vc == nil || vc.parentViewController == nil) {
+      return;
+    }
+    [RNSScreenStackHeaderConfig updateViewController:vc withConfig:config animated:NO];
+  });
 }
 
 - (void)layoutNavigationControllerView
@@ -652,6 +680,13 @@ RNS_IGNORE_SUPER_CALL_END
                                                 withCurrentItems:navitem.leftBarButtonItems];
   navitem.rightBarButtonItems = [config barButtonItemsFromConfigs:config.headerRightBarButtonItems
                                                  withCurrentItems:navitem.rightBarButtonItems];
+
+  // A bar button item assigned to a navigation bar that is not in a window yet misses the styling
+  // UIKit resolves against that window - on iOS 26 a `prominent` item ends up without its
+  // background until the items are assigned again. A stack nested in tabs reaches this state
+  // whenever a tab is re-selected after its view has been detached, and nothing reassigns the items
+  // afterwards, so record the incomplete application for `RNSScreenStackView` to repeat.
+  config->_appliedOutsideWindow = navctr.navigationBar.window == nil;
 
   // Setting navigation bar visibility is split to mitigate iOS 26 bug with bar button items
   // (setting nav bar visibility should be done after `navitem.*BarButtonItems`).


### PR DESCRIPTION
## Description

Closes #4479.

A `UIBarButtonItem` assigned to a navigation bar that is not part of any window misses the styling UIKit resolves against that window. On iOS 26 a `variant: 'prominent'` item then renders as a bare glyph — no background — until the items are assigned again.

A stack nested in tabs reaches that state on every tab re-selection that follows its view being detached, which is what `Appearance.setColorScheme()` on another tab triggers. `-[RNSScreenStackView navigationController:willShowViewController:animated:]` applies the header config while the bar is still window-less, and nothing reassigns the items afterwards, so the button stays background-less for the whole visit. Switching tabs once more assigns the items again, this time into an attached bar, which is why the button "repairs itself" on the second visit.

Instrumented `RNSScreenStackHeaderConfig` to confirm this. RNS does identical work in the broken and the self-repairing pass — same view controller, one `willShowViewController:`, a fresh `RNSBarButtonItem` with `variant=prominent` resolved to `UIBarButtonItemStyleProminent` — and the only difference is the bar's window:

```
# tab re-selection right after Appearance.setColorScheme() on the other tab
applied vc=0x13b023700 barWindow=0x0                <- button renders without background
# any later tab switch
applied vc=0x13b023700 barWindow=0x1061c0400        <- button renders correctly
```

Reusing the previous `UIBarButtonItem` instances instead of building new ones does **not** help, so this is not item churn — it is the window the bar is missing when the items land on it.

## Changes

- `RNSScreenStackHeaderConfig` records when an application landed on a window-less navigation bar, and exposes `-updateViewControllerIfAppliedOutsideWindow` to repeat exactly that application.
- `RNSScreenStackView -didMoveToWindow` asks the top screen's header config to repeat it once the stack is in a window.
- The repeat is dispatched one main-queue turn later. The hierarchy insertion that brought the bar into the window is still in progress while `didMoveToWindow` runs, and applying synchronously there leaves the styling unrealized exactly as before — verified on device before settling on the async hop.
- Added `Test4479` to the issue tests, based on the MRE @t0maboro attached to the issue.

Two notes on scope:

- The flag is not gated on iOS version. The incomplete application is a general property of applying header config to a detached bar; only the visible symptom found so far is iOS 26 specific.
- If a bar were to lack a window while the stack view already had one, no `didMoveToWindow` follows and the flag simply stays set until the next attach — the same behaviour as today, no regression.

## Before & after - visual documentation

`Test4479` on iPhone 17 Pro, iOS 26.5, after: tab One → tab Two → toggle appearance → back to tab One.

| Before | After |
| --- | --- |
| <img width="300" src="https://raw.githubusercontent.com/LizunovSergey/react-native-screens/assets/4479/before.png" /> | <img width="300" src="https://raw.githubusercontent.com/LizunovSergey/react-native-screens/assets/4479/after.png" /> |

## Test plan

`apps/src/tests/issue-tests/Test4479.tsx` (new), run through `FabricExample` on an iPhone 17 Pro / iOS 26.5 simulator.

1. Issue Tests → `Test4479`. Tab One shows a prominent `+` in the header.
2. Switch to tab Two, press **Toggle appearance, then go back to One**.
3. Switch back to tab One.

Before the change the `+` has lost its background and keeps it lost for the whole visit; after the change it keeps the background. Repeated toggles and tab switches were also checked in both directions.

Regression checks on the same build:

- Playgrounds → **Bar Button Items** → **Prominent Style Button**: a prominent item in a plain (non-tabbed) stack still renders with its background.
- Repeated tab switches without an appearance change behave as before, no flicker from the extra application.
- `yarn check-types` passes; the touched Objective-C files are unchanged under the repository `.clang-format`, and the new test file is Prettier-clean.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes

---

Written by an agent (Claude Code, claude-opus-5) on behalf of @LizunovSergey; the diagnosis above was verified on a simulator rather than inferred.
