### PR TITLE
feat(iOS, Stack v5): Add `hidesSharedBackground` prop to header items

### DIFF
--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/index.tsx
@@ -100,6 +100,7 @@ interface Config {
   largeSubtitle: LargeSubtitleOption;
   leadingItemsCount: number;
   trailingItemsCount: number;
+  hidesSharedBackground: boolean;
   title: TitleOption;
   subtitle: TitleOption;
   hitSlop: HitSlopValue;
@@ -130,6 +131,7 @@ const DEFAULT_CONFIG: Config = {
   largeSubtitle: 'none',
   leadingItemsCount: 2,
   trailingItemsCount: 2,
+  hidesSharedBackground: false,
   title: 'short',
   subtitle: 'short',
   hitSlop: '0',
@@ -175,6 +177,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
     }).map((_, i) => ({
       type: 'item',
       id: `leading-${i}`,
+      hidesSharedBackground: config.hidesSharedBackground,
       render: () => <ResizingItem />,
     }));
   if (leadingItems.length > 1) {
@@ -192,6 +195,7 @@ function buildHeaderConfig(config: Config): StackHeaderConfigProps | undefined {
     (_, i) => ({
       type: 'item',
       id: `trailing-${i}`,
+      hidesSharedBackground: config.hidesSharedBackground,
       render: () => <ResizingItem />,
     }),
   );
@@ -287,6 +291,11 @@ function ConfigScreen() {
         label="prompt"
         value={config.promptEnabled}
         onValueChange={v => updateConfig('promptEnabled', v)}
+      />
+      <SettingsSwitch
+        label="hidesSharedBackground"
+        value={config.hidesSharedBackground}
+        onValueChange={v => updateConfig('hidesSharedBackground', v)}
       />
       <SettingsSwitch
         label="large header enabled"

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
@@ -22,6 +22,7 @@ stay manual.
 ## Note
 
 - "Position of items on device matches element tree" means that the DevTools overlay the item highlight with correct position and size. Alternatively, this could be checked by pressing and moving the cursor over the button to see if the whole visible area works, not triggering onPressOut immediately
+- `hidesSharedBackground` is available in iOS 26 and above
 
 ### Known Issues/Important Observations
 
@@ -93,6 +94,14 @@ stay manual.
   - [ ] Prompt text shows above the title and the navigation bar grows in height.
   
   - [ ] Position of items on device matches element tree.
+  
+## hidesSharedBackground (iOS 26)
+  
+1. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
+
+2. Enable `hidesSharedBackground`. Repeat steps 4 - 10 on iPhone.
+
+  - [ ] No change in the behavior
 
 ## Steps on iPad
 

--- a/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
+++ b/apps/src/tests/single-feature-tests/stack-v5/test-stack-subviews-ios/scenario.md
@@ -99,7 +99,11 @@ stay manual.
   
 1. Reload the application (dev console causes some layout-related callbacks to trigger which may hide regressions)
 
-2. Enable `hidesSharedBackground`. Repeat steps 4 - 10 on iPhone.
+2. Enable `hidesSharedBackground`.
+
+  - [ ] Glass bubble is gone on all items. They may shift slightly (few pixels).
+
+3. Repeat main steps 4 - 10 on iPhone.
 
   - [ ] No change in the behavior
 

--- a/ios/stack/header/RNSStackHeaderItemComponentView.h
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) UIView *customView;
 @property (nonatomic, readonly) BOOL respondsToOnPress;
+@property (nonatomic, readonly) BOOL hidesSharedBackground;
 
 @property (nonatomic, nullable) NSString *titleProp;
 @property (nonatomic, nullable) RNSStackHeaderIconData *iconProp;

--- a/ios/stack/header/RNSStackHeaderItemComponentView.mm
+++ b/ios/stack/header/RNSStackHeaderItemComponentView.mm
@@ -52,6 +52,7 @@ namespace react = facebook::react;
   _placement = RNSHeaderItemPlacementTrailing;
   _didSetHeaderItemPlacement = NO;
   _respondsToOnPress = NO;
+  _hidesSharedBackground = NO;
 }
 
 - (void)setTitleProp:(NSString *)titleProp
