### PR TITLE
feat(iOS, Stack v5): Add `prompt` to stack header

### DIFF
--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,9 +1,7 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 
-// TEMP: swapped for prompt-prop verification, restore before commit
-// import Example from './Example';
-import { TestStackSubviewsIOS as Example } from './src/tests/single-feature-tests';
+import Example from './Example';
 
 // import { TestTabsSimpleNav as Example } from './src/tests/single-feature-tests';
 // import { TestTabsInStackStableEnterTransition as Example } from './src/tests/component-integration-tests';

--- a/apps/App.tsx
+++ b/apps/App.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { enableFreeze } from 'react-native-screens';
 
-import Example from './Example';
+// TEMP: swapped for prompt-prop verification, restore before commit
+// import Example from './Example';
+import { TestStackSubviewsIOS as Example } from './src/tests/single-feature-tests';
 
 // import { TestTabsSimpleNav as Example } from './src/tests/single-feature-tests';
 // import { TestTabsInStackStableEnterTransition as Example } from './src/tests/component-integration-tests';

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -94,6 +94,7 @@ function SmallHorizontalItem() {
 interface Config {
   enabled: boolean;
   hidden: boolean;
+  promptEnabled: boolean;
   largeTitleEnabled: boolean;
   largeTitle: LargeTitleOption;
   largeSubtitle: LargeSubtitleOption;
@@ -123,6 +124,7 @@ function resolveTitle(
 const DEFAULT_CONFIG: Config = {
   enabled: true,
   hidden: false,
+  promptEnabled: false,
   largeTitleEnabled: false,
   largeTitle: 'none',
   largeSubtitle: 'none',
@@ -206,6 +208,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
     subtitle: resolveTitle(config.subtitle),
     hidden: config.hidden,
     ios: {
+      prompt: config.promptEnabled ? 'Header prompt' : undefined,
       largeTitleEnabled: config.largeTitleEnabled,
       largeTitle: resolveTitle(config.largeTitle),
       largeSubtitle: resolveTitle(config.largeSubtitle),
@@ -279,6 +282,11 @@ function ConfigScreen() {
         label="hidden"
         value={config.hidden}
         onValueChange={v => updateConfig('hidden', v)}
+      />
+      <SettingsSwitch
+        label="prompt"
+        value={config.promptEnabled}
+        onValueChange={v => updateConfig('promptEnabled', v)}
       />
       <SettingsSwitch
         label="large header enabled"

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
@@ -81,11 +81,18 @@ stay manual.
 12. Set title to `long` and `largeTitle` to `short`. Scroll to reveal large title.
 
   - [ ] on iOS 18, largeTitle should be long
+  
   - [ ] on iOS 26, largeTitle should be short
 
 13. Set `largeTitle` to `none`.
 
   - [ ] on iOS 26, largeTitle should be long
+
+14. Enable `prompt`. Verify layout.
+
+  - [ ] Prompt text shows above the title and the navigation bar grows in height.
+  
+  - [ ] Position of items on device matches element tree.
 
 ## Steps on iPad
 

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.h
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.h
@@ -22,6 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *largeTitle;
 @property (nonatomic, readonly, nullable) NSString *largeSubtitle;
 @property (nonatomic, readonly) BOOL largeTitleEnabled;
+@property (nonatomic, readonly, nullable) NSString *prompt;
 @property (nonatomic, readonly, nullable) NSString *backButtonTitle;
 @property (nonatomic, readonly) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic, readonly) BOOL backButtonMenuEnabled;

--- a/ios/stack/header/RNSStackHeaderConfigComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderConfigComponentView.mm
@@ -66,6 +66,7 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
   _largeTitle = nil;
   _largeSubtitle = nil;
   _largeTitleEnabled = NO;
+  _prompt = nil;
   _backButtonTitle = nil;
   _backButtonDisplayMode = UINavigationItemBackButtonDisplayModeDefault;
   _backButtonMenuEnabled = YES;
@@ -432,6 +433,10 @@ static void RNSAssertIsValidHeaderChild(UIView *child)
 
   if (oldHeaderProps.largeTitleEnabled != newHeaderProps.largeTitleEnabled) {
     _largeTitleEnabled = newHeaderProps.largeTitleEnabled;
+  }
+
+  if (oldHeaderProps.prompt != newHeaderProps.prompt) {
+    _prompt = RCTNSStringFromStringNilIfEmpty(newHeaderProps.prompt);
   }
 
   if (oldHeaderProps.backButtonTitle != newHeaderProps.backButtonTitle) {

--- a/ios/stack/header/RNSStackHeaderConfigDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderConfigDataProviding.h
@@ -14,6 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) NSString *largeTitle;
 @property (nonatomic, readonly, nullable) NSString *largeSubtitle;
 @property (nonatomic, readonly) BOOL largeTitleEnabled;
+@property (nonatomic, readonly, nullable) NSString *prompt;
 @property (nonatomic, readonly, nullable) NSString *backButtonTitle;
 @property (nonatomic, readonly) UINavigationItemBackButtonDisplayMode backButtonDisplayMode;
 @property (nonatomic, readonly) BOOL backButtonMenuEnabled;

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -335,6 +335,7 @@
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 
 #if !TARGET_OS_TV
+  navItem.prompt = nil;
   navItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 
   [self clearAppliedBackButtonConfig];
@@ -424,6 +425,14 @@
   navItem.title = _configDataProvider.title;
 
 #if !TARGET_OS_TV
+  NSString *prompt = _configDataProvider.prompt;
+  if (navItem.prompt != prompt && ![navItem.prompt isEqualToString:prompt]) {
+    navItem.prompt = prompt;
+    // UIKit does not resize an already visible navigation bar when the prompt
+    // of its navigation item changes - request layout explicitly.
+    [controller.navigationController.view setNeedsLayout];
+  }
+
   [self applyBackButtonConfigForController:controller];
 #endif // !TARGET_OS_TV
 

--- a/src/components/stack/header/StackHeaderConfig.ios.tsx
+++ b/src/components/stack/header/StackHeaderConfig.ios.tsx
@@ -55,6 +55,7 @@ function StackHeaderConfig(
     largeTitle,
     largeSubtitle,
     largeTitleEnabled,
+    prompt,
     backButtonTitle,
     backButtonDisplayMode,
     backButtonMenuEnabled,
@@ -160,6 +161,7 @@ function StackHeaderConfig(
       largeTitle={largeTitle}
       largeSubtitle={largeSubtitle}
       largeTitleEnabled={!!largeTitleEnabled}
+      prompt={prompt}
       titleMenu={resolvedTitleMenu}
       style={styles.config}
       onMenuItemPress={handleMenuItemPress}

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -425,6 +425,16 @@ export interface StackHeaderConfigPropsIOS {
    * @supported iOS 26 and higher
    */
   largeSubtitleItem?: StackHeaderTitleCustomItemIOS | undefined;
+  /**
+   * @summary A single line of text displayed at the top of the navigation bar,
+   * above the title.
+   *
+   * @description
+   * Setting this prop increases the height of the navigation bar.
+   *
+   * @platform iOS
+   */
+  prompt?: string | undefined;
 }
 
 export interface StackHeaderConfigCommandsIOS {

--- a/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderConfigIOSNativeComponent.ts
@@ -37,6 +37,8 @@ export interface NativeProps extends ViewProps {
   largeSubtitle?: string | undefined;
   largeTitleEnabled?: CT.WithDefault<boolean, false>;
 
+  prompt?: string | undefined;
+
   titleMenu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;
 
   onMenuItemPress?: CT.DirectEventHandler<MenuItemPressEvent> | undefined;


### PR DESCRIPTION
Closes https://github.com/software-mansion/react-native-screens-labs/issues/1135

## Description

This PR adds `prompt` prop to stack header. This is one-line text displayed above the header. 

As a side-effect, it makes the header larger.

## Changes

- Added `prompt` prop
- Updated header subviews SFT

## Before & after - visual documentation

<img width="400" height="298" alt="image" src="https://github.com/user-attachments/assets/7a914b19-0fee-4929-a7f3-4682a8460519" />

## Test plan

Verify layout with `test-stack-subviews-ios` SFT

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
