### PR TITLE
feat(iOS, Split): Nesting Stack v5 in SplitView

### DIFF
--- a/ios/helpers/container/RNSNavigationControllerProviding.h
+++ b/ios/helpers/container/RNSNavigationControllerProviding.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * A component view backed by a navigation controller, which a parent component may install directly
+ * in its own view controller hierarchy instead of adding the component view as a subview.
+ */
+@protocol RNSNavigationControllerProviding <NSObject>
+
+@property (nonatomic, strong, readonly, nonnull) UINavigationController *navigationController;
+
+/**
+ * Set by the parent that installs `navigationController` itself; while YES the component must not
+ * place the controller on its own.
+ */
+@property (nonatomic, getter=isNavigationControllerPlacedByParent) BOOL navigationControllerPlacedByParent;
+
+/**
+ * Applies pending updates of `navigationController` immediately. Called by the parent before it
+ * installs the controller.
+ */
+- (void)flushPendingUpdates;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -122,11 +122,10 @@
   [self validateColumns:currentColumns];
   [self validateInspectors:currentInspectors];
 
-  NSMutableArray<RNSSplitNavigationController *> *currentViewControllers =
+  NSMutableArray<UINavigationController *> *currentViewControllers =
       [NSMutableArray arrayWithCapacity:currentColumns.count];
   for (RNSSplitScreenComponentView *column in currentColumns) {
-    [currentViewControllers addObject:[[RNSSplitNavigationController alloc] initWithRootViewController:column.controller
-                                                                             frameOriginChangeDelegate:self]];
+    [currentViewControllers addObject:[self navigationControllerForColumn:column]];
   }
 
   self.viewControllers = currentViewControllers;
@@ -160,6 +159,18 @@
   /** The assumption is that it should come in a single batch and it won't cause any delays in rendering the content. */
   [navigationController setNavigationBarHidden:YES animated:NO];
   [navigationController setNavigationBarHidden:NO animated:NO];
+}
+
+- (UINavigationController *)navigationControllerForColumn:(RNSSplitScreenComponentView *)column
+{
+  UIView<RNSNavigationControllerProviding> *provider = column.navigationControllerProvider;
+  if (provider != nil) {
+    // Controller's pending updates must be populated before the SplitView attaches it.
+    [provider flushPendingUpdates];
+    return provider.navigationController;
+  }
+  return [[RNSSplitNavigationController alloc] initWithRootViewController:column.controller
+                                                frameOriginChangeDelegate:self];
 }
 
 #pragma mark - Helpers
@@ -316,16 +327,16 @@
 }
 
 /**
- * @brief Gets the children RNSSplitScreenController instances.
+ * @brief Gets the children UINavigationControllers instances.
  *
  * Accesses Split controllers associated with presented columns. It asserts that each view controller is a navigation
  * controller and its topViewController is of type RNSSplitScreenController.
  *
- * @return An array of RNSSplitScreenController corresponding to current split view columns.
+ * @return An array of UINavigationController corresponding to current split view columns.
  */
