### PR TITLE
fix: wrap children in DelayedFreeze instead of AnimatedScreen

### DIFF
--- a/src/legacy/components/Screen.tsx
+++ b/src/legacy/components/Screen.tsx
@@ -207,8 +207,7 @@ export const InnerScreen = React.forwardRef<ScreenInstance, ScreenProps>(
         (shouldFreeze !== undefined ? shouldFreeze : activityState === 0);
 
       return (
-        <DelayedFreeze freeze={freeze}>
-          <AnimatedScreen
+        <AnimatedScreen
             {...props}
             /**
              * This messy override is to conform NativeProps used by codegen and
@@ -287,7 +286,7 @@ export const InnerScreen = React.forwardRef<ScreenInstance, ScreenProps>(
               featureFlags.experiment.iosOrientationInheritanceFixEnabled
             }>
             {!isNativeStack ? ( // see comment of this prop in types.tsx for information why it is needed
-              children
+              <DelayedFreeze freeze={freeze}>{children}</DelayedFreeze>
             ) : (
               <TransitionProgressContext.Provider
                 value={{
@@ -295,11 +294,12 @@ export const InnerScreen = React.forwardRef<ScreenInstance, ScreenProps>(
                   closing,
                   goingForward,
                 }}>
-                {children}
+                <DelayedFreeze freeze={freeze}>
+                  {children}
+                </DelayedFreeze>
               </TransitionProgressContext.Provider>
             )}
           </AnimatedScreen>
-        </DelayedFreeze>
       );
     } else {
       // same reason as above


### PR DESCRIPTION
## Description

With `freezeOnBlur` enabled, a screen can freeze **in the same commit as its deactivation**. The suspended subtree never delivers `activityState = 0` to the native side, so more than one screen ends up reporting `RNSActivityStateOnTop`, and a tab navigator permanently renders the wrong screen.

`DelayedFreeze` currently wraps the whole `AnimatedScreen`, which places the `activityState` prop — the deactivation signal — *inside* the freeze boundary. The one-render delay (`setTimeout(0)`) is a timing mitigation, not a guarantee: when `freeze` and deactivation land in one commit, the suspension can still swallow the update.

This PR moves `DelayedFreeze` inside, so only `children` are frozen and the native screen view (with its `activityState` prop) stays outside the boundary — following the direction suggested by @satya164 in the issue.

Closes #4518.

## Changes

- `src/legacy/components/Screen.tsx`: wrapped `children` (both plain and `TransitionProgressContext.Provider` branches) in `DelayedFreeze` instead of wrreen`; no changes to `DelayedFreeze`itself.

## Test plan

No visual changes.

Type-level verification:
- `yarn check-types` passes
- `prettier --check src/legacy/components/Screen.tsx` passes

Manual reproduction of the issue (as reported in #4518):

```tsx
import { enableFreeze } from 'react-native
import { NavigationContainer } from '@react-navigation/native';
import { createBottomTabNavigator } from 's';

enableFreeze();

const Tab = createBottomTabNavigator();

function ScreenA() {
  return <Text style={{ padding: 100 }}>Screen A</Text>;
}

function ScreenB() {
  return <Text style={{ padding: 100 }}>Screen B</Text>;
}

export default function App() {
  return (
    <NavigationContainer>
      <Tab.Navigator>
        <Tab.Screen name="A" component={Sc
        <Tab.Screen name="B" component={ScreenB} />
      </Tab.Navigator>
    </NavigationContainer>
  );
}
```

Steps: rapidly switch between tabs. Before the fix, the tab bar tracks the selection but the content wedges on
one screen (the screen froze in the same co activityState = 0 never reached native).After the fix, deactivation is delivered reliably and the content follows the selection.

Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screensumenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes