### PR TITLE
fix(ios): prevent mirrored RTL large titles

### DIFF
--- a/apps/src/tests/issue-tests/Test4280.tsx
+++ b/apps/src/tests/issue-tests/Test4280.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+const Stack = createNativeStackNavigator();
+
+const rtlScreenOptions = {
+  headerLargeTitle: true,
+  unstable_nativeProps: {
+    headerConfig: {
+      direction: 'rtl',
+    },
+  },
+} as never;
+
+export default function App() {
+  return (
+    <NavigationContainer>
+      <Stack.Navigator screenOptions={rtlScreenOptions}>
+        <Stack.Screen
+          name="Profile"
+          component={Profile}
+          options={{ title: 'ملف الرفيق' }}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
+  );
+}
+
+function Profile() {
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      style={styles.scrollView}>
+      <View style={styles.content}>
+        <Text style={styles.referenceTitle}>ملف الرفيق</Text>
+        <Text style={styles.description}>
+          يجب أن يظهر العنوان الكبير والعنوان المرجعي في اتجاه صحيح.
+        </Text>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    direction: 'rtl',
+  },
+  content: {
+    direction: 'rtl',
+    padding: 24,
+  },
+  referenceTitle: {
+    fontSize: 34,
+    fontWeight: '700',
+    textAlign: 'right',
+  },
+  description: {
+    fontSize: 18,
+    marginTop: 16,
+    textAlign: 'right',
+  },
+});

--- a/apps/src/tests/issue-tests/Test4280.tsx
+++ b/apps/src/tests/issue-tests/Test4280.tsx
@@ -1,44 +1,122 @@
 import * as React from 'react';
-import { ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Button, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
-import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import {
+  NativeStackScreenProps,
+  createNativeStackNavigator,
+} from '@react-navigation/native-stack';
 
-const Stack = createNativeStackNavigator();
+type StackParamList = {
+  Profile: undefined;
+  Details: undefined;
+};
 
-const rtlScreenOptions = {
-  headerLargeTitle: true,
-  unstable_nativeProps: {
-    headerConfig: {
-      direction: 'rtl',
-    },
-  },
-} as never;
+type ProfileProps = NativeStackScreenProps<StackParamList, 'Profile'>;
+
+const Stack = createNativeStackNavigator<StackParamList>();
 
 export default function App() {
+  const [isRTL, setIsRTL] = React.useState(true);
+  const [hasLargeTitle, setHasLargeTitle] = React.useState(true);
+  const [usesAlternateTitle, setUsesAlternateTitle] = React.useState(false);
+  const title = usesAlternateTitle ? 'الملف البديل' : 'ملف الرفيق';
+
   return (
     <NavigationContainer>
-      <Stack.Navigator screenOptions={rtlScreenOptions}>
-        <Stack.Screen
-          name="Profile"
-          component={Profile}
-          options={{ title: 'ملف الرفيق' }}
-        />
+      <Stack.Navigator
+        screenOptions={{
+          headerLargeTitle: hasLargeTitle,
+          unstable_nativeProps: {
+            headerConfig: {
+              direction: isRTL ? 'rtl' : 'ltr',
+            },
+          },
+        }}>
+        <Stack.Screen name="Profile" options={{ title }}>
+          {props => (
+            <Profile
+              {...props}
+              hasLargeTitle={hasLargeTitle}
+              isRTL={isRTL}
+              setHasLargeTitle={setHasLargeTitle}
+              setIsRTL={setIsRTL}
+              setUsesAlternateTitle={setUsesAlternateTitle}
+              title={title}
+            />
+          )}
+        </Stack.Screen>
+        <Stack.Screen name="Details" options={{ title: 'تفاصيل الملف' }}>
+          {props => <Details {...props} isRTL={isRTL} />}
+        </Stack.Screen>
       </Stack.Navigator>
     </NavigationContainer>
   );
 }
 
-function Profile() {
+type ProfileTestProps = ProfileProps & {
+  hasLargeTitle: boolean;
+  isRTL: boolean;
+  setHasLargeTitle: React.Dispatch<React.SetStateAction<boolean>>;
+  setIsRTL: React.Dispatch<React.SetStateAction<boolean>>;
+  setUsesAlternateTitle: React.Dispatch<React.SetStateAction<boolean>>;
+  title: string;
+};
+
+function Profile({
+  hasLargeTitle,
+  isRTL,
+  navigation,
+  setHasLargeTitle,
+  setIsRTL,
+  setUsesAlternateTitle,
+  title,
+}: ProfileTestProps) {
   return (
     <ScrollView
       contentInsetAdjustmentBehavior="automatic"
-      style={styles.scrollView}>
-      <View style={styles.content}>
-        <Text style={styles.referenceTitle}>ملف الرفيق</Text>
-        <Text style={styles.description}>
-          يجب أن يظهر العنوان الكبير والعنوان المرجعي في اتجاه صحيح.
+      style={[styles.scrollView, { direction: isRTL ? 'rtl' : 'ltr' }]}>
+      <View style={[styles.content, { direction: isRTL ? 'rtl' : 'ltr' }]}>
+        <Text testID="duplicate-react-title" style={styles.referenceTitle}>
+          {title}
         </Text>
+        <Text style={styles.description}>
+          Duplicate React content. It must never receive a second transform.
+        </Text>
+        <Text style={styles.testState}>
+          {isRTL ? 'RTL' : 'LTR'} · large title {hasLargeTitle ? 'on' : 'off'}
+        </Text>
+        <Button
+          title="Change title"
+          onPress={() => setUsesAlternateTitle(value => !value)}
+        />
+        <Button
+          title="Toggle large title"
+          onPress={() => setHasLargeTitle(value => !value)}
+        />
+        <Button
+          title="Toggle direction"
+          onPress={() => setIsRTL(value => !value)}
+        />
+        <Button
+          title="Push details"
+          onPress={() => navigation.push('Details')}
+        />
+        <View style={styles.longContent} />
       </View>
+    </ScrollView>
+  );
+}
+
+function Details({
+  isRTL,
+  navigation,
+}: NativeStackScreenProps<StackParamList, 'Details'> & { isRTL: boolean }) {
+  return (
+    <ScrollView
+      contentInsetAdjustmentBehavior="automatic"
+      style={{ direction: isRTL ? 'rtl' : 'ltr' }}>
+      <Button title="Pop profile" onPress={() => navigation.pop()} />
+      <View style={styles.longContent} />
     </ScrollView>
   );
 }
@@ -54,11 +132,18 @@ const styles = StyleSheet.create({
   referenceTitle: {
     fontSize: 34,
     fontWeight: '700',
-    textAlign: 'right',
+    textAlign: 'start',
   },
   description: {
     fontSize: 18,
     marginTop: 16,
     textAlign: 'right',
+  },
+  testState: {
+    marginVertical: 16,
+    textAlign: 'center',
+  },
+  longContent: {
+    height: 1200,
   },
 });

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -205,6 +205,7 @@ export { default as Test4258 } from './Test4258';
 export { default as Test4264 } from './Test4264';
 export { default as Test4265 } from './Test4265';
 export { default as Test4276 } from './Test4276';
+export { default as Test4280 } from './Test4280';
 export { default as Test4314 } from './Test4314';
 export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';

--- a/ios/legacy/RNSScreenStack.mm
+++ b/ios/legacy/RNSScreenStack.mm
@@ -48,8 +48,7 @@ static BOOL RNSViewContainsLabelWithText(UIView *view, NSString *text)
 static BOOL RNSScrollViewHasMirroredContentSubview(UIScrollView *scrollView)
 {
   for (UIView *subview in scrollView.subviews) {
-    if (subview.transform.a < 0 &&
-        ![objc_getAssociatedObject(subview, RNSRTLLargeTitleCounterTransformKey) boolValue]) {
+    if (subview.transform.a < 0) {
       return YES;
     }
   }
@@ -59,21 +58,35 @@ static BOOL RNSScrollViewHasMirroredContentSubview(UIScrollView *scrollView)
 
 static void RNSSetRTLLargeTitleCounterTransform(UIView *view, BOOL enabled)
 {
-  BOOL wasCounterTransformed = [objc_getAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey) boolValue];
+  if (![view isKindOfClass:UILabel.class]) {
+    for (UIView *subview in view.subviews) {
+      RNSSetRTLLargeTitleCounterTransform(subview, enabled);
+    }
+    return;
+  }
 
+  NSValue *originalTransformValue = objc_getAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey);
   if (enabled) {
-    if (view.transform.a >= 0) {
-      view.transform = CGAffineTransformScale(view.transform, -1, 1);
-      objc_setAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    if (originalTransformValue == nil) {
+      originalTransformValue = [NSValue valueWithCATransform3D:view.layer.sublayerTransform];
+      objc_setAssociatedObject(
+          view, RNSRTLLargeTitleCounterTransformKey, originalTransformValue, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
     }
-  } else if (wasCounterTransformed) {
-    if (view.transform.a < 0) {
-      view.transform = CGAffineTransformScale(view.transform, -1, 1);
-    }
+    // Correct the label contents without changing its frame. UIKit resets UILabel.transform during title updates
+    // and navigation transitions, but it preserves the label layer's sublayer transform.
+    view.layer.sublayerTransform = CATransform3DScale(originalTransformValue.CATransform3DValue, -1, 1, 1);
+  } else if (originalTransformValue != nil) {
+    view.layer.sublayerTransform = originalTransformValue.CATransform3DValue;
     objc_setAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
   }
 }
 #endif // TARGET_OS_IOS
+
+@interface RNSNavigationController ()
+
+- (void)maybeCorrectRTLLargeTitleInScrollView:(RNSScreen *)screenController;
+
+@end
 
 @interface RNSScreenStackView () <UINavigationControllerDelegate,
                                   UIAdaptivePresentationControllerDelegate,
@@ -111,6 +124,15 @@ static void RNSSetRTLLargeTitleCounterTransform(UIView *view, BOOL enabled)
   if ([self.topViewController isKindOfClass:[RNSScreen class]]) {
     RNSScreen *screenController = (RNSScreen *)self.topViewController;
     [self maybeCorrectRTLLargeTitleInScrollView:screenController];
+    // UIKit finishes installing or updating its private large-title label after this layout callback.
+    // Run once more on the main queue. Unlike a delayed timer, this executes before the next rendered frame.
+    __weak RNSNavigationController *weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+      RNSNavigationController *strongSelf = weakSelf;
+      if ([strongSelf.topViewController isKindOfClass:[RNSScreen class]]) {
+        [strongSelf maybeCorrectRTLLargeTitleInScrollView:(RNSScreen *)strongSelf.topViewController];
+      }
+    });
     BOOL isNotDismissingModal = screenController.presentedViewController == nil ||
         (screenController.presentedViewController != nil &&
          ![screenController.presentedViewController isBeingDismissed]);
@@ -143,10 +165,11 @@ static void RNSSetRTLLargeTitleCounterTransform(UIView *view, BOOL enabled)
     NSString *title = screenController.navigationItem.title;
     BOOL shouldCounterTransform = headerConfig.largeTitle && title.length > 0 && scrollView.transform.a < 0 &&
         RNSScrollViewHasMirroredContentSubview(scrollView);
-
     for (UIView *subview in scrollView.subviews) {
-      BOOL isLargeTitleView = title.length > 0 && RNSViewContainsLabelWithText(subview, title);
-      RNSSetRTLLargeTitleCounterTransform(subview, shouldCounterTransform && isLargeTitleView);
+      // The React content host is already mirrored. UIKit inserts the unmirrored large-title label host
+      // beside it. Match the current navigation title so unrelated UIKit labels are not transformed.
+      BOOL isUIKitLabelHost = subview.transform.a >= 0 && RNSViewContainsLabelWithText(subview, title);
+      RNSSetRTLLargeTitleCounterTransform(subview, shouldCounterTransform && isUIKitLabelHost);
     }
   }
 #endif // TARGET_OS_IOS

--- a/ios/legacy/RNSScreenStack.mm
+++ b/ios/legacy/RNSScreenStack.mm
@@ -6,6 +6,7 @@
 #import <React/RCTSurfaceTouchHandler.h>
 #import <React/RCTSurfaceView.h>
 #import <React/UIView+React.h>
+#import <objc/runtime.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -25,6 +26,54 @@
 #import "integrations/RNSDismissibleModalProtocol.h"
 
 namespace react = facebook::react;
+
+#if TARGET_OS_IOS
+static void *RNSRTLLargeTitleCounterTransformKey = &RNSRTLLargeTitleCounterTransformKey;
+
+static BOOL RNSViewContainsLabelWithText(UIView *view, NSString *text)
+{
+  if ([view isKindOfClass:UILabel.class] && [((UILabel *)view).text isEqualToString:text]) {
+    return YES;
+  }
+
+  for (UIView *subview in view.subviews) {
+    if (RNSViewContainsLabelWithText(subview, text)) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
+static BOOL RNSScrollViewHasMirroredContentSubview(UIScrollView *scrollView)
+{
+  for (UIView *subview in scrollView.subviews) {
+    if (subview.transform.a < 0 &&
+        ![objc_getAssociatedObject(subview, RNSRTLLargeTitleCounterTransformKey) boolValue]) {
+      return YES;
+    }
+  }
+
+  return NO;
+}
+
+static void RNSSetRTLLargeTitleCounterTransform(UIView *view, BOOL enabled)
+{
+  BOOL wasCounterTransformed = [objc_getAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey) boolValue];
+
+  if (enabled) {
+    if (view.transform.a >= 0) {
+      view.transform = CGAffineTransformScale(view.transform, -1, 1);
+      objc_setAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey, @YES, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+    }
+  } else if (wasCounterTransformed) {
+    if (view.transform.a < 0) {
+      view.transform = CGAffineTransformScale(view.transform, -1, 1);
+    }
+    objc_setAssociatedObject(view, RNSRTLLargeTitleCounterTransformKey, nil, OBJC_ASSOCIATION_RETAIN_NONATOMIC);
+  }
+}
+#endif // TARGET_OS_IOS
 
 @interface RNSScreenStackView () <UINavigationControllerDelegate,
                                   UIAdaptivePresentationControllerDelegate,
@@ -61,6 +110,7 @@ namespace react = facebook::react;
   [super viewDidLayoutSubviews];
   if ([self.topViewController isKindOfClass:[RNSScreen class]]) {
     RNSScreen *screenController = (RNSScreen *)self.topViewController;
+    [self maybeCorrectRTLLargeTitleInScrollView:screenController];
     BOOL isNotDismissingModal = screenController.presentedViewController == nil ||
         (screenController.presentedViewController != nil &&
          ![screenController.presentedViewController isBeingDismissed]);
@@ -76,6 +126,30 @@ namespace react = facebook::react;
 
     [self maybeUpdateHeaderLayoutInfoInShadowTree:screenController];
   }
+}
+
+- (void)maybeCorrectRTLLargeTitleInScrollView:(RNSScreen *)screenController
+{
+#if TARGET_OS_IOS
+  if (@available(iOS 26.0, *)) {
+    // On iOS 26, UIKit can move the large-title view into React Native's mirrored RTL scroll view.
+    // React content receives a counter-transform, but the UIKit-owned title does not.
+    UIScrollView *scrollView = [RNSScrollViewFinder findScrollViewInFirstDescendantChainFrom:screenController.view];
+    if (scrollView == nil) {
+      return;
+    }
+
+    RNSScreenStackHeaderConfig *headerConfig = screenController.screenView.findHeaderConfig;
+    NSString *title = screenController.navigationItem.title;
+    BOOL shouldCounterTransform = headerConfig.largeTitle && title.length > 0 && scrollView.transform.a < 0 &&
+        RNSScrollViewHasMirroredContentSubview(scrollView);
+
+    for (UIView *subview in scrollView.subviews) {
+      BOOL isLargeTitleView = title.length > 0 && RNSViewContainsLabelWithText(subview, title);
+      RNSSetRTLLargeTitleCounterTransform(subview, shouldCounterTransform && isLargeTitleView);
+    }
+  }
+#endif // TARGET_OS_IOS
 }
 
 - (UIInterfaceOrientationMask)supportedInterfaceOrientations


### PR DESCRIPTION
## Description

Closes #4280.

On iOS 26, UIKit can insert the native large-title view as a direct child of React Native's mirrored RTL scroll view. React Native counter-transforms its own content, but the UIKit-owned title does not receive that transform. The result is horizontally mirrored Arabic or Hebrew glyphs while the compact title remains correct.

The first correction used a view transform. UIKit resets that transform when it replaces or updates the large-title label, which caused incorrect positioning after a dynamic title change and a visible left-to-right correction after push and pop transitions.

This revision applies the counter-transform to the matched large-title label's sublayer. The label frame stays in UIKit's trailing position, and the correction persists when UIKit updates the title or performs a navigation transition. The implementation uses public `UIView`, `UIScrollView`, `UILabel`, and Core Animation APIs. It does not depend on private UIKit class names.

## Changes

- Detect the iOS 26 mirrored RTL scroll-view arrangement.
- Match the UIKit large-title host to the current navigation title.
- Preserve the UIKit label frame and counter-transform only its rendered contents.
- Recheck the label in the current and next main-queue layout phases without a delayed timer.
- Expand `Test4280` to cover dynamic title changes, RTL/LTR changes, large-title changes, and push/pop navigation.

## Test plan

1. Open `Test4280` on an iOS 26 simulator.
2. Confirm that the expanded `ملف الرفيق` title matches the React reference title and is trailing-aligned.
3. Select **Change title** and confirm that `الملف البديل` stays readable and trailing-aligned.
4. Select **Push details** and confirm that `تفاصيل الملف` does not flash on the left before moving right.
5. Return to the profile screen and confirm that the large title does not flash on the left.
6. Collapse and expand the large title and confirm that both title forms remain correct.
7. Toggle direction and large-title mode to confirm that the correction is removed when it is not required.

Validation completed on `RNS_PR4604_iPhone_17_Pro`, iOS 26.5:

- `yarn check-types`
- Prettier check for `Test4280.tsx`
- Native Debug build of `FabricExample`
- Manual dynamic-title, push, and pop checks
- Frame review of the recorded navigation flow
- `git diff --check`

## Before and after recordings

Both videos use `Test4280.tsx` from `b38af09fe`, on `RNS_PR4604_iPhone_17_Pro` (iOS 26.5). Each recording is uncut, at normal speed and 30 fps, with touch markers.

### Before — native code from `73591ca45`

The native large-title implementation is from the parent of this PR. The updated test screen is used so both builds have the same controls.

https://github.com/user-attachments/assets/2ed1a055-ffb5-497e-9963-a868e9f0204d

### After — `b38af09fe16cc99f03888e617928ee2bbe29faef`

https://github.com/user-attachments/assets/669f2f38-d65c-4c0c-94b8-a0499007ef1c

### Cases shown in both videos

| Case | Before | After |
| --- | --- | --- |
| Initial expanded RTL title and duplicate React reference | 00:00 | 00:00 |
| Change title, then restore it | 00:02 | 00:02 |
| Push details and return with Pop profile | 00:07 | 00:07 |
| Push details and return with the native back button | 00:13 | 00:12 |
| Scroll to collapse, then expand the title | 00:18 | 00:17 |
| Disable large title, change title twice, then enable and expand | 00:24 | 00:23 |
| Switch to LTR, expand, change title, push and pop | 00:38 | 00:37 |
| Restore the title and RTL direction, then expand | 00:52 | 00:50 |

The React reference text stays readable in both builds. The before build mirrors the native RTL large-title glyphs; the after build keeps them readable and right-aligned in the recorded RTL states. The LTR large titles remain left-aligned. These recordings cover this simulator and fixture, not all iOS versions or navigation configurations.

## Checklist

- [x] Included a code example that can be used to test this change.
- [x] Completed local visual verification for the dynamic-title and navigation flows.
- [x] No public API change is included.
- [x] Confirmed that all remote CI checks pass.