-- (NSArray<RNSSplitScreenController *> *)splitScreenControllers
+- (NSArray<UINavigationController *> *)visibleColumnNavigationControllers
 {
-  NSMutableArray<RNSSplitScreenController *> *splitScreenControllers =
+  NSMutableArray<UINavigationController *> *navigationControllers =
       [NSMutableArray arrayWithCapacity:_visibleColumns.count];
 
   for (NSNumber *columnNumber in _visibleColumns) {
@@ -333,27 +344,45 @@
     UIViewController *viewController = [self viewControllerForColumn:column];
     RCTAssert(viewController != nil, @"[RNScreens] viewController for column %ld is nil.", (long)column);
 
-    RNSSplitNavigationController *splitNavigationController =
-        [viewController isKindOfClass:RNSSplitNavigationController.class]
-        ? (RNSSplitNavigationController *)viewController
-        : nil;
-    RCTAssert(splitNavigationController != nil,
-              @"[RNScreens] Expected RNSSplitNavigationController but got %@",
+    RCTAssert([viewController isKindOfClass:UINavigationController.class],
+              @"[RNScreens] Expected UINavigationController but got %@",
               NSStringFromClass(viewController.class));
 
-    UIViewController *maybeSplitScreenController = splitNavigationController.topViewController;
-    RCTAssert(
-        maybeSplitScreenController != nil, @"[RNScreens] RNSSplitScreenController is nil for column %ld", (long)column);
-    RCTAssert([maybeSplitScreenController isKindOfClass:RNSSplitScreenController.class],
-              @"[RNScreens] Expected RNSSplitScreenController but got %@",
-              NSStringFromClass(maybeSplitScreenController.class));
-
-    if ([maybeSplitScreenController isKindOfClass:RNSSplitScreenController.class]) {
-      [splitScreenControllers addObject:(RNSSplitScreenController *)maybeSplitScreenController];
+    if ([viewController isKindOfClass:UINavigationController.class]) {
+      [navigationControllers addObject:(UINavigationController *)viewController];
     }
   }
 
-  return splitScreenControllers;
+  return navigationControllers;
+}
+
+/**
+ * @brief Gets the RNSSplitScreenController of a **plain** column, or nil for a column backed by a provided
+ * external UINavigationController.
+ *
+ * A column providing an external UINavigationController has no RNSSplitScreenController in the hierarchy:
+ * the provided controller is installed directly and its top view controller is a screen of the nested container.
+ * Such a column reports its frame on its own, from the provided controller's view.
+ *
+ * TODO(@t0maboro): Unify layout reporting so that every column is re-reported through a single entry point,
+ * regardless of the UINavigationController origin.
+ */
+- (nullable RNSSplitScreenController *)splitScreenControllerOfSplitNavigationController:
+    (UINavigationController *)navigationController
+{
+  if (![navigationController isKindOfClass:RNSSplitNavigationController.class]) {
+    return nil;
+  }
+
+  UIViewController *maybeSplitScreenController = navigationController.topViewController;
+  RCTAssert(maybeSplitScreenController != nil, @"[RNScreens] RNSSplitScreenController is nil for a plain column");
+  RCTAssert([maybeSplitScreenController isKindOfClass:RNSSplitScreenController.class],
+            @"[RNScreens] Expected RNSSplitScreenController but got %@",
+            NSStringFromClass(maybeSplitScreenController.class));
+
+  return [maybeSplitScreenController isKindOfClass:RNSSplitScreenController.class]
+      ? (RNSSplitScreenController *)maybeSplitScreenController
+      : nil;
 }
 
 /**
@@ -394,7 +423,10 @@
  */
 - (void)splitNavigationControllerFrameOriginDidChange:(RNSSplitNavigationController *)splitNavCtrl
 {
-  for (RNSSplitScreenController *controller in self.splitScreenControllers) {
+  for (UINavigationController *navigationController in self.visibleColumnNavigationControllers) {
+    // Columns with external UINavigationController provider report on their own.
+    // TODO(@t0maboro): unify frame reporting logic
+    RNSSplitScreenController *controller = [self splitScreenControllerOfSplitNavigationController:navigationController];
     [controller columnPositioningDidChangeInSplitViewController:self];
   }
 }
@@ -531,7 +563,11 @@
       return;
     }
 
-    for (RNSSplitScreenController *controller in [strongSelf splitScreenControllers]) {
+    for (UINavigationController *navigationController in strongSelf.visibleColumnNavigationControllers) {
+      // Columns with external UINavigationController provider report on their own.
+      // TODO(@t0maboro): unify frame reporting logic
+      RNSSplitScreenController *controller =
+          [strongSelf splitScreenControllerOfSplitNavigationController:navigationController];
       [controller columnPositioningDidChangeInSplitViewController:strongSelf];
     }
   };

--- a/ios/split/RNSSplitScreenComponentView.h
+++ b/ios/split/RNSSplitScreenComponentView.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #import "RNSEnums.h"
+#import "RNSNavigationControllerProviding.h"
 #import "RNSReactBaseView.h"
 #import "RNSSafeAreaProviding.h"
 #import "RNSSplitScreenComponentEventEmitter.h"
@@ -22,6 +23,18 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, strong, readonly, nonnull) RNSSplitScreenController *controller;
 @property (nonatomic, weak, readwrite, nullable) RNSSplitHostComponentView *splitHost;
+
+@end
+
+#pragma mark - Nested container
+
+/**
+ * A column whose **only** child conforms to `RNSNavigationControllerProviding` is backed by the provided navigation
+ * controller instead of `controller`; neither the column view nor the child's view enter the UIKit hierarchy.
+ */
+@interface RNSSplitScreenComponentView ()
+
+@property (nonatomic, weak, readonly, nullable) UIView<RNSNavigationControllerProviding> *navigationControllerProvider;
 
 @end
 

--- a/ios/split/RNSSplitScreenComponentView.mm
+++ b/ios/split/RNSSplitScreenComponentView.mm
@@ -4,9 +4,15 @@
 #import <rnscreens/RNSSplitScreenComponentDescriptor.h>
 #import "RNSConversions.h"
 #import "RNSSafeAreaViewNotifications.h"
+#import "RNSSplitHostComponentView.h"
+#import "RNSSplitHostController.h"
 #import "RNSSplitScreenController.h"
 
 namespace react = facebook::react;
+
+// TODO(@t0maboro): Temporary frame-reporting logic for stack-backed columns. Unify this with
+// RNSSplitNavigationControllerFrameObserver.
+static void *RNSSplitScreenProvidedViewFrameContext = &RNSSplitScreenProvidedViewFrameContext;
 
 @implementation RNSSplitScreenComponentView {
   RNSSplitScreenComponentEventEmitter *_Nonnull _reactEventEmitter;
@@ -14,6 +20,9 @@ namespace react = facebook::react;
   RNSSplitScreenShadowStateProxy *_Nonnull _shadowStateProxy;
   RCTSurfaceTouchHandler *_Nullable _touchHandler;
   NSMutableSet<UIView *> *_viewsForFrameCorrection;
+
+  __weak UIView<RNSNavigationControllerProviding> *_Nullable _navigationControllerProvider;
+  __weak UIView *_Nullable _observedProvidedView;
 }
 
 - (RNSSplitScreenController *)controller
@@ -94,6 +103,95 @@ namespace react = facebook::react;
   [_viewsForFrameCorrection removeObject:view];
 }
 
