### PR TITLE
refactor(iOS, SplitView): Read Host configuration through providers

### DIFF
--- a/ios/split/RNSSplitAppearanceApplicator.h
+++ b/ios/split/RNSSplitAppearanceApplicator.h
@@ -2,8 +2,8 @@
 
 #import <Foundation/Foundation.h>
 #import "RNSSplitAppearanceCoordinator.h"
+#import "RNSSplitHostProviders.h"
 
-@class RNSSplitHostComponentView;
 @class RNSSplitHostController;
 
 NS_ASSUME_NONNULL_BEGIN
@@ -12,7 +12,7 @@ NS_ASSUME_NONNULL_BEGIN
  * @brief - Class responsible for applying all upcoming updates to SplitView.
  *
  * This class is synchronizing UISplitViewController configuration props which are affecting the SplitView appearance
- * with props passed to RNSSplitHostComponentView from the ElementTree.
+ * with the configuration exposed by the appearance provider.
  */
 @interface RNSSplitAppearanceApplicator : NSObject
 
@@ -21,13 +21,13 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * It requests calling proper callbacks with batched SplitView updates on the AppearanceCoordinator object
  *
- * @param splitHost The view representing JS component which is sending updates.
+ * @param provider The provider of the appearance configuration.
  * @param splitHostController The controller associated with the SplitView component which receives updates and
  * manages the native layer.
  * @param appearanceCoordinator The coordinator which is checking whether the update needs to be applied and if so, it
  * executes the callback passed by this class.
  */
-- (void)updateAppearanceIfNeeded:(RNSSplitHostComponentView *)splitHost
+- (void)updateAppearanceIfNeeded:(id<RNSSplitHostAppearanceProvider>)provider
              splitHostController:(RNSSplitHostController *)splitHostController
            appearanceCoordinator:(RNSSplitAppearanceCoordinator *)appearanceCoordinator;
 

--- a/ios/split/RNSSplitAppearanceApplicator.mm
+++ b/ios/split/RNSSplitAppearanceApplicator.mm
@@ -3,12 +3,11 @@
 #import <React/RCTAssert.h>
 #import "RNSDefines.h"
 #import "RNSScreenWindowTraits.h"
-#import "RNSSplitHostComponentView.h"
 #import "RNSSplitHostController.h"
 
 @implementation RNSSplitAppearanceApplicator
 
-- (void)updateAppearanceIfNeeded:(RNSSplitHostComponentView *)splitHost
+- (void)updateAppearanceIfNeeded:(id<RNSSplitHostAppearanceProvider>)provider
              splitHostController:(RNSSplitHostController *)splitHostController
            appearanceCoordinator:(RNSSplitAppearanceCoordinator *)appearanceCoordinator
 {
@@ -21,7 +20,7 @@
                              return;
                            }
 
-                           [strongSelf updateSplitViewConfigurationFor:splitHost withController:splitHostController];
+                           [strongSelf updateSplitViewConfigurationFor:provider withController:splitHostController];
                          }];
 
   [appearanceCoordinator updateIfNeeded:RNSSplitAppearanceUpdateFlagsSecondaryScreenNavBarUpdate
@@ -41,7 +40,7 @@
                              return;
                            }
 
-                           [strongSelf updateSplitViewDisplayModeFor:splitHost withController:splitHostController];
+                           [strongSelf updateSplitViewDisplayModeFor:provider withController:splitHostController];
                          }];
 
   [appearanceCoordinator updateIfNeeded:RNSSplitAppearanceUpdateFlagsOrientationUpdate
@@ -55,101 +54,99 @@
  *
  * It calls all setters on RNSSplitHostController that doesn't require any custom logic and conditions to be met.
  *
- * @param splitHost The view representing JS component which is sending updates.
+ * @param provider The provider of the appearance configuration.
  * @param splitHostController The controller associated with the SplitView component which receives updates and
  * manages the native layer.
  */
-- (void)updateSplitViewConfigurationFor:(RNSSplitHostComponentView *)splitHost
+- (void)updateSplitViewConfigurationFor:(id<RNSSplitHostAppearanceProvider>)provider
                          withController:(RNSSplitHostController *)splitHostController
 {
   // Step 1 - general settings
-  splitHostController.displayModeButtonVisibility = splitHost.displayModeButtonVisibility;
-  splitHostController.preferredSplitBehavior = splitHost.preferredSplitBehavior;
-  splitHostController.overrideUserInterfaceStyle = splitHost.colorScheme;
+  splitHostController.displayModeButtonVisibility = provider.displayModeButtonVisibility;
+  splitHostController.preferredSplitBehavior = provider.preferredSplitBehavior;
+  splitHostController.overrideUserInterfaceStyle = provider.colorScheme;
 #if !TARGET_OS_TV
-  splitHostController.primaryBackgroundStyle = splitHost.primaryBackgroundStyle;
+  splitHostController.primaryBackgroundStyle = provider.primaryBackgroundStyle;
 #endif
-  splitHostController.presentsWithGesture = splitHost.presentsWithGesture;
-  splitHostController.primaryEdge = splitHost.primaryEdge;
-  splitHostController.showsSecondaryOnlyButton = splitHost.showSecondaryToggleButton;
+  splitHostController.presentsWithGesture = provider.presentsWithGesture;
+  splitHostController.primaryEdge = provider.primaryEdge;
+  splitHostController.showsSecondaryOnlyButton = provider.showSecondaryToggleButton;
 
   // Step 2.1 - validating column constraints
-  [self validateColumnConstraintsWithMinWidth:splitHost.minimumPrimaryColumnWidth
-                                     maxWidth:splitHost.maximumPrimaryColumnWidth];
+  [self validateColumnConstraintsWithMinWidth:provider.minimumPrimaryColumnWidth
+                                     maxWidth:provider.maximumPrimaryColumnWidth];
 
-  [self validateColumnConstraintsWithMinWidth:splitHost.minimumSupplementaryColumnWidth
-                                     maxWidth:splitHost.maximumSupplementaryColumnWidth];
+  [self validateColumnConstraintsWithMinWidth:provider.minimumSupplementaryColumnWidth
+                                     maxWidth:provider.maximumSupplementaryColumnWidth];
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
   if (@available(iOS 26.0, *)) {
-    [self validateColumnConstraintsWithMinWidth:splitHost.minimumInspectorColumnWidth
-                                       maxWidth:splitHost.maximumInspectorColumnWidth];
+    [self validateColumnConstraintsWithMinWidth:provider.minimumInspectorColumnWidth
+                                       maxWidth:provider.maximumInspectorColumnWidth];
   }
 #endif
 
   // Step 2.2 - applying updates to columns
-  if (splitHost.minimumPrimaryColumnWidth >= 0) {
-    splitHostController.minimumPrimaryColumnWidth = splitHost.minimumPrimaryColumnWidth;
+  if (provider.minimumPrimaryColumnWidth >= 0) {
+    splitHostController.minimumPrimaryColumnWidth = provider.minimumPrimaryColumnWidth;
   }
 
-  if (splitHost.maximumPrimaryColumnWidth >= 0) {
-    splitHostController.maximumPrimaryColumnWidth = splitHost.maximumPrimaryColumnWidth;
+  if (provider.maximumPrimaryColumnWidth >= 0) {
+    splitHostController.maximumPrimaryColumnWidth = provider.maximumPrimaryColumnWidth;
   }
 
-  if (splitHost.preferredPrimaryColumnWidthOrFraction >= 0 && splitHost.preferredPrimaryColumnWidthOrFraction < 1) {
-    splitHostController.preferredPrimaryColumnWidthFraction = splitHost.preferredPrimaryColumnWidthOrFraction;
-  } else if (splitHost.preferredPrimaryColumnWidthOrFraction >= 1) {
-    splitHostController.preferredPrimaryColumnWidth = splitHost.preferredPrimaryColumnWidthOrFraction;
+  if (provider.preferredPrimaryColumnWidthOrFraction >= 0 && provider.preferredPrimaryColumnWidthOrFraction < 1) {
+    splitHostController.preferredPrimaryColumnWidthFraction = provider.preferredPrimaryColumnWidthOrFraction;
+  } else if (provider.preferredPrimaryColumnWidthOrFraction >= 1) {
+    splitHostController.preferredPrimaryColumnWidth = provider.preferredPrimaryColumnWidthOrFraction;
   }
 
-  if (splitHost.minimumSupplementaryColumnWidth >= 0) {
-    splitHostController.minimumSupplementaryColumnWidth = splitHost.minimumSupplementaryColumnWidth;
+  if (provider.minimumSupplementaryColumnWidth >= 0) {
+    splitHostController.minimumSupplementaryColumnWidth = provider.minimumSupplementaryColumnWidth;
   }
 
-  if (splitHost.maximumSupplementaryColumnWidth >= 0) {
-    splitHostController.maximumSupplementaryColumnWidth = splitHost.maximumSupplementaryColumnWidth;
+  if (provider.maximumSupplementaryColumnWidth >= 0) {
+    splitHostController.maximumSupplementaryColumnWidth = provider.maximumSupplementaryColumnWidth;
   }
 
-  if (splitHost.preferredSupplementaryColumnWidthOrFraction >= 0 &&
-      splitHost.preferredSupplementaryColumnWidthOrFraction < 1) {
+  if (provider.preferredSupplementaryColumnWidthOrFraction >= 0 &&
+      provider.preferredSupplementaryColumnWidthOrFraction < 1) {
     splitHostController.preferredSupplementaryColumnWidthFraction =
-        splitHost.preferredSupplementaryColumnWidthOrFraction;
-  } else if (splitHost.preferredSupplementaryColumnWidthOrFraction >= 1) {
-    splitHostController.preferredSupplementaryColumnWidth = splitHost.preferredSupplementaryColumnWidthOrFraction;
+        provider.preferredSupplementaryColumnWidthOrFraction;
+  } else if (provider.preferredSupplementaryColumnWidthOrFraction >= 1) {
+    splitHostController.preferredSupplementaryColumnWidth = provider.preferredSupplementaryColumnWidthOrFraction;
   }
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0) && !TARGET_OS_TV
   if (@available(iOS 26.0, *)) {
-    if (splitHost.minimumSecondaryColumnWidth >= 0) {
-      splitHostController.minimumSecondaryColumnWidth = splitHost.minimumSecondaryColumnWidth;
+    if (provider.minimumSecondaryColumnWidth >= 0) {
+      splitHostController.minimumSecondaryColumnWidth = provider.minimumSecondaryColumnWidth;
     }
 
-    if (splitHost.preferredSecondaryColumnWidthOrFraction >= 0 &&
-        splitHost.preferredSecondaryColumnWidthOrFraction < 1) {
-      splitHostController.preferredSecondaryColumnWidthFraction = splitHost.preferredSecondaryColumnWidthOrFraction;
-    } else if (splitHost.preferredSecondaryColumnWidthOrFraction >= 1) {
-      splitHostController.preferredSecondaryColumnWidth = splitHost.preferredSecondaryColumnWidthOrFraction;
+    if (provider.preferredSecondaryColumnWidthOrFraction >= 0 && provider.preferredSecondaryColumnWidthOrFraction < 1) {
+      splitHostController.preferredSecondaryColumnWidthFraction = provider.preferredSecondaryColumnWidthOrFraction;
+    } else if (provider.preferredSecondaryColumnWidthOrFraction >= 1) {
+      splitHostController.preferredSecondaryColumnWidth = provider.preferredSecondaryColumnWidthOrFraction;
     }
 
-    if (splitHost.minimumInspectorColumnWidth >= 0) {
-      splitHostController.minimumInspectorColumnWidth = splitHost.minimumInspectorColumnWidth;
+    if (provider.minimumInspectorColumnWidth >= 0) {
+      splitHostController.minimumInspectorColumnWidth = provider.minimumInspectorColumnWidth;
     }
 
-    if (splitHost.maximumInspectorColumnWidth >= 0) {
-      splitHostController.maximumInspectorColumnWidth = splitHost.maximumInspectorColumnWidth;
+    if (provider.maximumInspectorColumnWidth >= 0) {
+      splitHostController.maximumInspectorColumnWidth = provider.maximumInspectorColumnWidth;
     }
 
-    if (splitHost.preferredInspectorColumnWidthOrFraction >= 0 &&
-        splitHost.preferredInspectorColumnWidthOrFraction < 1) {
-      splitHostController.preferredInspectorColumnWidthFraction = splitHost.preferredInspectorColumnWidthOrFraction;
-    } else if (splitHost.preferredInspectorColumnWidthOrFraction >= 1) {
-      splitHostController.preferredInspectorColumnWidth = splitHost.preferredInspectorColumnWidthOrFraction;
+    if (provider.preferredInspectorColumnWidthOrFraction >= 0 && provider.preferredInspectorColumnWidthOrFraction < 1) {
+      splitHostController.preferredInspectorColumnWidthFraction = provider.preferredInspectorColumnWidthOrFraction;
+    } else if (provider.preferredInspectorColumnWidthOrFraction >= 1) {
+      splitHostController.preferredInspectorColumnWidth = provider.preferredInspectorColumnWidthOrFraction;
     }
   }
 #endif
 
   // Step 2.3 - manipulating with inspector column
-  [splitHostController toggleSplitViewInspector:splitHost.showInspector];
+  [splitHostController toggleSplitViewInspector:provider.showInspector];
 }
 
 /**
@@ -160,14 +157,14 @@
  * executed natively, e. g. after showing/hiding a column by a swipe. In that case, any prop update incoming, would
  * reset `preferredDisplayMode` to the state from JS, what doesn't look good.
  *
- * @param splitHost The view representing JS component which is sending updates.
+ * @param provider The provider of the appearance configuration.
  * @param splitHostController The controller associated with the SplitView component which receives updates and
  * manages the native layer.
  */
-- (void)updateSplitViewDisplayModeFor:(RNSSplitHostComponentView *)splitHost
+- (void)updateSplitViewDisplayModeFor:(id<RNSSplitHostAppearanceProvider>)provider
                        withController:(RNSSplitHostController *)splitHostController
 {
-  splitHostController.preferredDisplayMode = splitHost.preferredDisplayMode;
+  splitHostController.preferredDisplayMode = provider.preferredDisplayMode;
 }
 
 - (void)validateColumnConstraintsWithMinWidth:(CGFloat)minWidth maxWidth:(CGFloat)maxWidth

--- a/ios/split/RNSSplitHostComponentView.h
+++ b/ios/split/RNSSplitHostComponentView.h
@@ -3,7 +3,7 @@
 #import "RNSDefines.h"
 #import "RNSEnums.h"
 #import "RNSReactBaseView.h"
-#import "RNSSplitHostComponentEventEmitter.h"
+#import "RNSSplitHostProviders.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -17,7 +17,8 @@ NS_ASSUME_NONNULL_BEGIN
  * Responsible for managing multi-column layouts via associated native UISplitViewController.
  * Manages updates to the layout properties, column configuration, and event emission.
  */
-@interface RNSSplitHostComponentView : RNSReactBaseView
+@interface RNSSplitHostComponentView
+    : RNSReactBaseView <RNSSplitHostAppearanceProvider, RNSSplitHostBehaviorProvider, RNSSplitHostColumnsProvider>
 
 - (nonnull NSMutableArray<RNSSplitScreenComponentView *> *)reactSubviews;
 
@@ -29,7 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * @category Props
- * @brief Definitions for React Native props.
+ * @brief Definitions for React Native props. They back the appearance and behavior providers of the Split host
+ * controller.
  */
 @interface RNSSplitHostComponentView ()
 
@@ -63,18 +65,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) RNSOrientation orientation;
 @property (nonatomic, readonly) UIUserInterfaceStyle colorScheme;
-
-@end
-
-#pragma mark - Events
-
-/**
- * @category Events
- * @brief APIs related to event emission to React Native.
- */
-@interface RNSSplitHostComponentView ()
-
-- (nonnull RNSSplitHostComponentEventEmitter *)reactEventEmitter;
 
 @end
 

--- a/ios/split/RNSSplitHostComponentView.mm
+++ b/ios/split/RNSSplitHostComponentView.mm
@@ -8,8 +8,10 @@
 #import "RNSContainerHelpers.h"
 #import "RNSConversions-SplitView.h"
 #import "RNSDefines.h"
+#import "RNSSplitHostComponentEventEmitter.h"
 #import "RNSSplitHostController.h"
 #import "RNSSplitScreenComponentView.h"
+#import "RNSSplitScreenController.h"
 
 namespace react = facebook::react;
 
@@ -18,7 +20,9 @@ static const CGFloat epsilon = 1e-6;
 #define COLUMN_METRIC_CHANGED(OLD, NEW, PROPERTY_NAME, EPSILON) \
   (fabs((OLD).columnMetrics.PROPERTY_NAME - (NEW).columnMetrics.PROPERTY_NAME) > (EPSILON))
 
-@interface RNSSplitHostComponentView () <RCTMountingTransactionObserving, RCTRNSSplitHostViewProtocol>
+@interface RNSSplitHostComponentView () <RCTMountingTransactionObserving,
+                                         RCTRNSSplitHostViewProtocol,
+                                         RNSSplitHostControllerEventsDelegate>
 @end
 
 @implementation RNSSplitHostComponentView {
@@ -116,7 +120,11 @@ static const CGFloat epsilon = 1e-6;
   if (_controller == nil) {
     int numberOfColumns = [self getNumberOfColumns];
 
-    _controller = [[RNSSplitHostController alloc] initWithSplitHostComponentView:self numberOfColumns:numberOfColumns];
+    _controller = [[RNSSplitHostController alloc] initWithNumberOfColumns:numberOfColumns];
+    _controller.eventsDelegate = self;
+    _controller.appearanceProvider = self;
+    _controller.behaviorProvider = self;
+    _controller.columnsProvider = self;
   }
 }
 
@@ -399,10 +407,51 @@ RNS_IGNORE_SUPER_CALL_END
 
 #pragma mark - Events
 
-- (nonnull RNSSplitHostComponentEventEmitter *)reactEventEmitter
+#pragma mark - RNSSplitHostColumnsProvider
+
+- (NSArray<RNSSplitScreenController *> *)columnControllers
 {
-  RCTAssert(_reactEventEmitter != nil, @"[RNScreens] Attempt to access uninitialized _reactEventEmitter");
-  return _reactEventEmitter;
+  return [self controllersOfColumnsWithType:RNSSplitScreenColumnTypeColumn];
+}
+
+- (NSArray<RNSSplitScreenController *> *)inspectorControllers
+{
+  return [self controllersOfColumnsWithType:RNSSplitScreenColumnTypeInspector];
+}
+
+- (NSArray<RNSSplitScreenController *> *)controllersOfColumnsWithType:(RNSSplitScreenColumnType)columnType
+{
+  NSMutableArray<RNSSplitScreenController *> *controllers = [NSMutableArray array];
+  for (RNSSplitScreenComponentView *column in _reactSubviews) {
+    if (column.columnType == columnType) {
+      [controllers addObject:column.controller];
+    }
+  }
+  return controllers;
+}
+
+#pragma mark - RNSSplitHostControllerEventsDelegate
+
+- (void)splitHostControllerDidCollapse:(RNSSplitHostController *)controller
+{
+  [_reactEventEmitter emitOnCollapse];
+}
+
+- (void)splitHostControllerDidExpand:(RNSSplitHostController *)controller
+{
+  [_reactEventEmitter emitOnExpand];
+}
+
+- (void)splitHostController:(RNSSplitHostController *)controller
+    willChangeDisplayModeFrom:(UISplitViewControllerDisplayMode)fromDisplayMode
+                           to:(UISplitViewControllerDisplayMode)toDisplayMode
+{
+  [_reactEventEmitter emitOnDisplayModeWillChangeFrom:fromDisplayMode to:toDisplayMode];
+}
+
+- (void)splitHostControllerDidHideInspector:(RNSSplitHostController *)controller
+{
+  [_reactEventEmitter emitOnHideInspector];
 }
 
 #pragma mark - Dynamic frameworks support

--- a/ios/split/RNSSplitHostController.h
+++ b/ios/split/RNSSplitHostController.h
@@ -3,31 +3,50 @@
 #import <UIKit/UIKit.h>
 #import "RNSOrientationProviding.h"
 #import "RNSReactMountingTransactionObserving.h"
+#import "RNSSplitHostProviders.h"
 
-@class RNSSplitHostComponentView;
+@class RNSSplitHostController;
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * @protocol RNSSplitHostControllerEventsDelegate
+ * @brief Receives UISplitViewController lifecycle notifications from the Split host controller.
+ */
+@protocol RNSSplitHostControllerEventsDelegate <NSObject>
+
+- (void)splitHostControllerDidCollapse:(RNSSplitHostController *)controller;
+- (void)splitHostControllerDidExpand:(RNSSplitHostController *)controller;
+- (void)splitHostController:(RNSSplitHostController *)controller
+    willChangeDisplayModeFrom:(UISplitViewControllerDisplayMode)fromDisplayMode
+                           to:(UISplitViewControllerDisplayMode)toDisplayMode;
+- (void)splitHostControllerDidHideInspector:(RNSSplitHostController *)controller;
+
+@end
 
 /**
  * @class RNSSplitHostController
  * @brief A controller associated with the RN native component representing Split host.
  *
- * Manages a collection of RNSSplitScreenComponentView instances,
- * synchronizes appearance settings with props, observes component lifecycle, and emits events.
+ * Installs the column controllers, synchronizes appearance settings with the configuration exposed by the providers,
+ * observes the UISplitViewController lifecycle and reports it to the delegate.
  */
 @interface RNSSplitHostController
     : UISplitViewController <RNSReactMountingTransactionObserving, RNSOrientationProviding>
+
+@property (nonatomic, weak, nullable) id<RNSSplitHostControllerEventsDelegate> eventsDelegate;
+@property (nonatomic, weak, nullable) id<RNSSplitHostAppearanceProvider> appearanceProvider;
+@property (nonatomic, weak, nullable) id<RNSSplitHostBehaviorProvider> behaviorProvider;
+@property (nonatomic, weak, nullable) id<RNSSplitHostColumnsProvider> columnsProvider;
 
 /**
  * @brief Initializes the Split host controller with provided style.
  *
  * The style for the Split component can be passed only in the initialization method and cannot be changed dynamically.
  *
- * @param splitHostComponentView The view managed by this controller.
  * @param numberOfColumns Expected number of visible columns.
  */
-- (instancetype)initWithSplitHostComponentView:(RNSSplitHostComponentView *)splitHostComponentView
-                               numberOfColumns:(NSInteger)numberOfColumns;
+- (instancetype)initWithNumberOfColumns:(NSInteger)numberOfColumns;
 
 #pragma mark - Signals
 

--- a/ios/split/RNSSplitHostController.mm
+++ b/ios/split/RNSSplitHostController.mm
@@ -4,10 +4,8 @@
 #import "RNSDefines.h"
 #import "RNSSplitAppearanceApplicator.h"
 #import "RNSSplitAppearanceCoordinator.h"
-#import "RNSSplitHostComponentView.h"
 #import "RNSSplitNavigationController.h"
 #import "RNSSplitNavigationControllerFrameOriginChangeDelegate.h"
-#import "RNSSplitScreenComponentView.h"
 #import "RNSSplitScreenController.h"
 
 [[maybe_unused]] static const NSInteger minNumberOfColumns = 2;
@@ -23,8 +21,6 @@
 
   RNSSplitAppearanceCoordinator *_splitAppearanceCoordinator;
   RNSSplitAppearanceApplicator *_splitAppearanceApplicator;
-
-  RNSSplitHostComponentView *_splitHostComponentView;
 
   /**
    * This variable is keeping the value of how many columns were set in the initial render. It's used for validation,
@@ -43,11 +39,9 @@
   NSMutableSet<NSNumber *> *_visibleColumns;
 }
 
-- (instancetype)initWithSplitHostComponentView:(RNSSplitHostComponentView *)splitHostComponentView
-                               numberOfColumns:(NSInteger)numberOfColumns
+- (instancetype)initWithNumberOfColumns:(NSInteger)numberOfColumns
 {
   if (self = [super initWithStyle:[RNSSplitHostController styleByNumberOfColumns:numberOfColumns]]) {
-    _splitHostComponentView = splitHostComponentView;
     _splitAppearanceCoordinator = [RNSSplitAppearanceCoordinator new];
     _splitAppearanceApplicator = [RNSSplitAppearanceApplicator new];
     _fixedColumnsCount = numberOfColumns;
@@ -58,11 +52,6 @@
   }
 
   return self;
-}
-
-- (RNSSplitHostComponentEventEmitter *)reactEventEmitter
-{
-  return [_splitHostComponentView reactEventEmitter];
 }
 
 #pragma mark - Signals
@@ -114,18 +103,16 @@
   RCTAssert(_needsChildViewControllersUpdate,
             @"[RNScreens] Child view controller must be invalidated when update is forced!");
 
-  NSArray<RNSSplitScreenComponentView *> *currentColumns = [self filterSubviewsOfType:RNSSplitScreenColumnTypeColumn
-                                                                                   in:self.splitReactSubviews];
-  NSArray<RNSSplitScreenComponentView *> *currentInspectors =
-      [self filterSubviewsOfType:RNSSplitScreenColumnTypeInspector in:self.splitReactSubviews];
+  NSArray<RNSSplitScreenController *> *currentColumns = [self.columnsProvider columnControllers];
+  NSArray<RNSSplitScreenController *> *currentInspectors = [self.columnsProvider inspectorControllers];
 
   [self validateColumns:currentColumns];
   [self validateInspectors:currentInspectors];
 
   NSMutableArray<RNSSplitNavigationController *> *currentViewControllers =
       [NSMutableArray arrayWithCapacity:currentColumns.count];
-  for (RNSSplitScreenComponentView *column in currentColumns) {
-    [currentViewControllers addObject:[[RNSSplitNavigationController alloc] initWithRootViewController:column.controller
+  for (RNSSplitScreenController *columnController in currentColumns) {
+    [currentViewControllers addObject:[[RNSSplitNavigationController alloc] initWithRootViewController:columnController
                                                                              frameOriginChangeDelegate:self]];
   }
 
@@ -142,7 +129,7 @@
 
 - (void)updateSplitAppearanceIfNeeded
 {
-  [_splitAppearanceApplicator updateAppearanceIfNeeded:_splitHostComponentView
+  [_splitAppearanceApplicator updateAppearanceIfNeeded:self.appearanceProvider
                                    splitHostController:self
                                  appearanceCoordinator:_splitAppearanceCoordinator];
 }
@@ -182,29 +169,6 @@
     default:
       return UISplitViewControllerStyleUnspecified;
   }
-}
-
-/**
- * @brief Filters the given subviews array by a specific column type.
- *
- * Iterates over the provided subviews array and returns only the elements that match
- * the specified RNSSplitScreenColumnType (e.g., .column, .inspector).
- *
- * @param type The target RNSSplitScreenColumnType to filter for.
- * @param subviews The array of RNSSplitScreenComponentView elements to filter.
- * @return A filtered array of RNSSplitScreenComponentView objects with the specified column type.
- */
-- (NSArray<RNSSplitScreenComponentView *> *)filterSubviewsOfType:(RNSSplitScreenColumnType)type
-                                                              in:(NSArray<RNSSplitScreenComponentView *> *)subviews
-{
-  NSMutableArray<RNSSplitScreenComponentView *> *filteredSubviews = [NSMutableArray array];
-  for (RNSSplitScreenComponentView *subview in subviews) {
-    if (subview.columnType == type) {
-      [filteredSubviews addObject:subview];
-    }
-  }
-
-  return filteredSubviews;
 }
 
 #pragma mark - Public setters
@@ -278,7 +242,7 @@
 
 - (RNSOrientation)evaluateOrientation
 {
-  return _splitHostComponentView.orientation;
+  return self.appearanceProvider.orientation;
 }
 
 #pragma mark - Validators
@@ -286,17 +250,12 @@
 /** @brief Validates that child structure meets required constraints defined for columns and the inspector. */
 - (void)validateSplitViewHierarchy
 {
-  NSArray<RNSSplitScreenComponentView *> *columns = [self filterSubviewsOfType:RNSSplitScreenColumnTypeColumn
-                                                                            in:self.splitReactSubviews];
-  NSArray<RNSSplitScreenComponentView *> *inspectors = [self filterSubviewsOfType:RNSSplitScreenColumnTypeInspector
-                                                                               in:self.splitReactSubviews];
-
-  [self validateColumns:columns];
-  [self validateInspectors:inspectors];
+  [self validateColumns:[self.columnsProvider columnControllers]];
+  [self validateInspectors:[self.columnsProvider inspectorControllers]];
 }
 
 /** @brief Ensures that number of columns is valid and hasn't changed dynamically. */
-- (void)validateColumns:(NSArray<RNSSplitScreenComponentView *> *)columns
+- (void)validateColumns:(NSArray<RNSSplitScreenController *> *)columns
 {
   RCTAssert((NSInteger)columns.count >= minNumberOfColumns && (NSInteger)columns.count <= maxNumberOfColumns,
             @"[RNScreens] Split can only have from %ld to %ld columns",
@@ -308,7 +267,7 @@
 }
 
 /** @brief Ensures that at most one inspector is present. */
-- (void)validateInspectors:(NSArray<RNSSplitScreenComponentView *> *)inspectors
+- (void)validateInspectors:(NSArray<RNSSplitScreenController *> *)inspectors
 {
   RCTAssert((NSInteger)inspectors.count <= maxNumberOfInspectors,
             @"[RNScreens] Split can only have %ld inspector",
@@ -356,33 +315,6 @@
   return splitScreenControllers;
 }
 
-/**
- * @brief Gets all React subviews of type RNSSplitScreenComponentView.
- *
- * Accesses all the subviews from the reactSubviews collection. It asserts that each one is a
- * RNSSplitScreenComponentView.
- *
- * @return An array of RNSSplitScreenComponentView subviews which are children of the host component view.
- */
-- (NSArray<RNSSplitScreenComponentView *> *)splitReactSubviews
-{
-  NSArray<RNSSplitScreenComponentView *> *reactSubviews = [_splitHostComponentView reactSubviews];
-  NSMutableArray<RNSSplitScreenComponentView *> *splitReactSubviews =
-      [NSMutableArray arrayWithCapacity:reactSubviews.count];
-
-  for (RNSSplitScreenComponentView *subview in reactSubviews) {
-    RCTAssert([subview isKindOfClass:RNSSplitScreenComponentView.class],
-              @"[RNScreens] Expected RNSSplitScreenComponentView but got %@",
-              NSStringFromClass(subview.class));
-
-    if ([subview isKindOfClass:RNSSplitScreenComponentView.class]) {
-      [splitReactSubviews addObject:subview];
-    }
-  }
-
-  return splitReactSubviews;
-}
-
 #pragma mark - RNSSplitNavigationControllerFrameOriginChangeDelegate
 
 /**
@@ -407,16 +339,16 @@
  *
  * Attaches a view controller for the inspector column.
  *
- * @param inspectors An array of inspector-type RNSSplitScreenComponentView subviews.
+ * @param inspectors An array of controllers of the inspector-type columns.
  */
-- (void)maybeSetupInspector:(NSArray<RNSSplitScreenComponentView *> *)inspectors
+- (void)maybeSetupInspector:(NSArray<RNSSplitScreenController *> *)inspectors
 {
 #if !TARGET_OS_TV
   if (@available(iOS 26.0, *)) {
-    RNSSplitScreenComponentView *inspector = inspectors.firstObject;
+    RNSSplitScreenController *inspector = inspectors.firstObject;
     if (inspector != nil) {
       RNSSplitNavigationController *inspectorViewController =
-          [[RNSSplitNavigationController alloc] initWithRootViewController:inspector.controller];
+          [[RNSSplitNavigationController alloc] initWithRootViewController:inspector];
       [self setViewController:inspectorViewController forColumn:UISplitViewControllerColumnInspector];
     }
   }
@@ -469,12 +401,12 @@
 
 - (void)splitViewControllerDidCollapse:(UISplitViewController *)svc
 {
-  [[self reactEventEmitter] emitOnCollapse];
+  [self.eventsDelegate splitHostControllerDidCollapse:self];
 }
 
 - (void)splitViewControllerDidExpand:(UISplitViewController *)svc
 {
-  [[self reactEventEmitter] emitOnExpand];
+  [self.eventsDelegate splitHostControllerDidExpand:self];
 }
 
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
@@ -508,7 +440,7 @@
     UIViewController *inspectorViewController = [self viewControllerForColumn:UISplitViewControllerColumnInspector];
     if (inspectorViewController != nil) {
       if (inspectorViewController.view.window == nil) {
-        [[self reactEventEmitter] emitOnHideInspector];
+        [self.eventsDelegate splitHostControllerDidHideInspector:self];
       }
     }
   }
@@ -521,7 +453,7 @@
     willChangeToDisplayMode:(UISplitViewControllerDisplayMode)displayMode
 {
   if (self.displayMode != displayMode) {
-    [[self reactEventEmitter] emitOnDisplayModeWillChangeFrom:self.displayMode to:displayMode];
+    [self.eventsDelegate splitHostController:self willChangeDisplayModeFrom:self.displayMode to:displayMode];
   }
 
   __weak auto weakSelf = self;
@@ -550,8 +482,8 @@
 - (UISplitViewControllerColumn)splitViewController:(UISplitViewController *)svc
          topColumnForCollapsingToProposedTopColumn:(UISplitViewControllerColumn)proposedTopColumn
 {
-  if (_splitHostComponentView.hasCustomTopColumnForCollapsing) {
-    return _splitHostComponentView.topColumnForCollapsingColumn;
+  if (self.behaviorProvider.hasCustomTopColumnForCollapsing) {
+    return self.behaviorProvider.topColumnForCollapsingColumn;
   }
 
   return proposedTopColumn;

--- a/ios/split/RNSSplitHostProviders.h
+++ b/ios/split/RNSSplitHostProviders.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#import <UIKit/UIKit.h>
+#import "RNSDefines.h"
+#import "RNSEnums.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class RNSSplitScreenController;
+
+/**
+ * @brief Configuration of the UISplitViewController appearance.
+ */
+@protocol RNSSplitHostAppearanceProvider <NSObject>
+
+- (UISplitViewControllerSplitBehavior)preferredSplitBehavior;
+- (UISplitViewControllerPrimaryEdge)primaryEdge;
+- (UISplitViewControllerDisplayMode)preferredDisplayMode;
+- (UISplitViewControllerDisplayModeButtonVisibility)displayModeButtonVisibility;
+#if !TARGET_OS_TV
+- (UISplitViewControllerBackgroundStyle)primaryBackgroundStyle;
+#endif // !TARGET_OS_TV
+- (BOOL)presentsWithGesture;
+- (BOOL)showSecondaryToggleButton;
+- (BOOL)showInspector;
+
+- (double)minimumPrimaryColumnWidth;
+- (double)maximumPrimaryColumnWidth;
+- (double)preferredPrimaryColumnWidthOrFraction;
+- (double)minimumSupplementaryColumnWidth;
+- (double)maximumSupplementaryColumnWidth;
+- (double)preferredSupplementaryColumnWidthOrFraction;
+
+#if RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+- (double)minimumSecondaryColumnWidth;
+- (double)preferredSecondaryColumnWidthOrFraction;
+- (double)minimumInspectorColumnWidth;
+- (double)maximumInspectorColumnWidth;
+- (double)preferredInspectorColumnWidthOrFraction;
+#endif // RNS_IPHONE_OS_VERSION_AVAILABLE(26_0)
+
+- (RNSOrientation)orientation;
+- (UIUserInterfaceStyle)colorScheme;
+
+@end
+
+/**
+ * @brief Behavior consulted by the UISplitViewController delegate callbacks.
+ */
+@protocol RNSSplitHostBehaviorProvider <NSObject>
+
+- (BOOL)hasCustomTopColumnForCollapsing;
+- (UISplitViewControllerColumn)topColumnForCollapsingColumn;
+
+@end
+
+/**
+ * @brief Controllers of the columns mounted in the host, in React order, split by column type.
+ */
+@protocol RNSSplitHostColumnsProvider <NSObject>
+
+- (NSArray<RNSSplitScreenController *> *)columnControllers;
+- (NSArray<RNSSplitScreenController *> *)inspectorControllers;
+
+@end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Another part of separating domains in iOS Split implementation. Until now, `RNSSplitHostController` kept a reference to its `RNSSplitHostComponentView` and read every prop straight off it. `RNSSplitAppearanceApplicator` did the same for the appearance props. This PR inverts the dependency: the controller reads its configuration through provider protocols and reports UIKit lifecycle through an events delegate. The component view implements all protocols. 

## Changes

- Added protocols for providers which Host implements
- Removed the HostComponentCiew references.
- AppearanceApplicator takes `RNSSplitHostAppearanceProvider` instead of the HostComponentView.

## Before & after - visual documentation

No visual changes

## Test plan

Go through some SplitView examples

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
