### PR TITLE
refactor(iOS, SplitView): Decouple `SplitViewController` from `ReactEventEmitter` & `ShadowState`

### DIFF
--- a/ios/split/RNSSplitScreenComponentView.h
+++ b/ios/split/RNSSplitScreenComponentView.h
@@ -3,8 +3,6 @@
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"
 #import "RNSSafeAreaProviding.h"
-#import "RNSSplitScreenComponentEventEmitter.h"
-#import "RNSSplitScreenShadowStateProxy.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -25,26 +23,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-#pragma mark - ShadowTreeState
-
-/**
- * @category ShadowTreeState
- * @brief Interactions between the host component and the associated ShadowNode.
- */
-@interface RNSSplitScreenComponentView ()
-
-/**
- * @brief Getter for the proxy object that interfaces with the Shadow Tree state for this screen.
- *
- * The ShadowStateProxy is the object that's responsible for sending layout updates coming from the Host tree to the
- * ShadowTree.
- *
- * @return A pointer to a RNSSplitScreenShadowStateProxy instance.
- */
-- (nonnull RNSSplitScreenShadowStateProxy *)shadowStateProxy;
-
-@end
-
 #pragma mark - Props
 
 /**
@@ -57,23 +35,6 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief Determines the purpose for the column (classic Column or one of specific types, like Inspector)
  */
 @property (nonatomic, readonly) RNSSplitScreenColumnType columnType;
-
-@end
-
-#pragma mark - Events
-
-/**
- * @category Events
- * @brief APIs related to event emission to React Native.
- */
-@interface RNSSplitScreenComponentView ()
-
-/**
- * @brief Getter for the component's event emitter used for emitting events to React.
- *
- * @return A pointer to RNSSplitScreenComponentEventEmitter instance.
- */
-- (nonnull RNSSplitScreenComponentEventEmitter *)reactEventEmitter;
 
 @end
 

--- a/ios/split/RNSSplitScreenComponentView.mm
+++ b/ios/split/RNSSplitScreenComponentView.mm
@@ -4,9 +4,14 @@
 #import <rnscreens/RNSSplitScreenComponentDescriptor.h>
 #import "RNSConversions.h"
 #import "RNSSafeAreaViewNotifications.h"
+#import "RNSSplitScreenComponentEventEmitter.h"
 #import "RNSSplitScreenController.h"
+#import "RNSSplitScreenShadowStateProxy.h"
 
 namespace react = facebook::react;
+
+@interface RNSSplitScreenComponentView () <RNSSplitScreenControllerDelegate>
+@end
 
 @implementation RNSSplitScreenComponentView {
   RNSSplitScreenComponentEventEmitter *_Nonnull _reactEventEmitter;
@@ -49,6 +54,7 @@ namespace react = facebook::react;
 {
   _controller = [[RNSSplitScreenController alloc] initWithSplitScreenComponentView:self];
   _controller.view = self;
+  _controller.delegate = self;
 }
 
 - (void)didMoveToWindow
@@ -108,20 +114,31 @@ namespace react = facebook::react;
   [super layoutSubviews];
 }
 
-#pragma mark - ShadowTreeState
+#pragma mark - RNSSplitScreenControllerDelegate
 
-- (nonnull RNSSplitScreenShadowStateProxy *)shadowStateProxy
+- (void)splitScreenController:(RNSSplitScreenController *)controller didChangeColumnFrame:(CGRect)frame
 {
-  RCTAssert(_shadowStateProxy != nil, @"[RNScreens] Attempt to access uninitialized _shadowStateProxy");
-  return _shadowStateProxy;
+  [_shadowStateProxy updateShadowStateWithFrame:frame];
 }
 
-#pragma mark - Events
-
-- (nonnull RNSSplitScreenComponentEventEmitter *)reactEventEmitter
+- (void)splitScreenControllerWillAppear:(RNSSplitScreenController *)controller
 {
-  RCTAssert(_reactEventEmitter != nil, @"[RNScreens] Attempt to access uninitialized _reactEventEmitter");
-  return _reactEventEmitter;
+  [_reactEventEmitter emitOnWillAppear];
+}
+
+- (void)splitScreenControllerDidAppear:(RNSSplitScreenController *)controller
+{
+  [_reactEventEmitter emitOnDidAppear];
+}
+
+- (void)splitScreenControllerWillDisappear:(RNSSplitScreenController *)controller
+{
+  [_reactEventEmitter emitOnWillDisappear];
+}
+
+- (void)splitScreenControllerDidDisappear:(RNSSplitScreenController *)controller
+{
+  [_reactEventEmitter emitOnDidDisappear];
 }
 
 #pragma mark - RNSSafeAreaProviding

--- a/ios/split/RNSSplitScreenController.h
+++ b/ios/split/RNSSplitScreenController.h
@@ -3,17 +3,41 @@
 #import <UIKit/UIKit.h>
 
 @class RNSSplitScreenComponentView;
+@class RNSSplitScreenController;
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @protocol RNSSplitScreenControllerDelegate
+ * @brief Receives layout and lifecycle notifications of a Split column from its controller.
+ */
+@protocol RNSSplitScreenControllerDelegate <NSObject>
+
+/**
+ * @brief Called whenever the column frame changes.
+ *
+ * @param frame The column frame in the coordinate space of the SplitHost controller's view, or the column view frame
+ * as is when the column is presented outside the SplitHost subtree (e.g. the inspector as a modal).
+ */
+- (void)splitScreenController:(RNSSplitScreenController *)controller didChangeColumnFrame:(CGRect)frame;
+
+- (void)splitScreenControllerWillAppear:(RNSSplitScreenController *)controller;
+- (void)splitScreenControllerDidAppear:(RNSSplitScreenController *)controller;
+- (void)splitScreenControllerWillDisappear:(RNSSplitScreenController *)controller;
+- (void)splitScreenControllerDidDisappear:(RNSSplitScreenController *)controller;
+
+@end
 
 /**
  * @class RNSSplitScreenController
  * @brief A UIViewController subclass that manages a Split column in a UISplitViewController.
  *
- * Associated with a RNSSplitScreenComponentView, it handles layout synchronization with the
- * Shadow Tree, emits React lifecycle events, and interacts with the SplitHost hierarchy.
+ * Associated with a RNSSplitScreenComponentView, it observes the column layout and lifecycle, reports them to its
+ * delegate, and interacts with the SplitHost hierarchy.
  */
 @interface RNSSplitScreenController : UIViewController
+
+@property (nonatomic, weak, nullable) id<RNSSplitScreenControllerDelegate> delegate;
 
 - (instancetype)initWithSplitScreenComponentView:(RNSSplitScreenComponentView *)splitScreenComponentView;
 
@@ -33,7 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 #pragma mark - Layout
 
 /**
- * @brief Request ShadowNode state update when the Split screen frame origin has changed.
+ * @brief Reports the column frame change after the Split repositioned its columns.
  *
  * @param splitViewController The UISplitViewController whose layout positioning changed, represented by
  * RNSSplitHostController.

--- a/ios/split/RNSSplitScreenController.h
+++ b/ios/split/RNSSplitScreenController.h
@@ -32,8 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @class RNSSplitScreenController
  * @brief A UIViewController subclass that manages a Split column in a UISplitViewController.
  *
- * Associated with a RNSSplitScreenComponentView, it observes the column layout and lifecycle, reports them to its
- * delegate, and interacts with the SplitHost hierarchy.
+ * It observes the column layout and lifecycle and reports them to its delegate.
  */
 @interface RNSSplitScreenController : UIViewController
 

--- a/ios/split/RNSSplitScreenController.mm
+++ b/ios/split/RNSSplitScreenController.mm
@@ -18,16 +18,6 @@
   return self;
 }
 
-- (RNSSplitScreenShadowStateProxy *)shadowStateProxy
-{
-  return [_splitScreenComponentView shadowStateProxy];
-}
-
-- (RNSSplitScreenComponentEventEmitter *)reactEventEmitter
-{
-  return [_splitScreenComponentView reactEventEmitter];
-}
-
 /**
  * @brief Searching for the SplitHost controller
  *
@@ -69,36 +59,29 @@
 {
   [super viewDidLayoutSubviews];
 
-  [self updateShadowTreeState];
-}
-
-/**
- * @brief Handles frame layout changes and updates Shadow Tree accordingly.
- *
- * Requests for the ShadowNode updates through the shadow state proxy.
- * Differentiates cases when we're in the Host hierarchy to calculate frame relatively
- * to the Host view from the modal case where we're passing absolute layout metrics to the ShadowNode.
- */
-- (void)updateShadowTreeState
-{
   // For modals, which are presented outside the SplitHost subtree (and RN hierarchy),
   // we're attaching our touch handler and we don't need to apply any offset corrections,
   // because it's positioned relatively to our RNSSplitScreenComponentView
   if (![self isInSplitHostSubtree]) {
-    [[self shadowStateProxy] updateShadowStateOfComponent:_splitScreenComponentView];
+    [_delegate splitScreenController:self didChangeColumnFrame:self.view.frame];
     return;
   }
 
   UIView *ancestorView = [self findSplitHostController].view;
   RCTAssert(ancestorView != nil, @"[RNScreens] Expected to find RNSSplitHost component for RNSSplitScreen component");
 
-  [[self shadowStateProxy] updateShadowStateOfComponent:_splitScreenComponentView inContextOfAncestorView:ancestorView];
+  [self reportColumnFrameInContextOfView:ancestorView];
 }
 
 - (void)columnPositioningDidChangeInSplitViewController:(UISplitViewController *)splitViewController
 {
-  [[self shadowStateProxy] updateShadowStateOfComponent:_splitScreenComponentView
-                                inContextOfAncestorView:splitViewController.view];
+  [self reportColumnFrameInContextOfView:splitViewController.view];
+}
+
+- (void)reportColumnFrameInContextOfView:(UIView *)ancestorView
+{
+  CGRect frame = [self.view convertRect:self.view.frame toView:ancestorView];
+  [_delegate splitScreenController:self didChangeColumnFrame:frame];
 }
 
 #pragma mark - Events
@@ -106,25 +89,25 @@
 - (void)viewWillAppear:(BOOL)animated
 {
   [super viewWillAppear:animated];
-  [[self reactEventEmitter] emitOnWillAppear];
+  [_delegate splitScreenControllerWillAppear:self];
 }
 
 - (void)viewDidAppear:(BOOL)animated
 {
   [super viewDidAppear:animated];
-  [[self reactEventEmitter] emitOnDidAppear];
+  [_delegate splitScreenControllerDidAppear:self];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
 {
   [super viewWillDisappear:animated];
-  [[self reactEventEmitter] emitOnWillDisappear];
+  [_delegate splitScreenControllerWillDisappear:self];
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
-  [[self reactEventEmitter] emitOnDidDisappear];
+  [_delegate splitScreenControllerDidDisappear:self];
 }
 
 @end

--- a/ios/split/RNSSplitScreenShadowStateProxy.h
+++ b/ios/split/RNSSplitScreenShadowStateProxy.h
@@ -10,8 +10,6 @@ namespace react = facebook::react;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class RNSSplitScreenComponentView;
-
 /**
  * @class RNSSplitScreenShadowStateProxy
  * @brief Manages communication between native UIView layout and associated React Native ShadowNode state.
@@ -20,44 +18,6 @@ NS_ASSUME_NONNULL_BEGIN
  * back to the Shadow Tree via RNSSplitScreenShadowNode.
  */
 @interface RNSSplitScreenShadowStateProxy : NSObject
-
-/**
- * @brief Triggers a shadow state update for the given SplitScreen component.
- *
- * Internally uses the component’s frame in UIWindow coordinates to update the Shadow Tree state.
- *
- * @param screenComponentView An instance of RNSSplitScreenComponentView whose state should be updated.
- */
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView;
-
-/**
- * @brief Triggers a shadow state update for the given SplitScreen component in the context of a given ancestor
- * view.
- *
- * Converts the split view screen's local frame to coordinates of the specified ancestor view
- * before applying the update to the Shadow Tree. If the ancestor haven't been defined frame is calculated relatively to
- * the UIWindow.
- *
- * @param screenComponentView An instance of RNSSplitScreenComponentView whose state should be updated.
- * @param ancestorView An optional UIView in whose coordinate space the frame should be computed.
- */
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView
-             inContextOfAncestorView:(UIView *_Nullable)ancestorView;
-
-/**
- * @brief Send an update to ShadowNode state with given frame if needed.
- *
- * Converts the frame to coordinates of the specified ancestor view,
- * before applying the update to the Shadow Tree.
- *
- * @param screenComponentView an instance of RNSSplitScreenComponentView whose state should be updated,
- * @param frame frame to update the shadow state with; it must be in coordinate system of `screenComponentView`,
- * @param ancestorView coordinate-system provider view, relative to which the frame should be converted before sending
- * the update.
- */
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView
-                           withFrame:(CGRect)frame
-             inContextOfAncestorView:(nonnull UIView *)ancestorView;
 
 /**
  * @brief Send an update to ShadowNode state with given layout metrics.

--- a/ios/split/RNSSplitScreenShadowStateProxy.mm
+++ b/ios/split/RNSSplitScreenShadowStateProxy.mm
@@ -1,5 +1,4 @@
 #import "RNSSplitScreenShadowStateProxy.h"
-#import "RNSSplitScreenComponentView.h"
 
 #import <React/RCTAssert.h>
 #import <React/RCTConversions.h>
@@ -21,21 +20,6 @@ namespace react = facebook::react;
   return self;
 }
 
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView
-{
-  [self updateShadowStateOfComponent:screenComponentView inContextOfAncestorView:nil];
-}
-
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView
-             inContextOfAncestorView:(UIView *_Nullable)ancestorView
-{
-  CGRect frame = screenComponentView.frame;
-  if (ancestorView != nil) {
-    frame = [screenComponentView convertRect:frame toView:ancestorView];
-  }
-  [self updateShadowStateWithFrame:frame];
-}
-
 - (void)updateShadowStateWithFrame:(CGRect)frame
 {
   if (_state == nullptr) {
@@ -48,15 +32,6 @@ namespace react = facebook::react;
 
     _lastScheduledFrame = frame;
   }
-}
-
-- (void)updateShadowStateOfComponent:(RNSSplitScreenComponentView *)screenComponentView
-                           withFrame:(CGRect)frame
-             inContextOfAncestorView:(nonnull UIView *)ancestorView
-{
-  RCTAssert(ancestorView != nil, @"[RNScreens] ancestorView must not be nil");
-  CGRect convertedFrame = [screenComponentView convertRect:frame toView:ancestorView];
-  [self updateShadowStateWithFrame:convertedFrame];
 }
 
 - (void)updateState:(react::State::Shared const &)state oldState:(react::State::Shared const &)oldState


### PR DESCRIPTION
## Description

First step in separating domains for SplitView on iOS. The native controller observes UIKit lifecycle and notifies a delegate, which is the React component view responsible of the Shadow Tree state updates and event emission.

Until now, `RNSSplitScreenController` reached into its `RNSSplitScreenComponentView` for the shadow state proxy and the event emitter and drove both directly. This PR inverts that: the controller reports column frames and appearance changes through `RNSSplitScreenControllerDelegate`, and the component view acts on them. The proxy and the emitter are no longer reachable from outside the component view.

## Changes

- Introducing `RNSSplitScreenControllerDelegate` 
-`RNSSplitScreenComponentView`conforms to the delegate contract and is now directly responsible for shadow state updates and event emission
- `shadowStateProxy` and `reactEventEmitter` were moved to the private API

## Before & after - visual documentation

No visual changes

## Test plan

Go through some SplitView examples.

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
