### PR TITLE
chore(iOS): add logs for invalid SFSymbols and xcassetss name

### DIFF
--- a/ios/stack/header/RNSStackHeaderIconResolver.mm
+++ b/ios/stack/header/RNSStackHeaderIconResolver.mm
@@ -1,4 +1,5 @@
 #import "RNSStackHeaderIconResolver.h"
+#import <React/RCTLog.h>
 
 @implementation RNSStackHeaderIconResolver
 
@@ -18,11 +19,17 @@
   switch (iconData.iconType) {
     case RNSStackHeaderIconTypeSfSymbol: {
       UIImage *image = [UIImage systemImageNamed:iconData.resourceName];
+      if (image == nil && iconData.resourceName != nil) {
+        RCTLogWarn(@"[RNScreens] Failed to load SF Symbol \"%@\" for header icon", iconData.resourceName);
+      }
       iconData.resolvedImage = image;
       return image;
     }
     case RNSStackHeaderIconTypeXcasset: {
       UIImage *image = [UIImage imageNamed:iconData.resourceName];
+      if (image == nil && iconData.resourceName != nil) {
+        RCTLogWarn(@"[RNScreens] Failed to load xcasset \"%@\" for header icon", iconData.resourceName);
+      }
       iconData.resolvedImage = image;
       return image;
     }

--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -63,9 +63,17 @@
   if (screenView.iconType == RNSTabsIconTypeSfSymbol || screenView.iconType == RNSTabsIconTypeXcasset) {
     if (screenView.iconResourceName != nil) {
       if (screenView.iconType == RNSTabsIconTypeSfSymbol) {
-        tabBarItem.image = [UIImage systemImageNamed:screenView.iconResourceName];
+        UIImage *image = [UIImage systemImageNamed:screenView.iconResourceName];
+        if (image == nil) {
+          RCTLogWarn(@"[RNScreens] Failed to load SF Symbol \"%@\" for tab bar item", screenView.iconResourceName);
+        }
+        tabBarItem.image = image;
       } else {
-        tabBarItem.image = [UIImage imageNamed:screenView.iconResourceName];
+        UIImage *image = [UIImage imageNamed:screenView.iconResourceName];
+        if (image == nil) {
+          RCTLogWarn(@"[RNScreens] Failed to load xcasset \"%@\" for tab bar item", screenView.iconResourceName);
+        }
+        tabBarItem.image = image;
       }
     } else if (screenView.systemItem != RNSTabsScreenSystemItemNone) {
       // Restore default system item icon
@@ -84,9 +92,19 @@
 
     if (screenView.selectedIconResourceName != nil) {
       if (screenView.iconType == RNSTabsIconTypeSfSymbol) {
-        tabBarItem.selectedImage = [UIImage systemImageNamed:screenView.selectedIconResourceName];
+        UIImage *selectedImage = [UIImage systemImageNamed:screenView.selectedIconResourceName];
+        if (selectedImage == nil) {
+          RCTLogWarn(@"[RNScreens] Failed to load SF Symbol \"%@\" for selected tab bar item",
+                     screenView.selectedIconResourceName);
+        }
+        tabBarItem.selectedImage = selectedImage;
       } else {
-        tabBarItem.selectedImage = [UIImage imageNamed:screenView.selectedIconResourceName];
+        UIImage *selectedImage = [UIImage imageNamed:screenView.selectedIconResourceName];
+        if (selectedImage == nil) {
+          RCTLogWarn(@"[RNScreens] Failed to load xcasset \"%@\" for selected tab bar item",
+                     screenView.selectedIconResourceName);
+        }
+        tabBarItem.selectedImage = selectedImage;
       }
     } else if (screenView.systemItem != RNSTabsScreenSystemItemNone) {
       // Restore default system item icon


### PR DESCRIPTION
## Description

This PR adds `RCTLogWarn` when icon name is not nil and the image isn't founded.

Closes https://github.com/software-mansion/react-native-screens-labs/issues/153

## Changes

- Add warns for `image` in `ios/stack/header/RNSStackHeaderIconResolver.mm`
- Add warns for `image` and `selectedImage` in `ios/tabs/RNSTabBarAppearanceCoordinator.mm`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
