### PR TITLE
chore: remove redundant main-labs from CI workflows

### DIFF
--- a/.github/workflows/android-build-test-fabric.yml
+++ b/.github/workflows/android-build-test-fabric.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - main-labs
     paths:
       - 'android/**'
       - 'common/**'
@@ -14,7 +13,6 @@ on:
   push:
     branches:
       - main
-      - main-labs
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/ios-build-test-fabric.yml
+++ b/.github/workflows/ios-build-test-fabric.yml
@@ -3,7 +3,6 @@ on:
   pull_request:
     branches:
       - main
-      - main-labs
     paths:
       - '.github/workflows/ios-build-test-fabric.yml'
       - 'RNScreens.podspec'
@@ -15,7 +14,6 @@ on:
   push:
     branches:
       - main
-      - main-labs
   workflow_dispatch:
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,11 +3,9 @@ on:
   push:
     branches:
       - main
-      - main-labs
   pull_request:
     branches:
       - main
-      - main-labs
   workflow_dispatch:
 jobs:
   lint-js:


### PR DESCRIPTION
## Description

Remove redundant `main-labs` from `branches:` section in CI workflows

Closes [#1787](https://github.com/software-mansion/react-native-screens-labs/issues/1787).


## Before & after - visual documentation
N/A

## Test plan

All CI jobs pass

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [x] Ensured that CI passes