+- (void)dealloc
+{
+  [self stopObservingProvidedView];
+}
+
+#pragma mark - Nested container
+
+- (nullable UIView<RNSNavigationControllerProviding> *)navigationControllerProvider
+{
+  return _navigationControllerProvider;
+}
+
+- (void)takeOverNavigationControllerOfProvider:(UIView<RNSNavigationControllerProviding> *)provider
+{
+  RCTAssert(_navigationControllerProvider == nil && self.subviews.count == 0,
+            @"[RNScreens] A component providing a navigation controller must be the only child of a Split column");
+
+  _navigationControllerProvider = provider;
+  provider.navigationControllerPlacedByParent = YES;
+  [self startObservingProvidedView:provider.navigationController];
+
+  [self requestSplitHostControllerUpdateIfNeeded];
+}
+
+- (void)releaseNavigationControllerOfProvider:(UIView<RNSNavigationControllerProviding> *)provider
+{
+  RCTAssert(provider == _navigationControllerProvider,
+            @"[RNScreens] Attempt to release a provider which is not the column's one");
+
+  [self stopObservingProvidedView];
+  provider.navigationControllerPlacedByParent = NO;
+  _navigationControllerProvider = nil;
+
+  [self requestSplitHostControllerUpdateIfNeeded];
+}
+
+- (void)requestSplitHostControllerUpdateIfNeeded
+{
+  if (self.splitHost != nil) {
+    [self.splitHost.splitHostController setNeedsUpdateOfChildViewControllers];
+  }
+}
+
+// TODO(@t0maboro): Temporary frame-reporting logic for stack-backed columns. Unify this with
+// RNSSplitNavigationControllerFrameObserver.
+- (void)startObservingProvidedView:(UIViewController *)controller
+{
+  [self stopObservingProvidedView];
+
+  // Loaded here so that the very first frame set by UISplitViewController is observed.
+  [controller loadViewIfNeeded];
+  UIView *view = controller.view;
+  [view addObserver:self
+         forKeyPath:@"frame"
+            options:NSKeyValueObservingOptionNew
+            context:RNSSplitScreenProvidedViewFrameContext];
+  _observedProvidedView = view;
+}
+
+- (void)stopObservingProvidedView
+{
+  [_observedProvidedView removeObserver:self forKeyPath:@"frame" context:RNSSplitScreenProvidedViewFrameContext];
+  _observedProvidedView = nil;
+}
+
+- (void)observeValueForKeyPath:(NSString *)keyPath
+                      ofObject:(id)object
+                        change:(NSDictionary<NSKeyValueChangeKey, id> *)change
+                       context:(void *)context
+{
+  if (context != RNSSplitScreenProvidedViewFrameContext) {
+    [super observeValueForKeyPath:keyPath ofObject:object change:change context:context];
+    return;
+  }
+  [self updateShadowStateFromProvidedView];
+}
+
+- (void)updateShadowStateFromProvidedView
+{
+  UIView *providedView = _observedProvidedView;
+  if (providedView.window == nil || self.splitHost == nil) {
+    return;
+  }
+
+  UIView *ancestorView = self.splitHost.splitHostController.view;
+  CGRect frame = [providedView convertRect:providedView.bounds toView:ancestorView];
+  [_shadowStateProxy updateShadowStateWithFrame:frame];
+}
+
 #pragma mark - Layout
 
 /**
@@ -158,6 +256,27 @@ namespace react = facebook::react;
   // There won't be tens of instances of this component usually & it's easier for now.
   // We could consider enabling it someday though.
   return NO;
+}
+
+- (void)mountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  if ([childComponentView conformsToProtocol:@protocol(RNSNavigationControllerProviding)]) {
+    [self takeOverNavigationControllerOfProvider:(UIView<RNSNavigationControllerProviding> *)childComponentView];
+    return;
+  }
+
+  RCTAssert(_navigationControllerProvider == nil,
+            @"[RNScreens] A column backed by a provided navigation controller cannot have other children");
+  [super mountChildComponentView:childComponentView index:index];
+}
+
+- (void)unmountChildComponentView:(UIView<RCTComponentViewProtocol> *)childComponentView index:(NSInteger)index
+{
+  if (childComponentView == (UIView *)_navigationControllerProvider) {
+    [self releaseNavigationControllerOfProvider:(UIView<RNSNavigationControllerProviding> *)childComponentView];
+    return;
+  }
+  [super unmountChildComponentView:childComponentView index:index];
 }
 
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState

--- a/ios/stack/host/RNSStackHostComponentView.h
+++ b/ios/stack/host/RNSStackHostComponentView.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#import "RNSNavigationControllerProviding.h"
 #import "RNSReactBaseView.h"
 #import "RNSStackScreenComponentView.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface RNSStackHostComponentView : RNSReactBaseView
+@interface RNSStackHostComponentView : RNSReactBaseView <RNSNavigationControllerProviding>
 
 @end
 

--- a/ios/stack/host/RNSStackHostComponentView.mm
+++ b/ios/stack/host/RNSStackHostComponentView.mm
@@ -25,6 +25,7 @@ namespace react = facebook::react;
   RNSStackNavigationController *_Nonnull _stackNavigationController;
   RNSStackOperationCoordinator *_Nonnull _stackOperationCoordinator;
   NSMutableArray<RNSStackScreenComponentView *> *_Nonnull _renderedScreens;
+  BOOL _isNavigationControllerPlacedByParent;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -43,6 +44,33 @@ namespace react = facebook::react;
   _stackNavigationController = [RNSStackNavigationController new];
   _stackOperationCoordinator = [RNSStackOperationCoordinator new];
   _renderedScreens = [NSMutableArray new];
+  _isNavigationControllerPlacedByParent = NO;
+}
+
+#pragma mark - RNSNavigationControllerProviding
+
+- (UINavigationController *)navigationController
+{
+  return _stackNavigationController;
+}
+
+- (BOOL)isNavigationControllerPlacedByParent
+{
+  return _isNavigationControllerPlacedByParent;
+}
+
+- (void)setNavigationControllerPlacedByParent:(BOOL)placedByParent
+{
+  RCTAssert(!placedByParent || _stackNavigationController.parentViewController == nil,
+            @"[RNScreens] Placement of the navigation controller can be handed over to the parent only before the host "
+            @"places it itself");
+  _isNavigationControllerPlacedByParent = placedByParent;
+}
+
+- (void)flushPendingUpdates
+{
+  [_stackOperationCoordinator executePendingOperationsIfNeeded:_stackNavigationController
+                                           withRenderedScreens:_renderedScreens];
 }
 
 #pragma mark - UIKit Callbacks
@@ -50,6 +78,9 @@ namespace react = facebook::react;
 - (void)didMoveToWindow
 {
   RNSLog(@"[RNScreens] StackHost [%ld] attached to window", self.tag);
+  if (_isNavigationControllerPlacedByParent) {
+    return;
+  }
   if (self.window != nil && _stackNavigationController.parentViewController == nil) {
     BOOL mountResult = [RNSContainerHelpers addChildViewController:_stackNavigationController
                                           toViewControllerManaging:self.reactSuperview
@@ -179,8 +210,7 @@ namespace react = facebook::react;
 - (void)mountingTransactionDidMount:(const facebook::react::MountingTransaction &)transaction
                withSurfaceTelemetry:(const facebook::react::SurfaceTelemetry &)surfaceTelemetry
 {
-  [_stackOperationCoordinator executePendingOperationsIfNeeded:_stackNavigationController
-                                           withRenderedScreens:_renderedScreens];
+  [self flushPendingUpdates];
 }
 
 #pragma mark - Dynamic frameworks support


### PR DESCRIPTION
## Description

POC of hosting Stack v5 directly inside Split columns on iOS. A `Stack.Host` mounted as the only child of a `Split.Column` becomes the column itself: its `RNSStackNavigationController` is installed as the column's view controller, the stack screens become the column's view controllers.
The stack keeps the exact structure it has standalone. `Stack.Host` still owns and drives all navigation operations. The only thing that differs is that, for SplitView, the SplitHost is placing that controller in the VC hierarchy. The whole communication goes through a generic protocol, so Split knows nothing about Stack.

Consequence worth stating explicitly: in this mode neither the `Split.Column` view nor the `Stack.Host` view is part of the UIKit view hierarchy.

This is an initial PR proposing only the attachment mechanism and the resulting hierarchy. Follow-ups are listed below and are deliberately out of scope of this content.

Closes: https://github.com/software-mansion/react-native-screens-labs/issues/694

## Changes

- **`RNSNavigationControllerProviding`**: a component view backed by a `UINavigationController` exposes it, accepts a flag telling it that the parent places the controller and can apply its pending updates on demand.
- **`RNSStackHostComponentView`**: conforms to that protocol. It keeps owning its `RNSStackNavigationController`, but `didMoveToWindow` can skip the self-placement while the flag is set.
- **`RNSSplitScreenComponentView`**: `mountChildComponentView:` detects a child conforming to the protocol, marks the provider as placed by the parent. The column frame for such a column is reported to the ShadowTree via KVO on the provided controller's view frame (the view is loaded at mount so the very first frame set by `UISplitViewController` is observed). This is marked as temporary, to be unified with `RNSSplitNavigationControllerFrameObserver`.
- **`RNSSplitHostController`**:  flushes the provider to execute the external controller's updates before the split attaches it.

## Out of scope of the POC (known, expected not to work)

- safe area integration
- hit testing
- column lifecycle events are not emitted for stack-backed columns (no `RNSSplitScreenController` in the hierarchy), stack emits these events instead.
- inspector column (iOS 26) with a `Stack.Host` child is not supported yet.
- **Important:** frame reporting is split between `RNSSplitNavigationControllerFrameObserver` (for plain columns) and the KVO in the column view (stack-backed columns); the further direction is one observer per column owned by the native column controller, with the SplitHost talking to columns only.

## Before & after - visual documentation

| iOS 18 | iOS 26 |
| --- | --- |
| <video src="https://github.com/user-attachments/assets/d59d8bc2-e193-484a-8d0e-29010b5bd22e" /> | <video src="https://github.com/user-attachments/assets/30e5280c-910d-41e6-aaad-dfc2f43db29c" /> |

## Test plan

The scenario will be added after discussing the solution. I'd recommend pasting the minimal example into `TestSplitPressables` for now. 

```tsx
import React from 'react';
import { scenarioDescription } from './scenario-description';
import { createScenario } from '@apps/tests/shared/helpers';
import { Split } from 'react-native-screens';
import { TestStackSubviewsIOS } from '../../stack-v5';

function TestSplitPressables() {
  return (
    <Split.Host preferredDisplayMode="oneBesideSecondary">
      <Split.Column>
        <TestStackSubviewsIOS />
      </Split.Column>
      <Split.Column>
        <TestStackSubviewsIOS />
      </Split.Column>
      <Split.Column>
        <TestStackSubviewsIOS />
      </Split.Column>
    </Split.Host>
  );
}

export default createScenario(TestSplitPressables, scenarioDescription);
```

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