@@ -217,6 +218,11 @@ RNS_IGNORE_SUPER_CALL_END
 
   if (oldItemProps.respondsToOnPress != newItemProps.respondsToOnPress) {
     _respondsToOnPress = newItemProps.respondsToOnPress;
+    needsUpdate = YES;
+  }
+
+  if (oldItemProps.hidesSharedBackground != newItemProps.hidesSharedBackground) {
+    _hidesSharedBackground = newItemProps.hidesSharedBackground;
     needsUpdate = YES;
   }
 

--- a/ios/stack/header/RNSStackHeaderItemDataProviding.h
+++ b/ios/stack/header/RNSStackHeaderItemDataProviding.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly, nullable) RNSStackHeaderMenuData *menu;
 @property (nonatomic, readonly, nullable) UIView *customView;
 @property (nonatomic, readonly) BOOL respondsToOnPress;
+@property (nonatomic, readonly) BOOL hidesSharedBackground;
 
 @end
 

--- a/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
+++ b/ios/stack/screen/RNSStackScreenHeaderCoordinator.mm
@@ -549,6 +549,7 @@
     if (item.identifier != nil) {
       barButtonItem.identifier = item.identifier;
     }
+    barButtonItem.hidesSharedBackground = item.hidesSharedBackground;
   }
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
 

--- a/src/components/stack/header/StackHeaderConfig.ios.types.ts
+++ b/src/components/stack/header/StackHeaderConfig.ios.types.ts
@@ -95,6 +95,24 @@ export interface SupportsMenuIOS {
   menu?: StackHeaderMenuIOS | undefined;
 }
 
+export interface SupportsSharedBackgroundIOS {
+  /**
+   * @summary Whether the liquid glass background for this item should be hidden.
+   *
+   * @description
+   * On iOS 26, adjacent bar button items are grouped inside a shared liquid
+   * glass background. Setting this to `true` removes the shared background
+   * from this item.
+   *
+   * @default false
+   *
+   * @platform iOS
+   *
+   * @supported iOS 26 and higher
+   */
+  hidesSharedBackground?: boolean | undefined;
+}
+
 export interface SupportsIdentifierIOS {
   /**
    * @summary Stable identifier used to match the item across different screens
@@ -122,7 +140,8 @@ export interface SupportsIdentifierIOS {
 export interface StackHeaderInlineItemIOS
   extends StackHeaderBaseItemIOS,
     SupportsMenuIOS,
-    SupportsIdentifierIOS {
+    SupportsIdentifierIOS,
+    SupportsSharedBackgroundIOS {
   /**
    * @summary Marks this object as a header item definition.
    *
@@ -149,7 +168,8 @@ export interface StackHeaderInlineItemIOS
  */
 export interface StackHeaderInlineCustomItemIOS
   extends SupportsMenuIOS,
-    SupportsIdentifierIOS {
+    SupportsIdentifierIOS,
+    SupportsSharedBackgroundIOS {
   /**
    * @summary A unique identifier within the screen header.
    *

--- a/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
+++ b/src/components/stack/header/ios/StackHeaderItem.ios.types.ts
@@ -13,6 +13,7 @@ export type StackHeaderItemProps = {
   placement: StackHeaderItemPlacement;
   itemId?: string | undefined;
   identifier?: string | undefined;
+  hidesSharedBackground?: boolean | undefined;
   title?: string | undefined;
   icon?: PlatformIconIOS | undefined;
   render?: (() => ReactElement) | undefined;

--- a/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
+++ b/src/fabric/stack/StackHeaderItemIOSNativeComponent.ts
@@ -71,6 +71,7 @@ export interface NativeProps extends ViewProps {
   placement?: CT.WithDefault<Placement, 'trailing'>;
   itemId?: string | undefined;
   identifier?: string | undefined;
+  hidesSharedBackground?: CT.WithDefault<boolean, false>;
   title?: string | undefined;
   icon?: UnsafeMixed<PlatformIconIOS> | undefined;
   menu?: UnsafeMixed<StackHeaderMenuIOS> | undefined;


### PR DESCRIPTION
## Description

This PR adds `hidesSharedBackground` prop to iOS header items. On iOS 26+ this removes the glass effect from items that set it.

## Changes

- Added `hidesSharedBackground` prop
- Extended test-stack-subviews-ios SFT

## Before & after - visual documentation


https://github.com/user-attachments/assets/6ec84e49-78d9-4f48-ab23-35e184f1aebf


## Test plan

Use `test-stack-subviews-ios` SFT. Verify the layout with `hidesSharedBackground` set to true.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
