### PR TITLE
fix(iOS): create headerSearchPaths list dynamically for spm

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,43 +1,30 @@
 // swift-tools-version: 6.0
+import Foundation
 import PackageDescription
 
-// Header search paths for quoted cross-directory imports (SPM has no CocoaPods header maps).
-// Keep in sync when adding new ios/ subdirectories that contain headers.
-let headerSearchPaths: [String] = [
-    "ios",
-    "ios/bridging",
-    "ios/conversion",
-    "ios/helpers/container",
-    "ios/helpers/image",
-    "ios/helpers/scroll-view",
-    "ios/legacy",
-    "ios/legacy/events",
-    "ios/legacy/integrations",
-    "ios/legacy/utils",
-    "ios/modals/form-sheet",
-    "ios/modals/utils",
-    "ios/safe-area",
-    "ios/scroll-to-top-guard",
-    "ios/scroll-view-marker",
-    "ios/scroll-view-marker/conversion",
-    "ios/split",
-    "ios/split/conversion",
-    "ios/stack",
-    "ios/stack/conversion",
-    "ios/stack/header",
-    "ios/stack/host",
-    "ios/stack/screen",
-    "ios/tabs",
-    "ios/tabs/bottom-accessory",
-    "ios/tabs/conversion",
-    "ios/tabs/extensions",
-    "ios/tabs/host",
-    "ios/tabs/screen",
-    "ios/utils",
-    "ios/utils/extensions",
-    "common/cpp",
-    "cpp/legacy",
-]
+// Header search paths for quoted cross-directory imports (SPM has no CocoaPods
+// header maps, and no glob in its manifest API). Discovered at manifest-eval time
+// -- the equivalent of the podspec's `ios/**/*.h` -- so contributors never have to
+// hand-maintain this list. Every directory containing a header gets an `-I`.
+func discoverHeaderSearchPaths() -> [String] {
+    let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+    var dirs = Set<String>()
+    for base in ["ios", "common/cpp", "cpp"] {
+        let baseURL = root.appendingPathComponent(base)
+        guard let enumerator = FileManager.default.enumerator(
+            at: baseURL, includingPropertiesForKeys: nil
+        ) else { continue }
+        for case let url as URL in enumerator
+            where url.pathExtension == "h" && !url.path.contains(".xcodeproj") {
+            let dir = url.deletingLastPathComponent().path
+                .replacingOccurrences(of: root.path + "/", with: "")
+            dirs.insert(dir)
+        }
+    }
+    return dirs.sorted()
+}
+
+let headerSearchPaths = discoverHeaderSearchPaths()
 
 let cSettings: [CSetting] = headerSearchPaths.map { .headerSearchPath($0) }
 

--- a/Package.swift
+++ b/Package.swift
@@ -7,18 +7,27 @@ import PackageDescription
 // -- the equivalent of the podspec's `ios/**/*.h` -- so contributors never have to
 // hand-maintain this list. Every directory containing a header gets an `-I`.
 func discoverHeaderSearchPaths() -> [String] {
-    let root = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
-    var dirs = Set<String>()
-    for base in ["ios", "common/cpp", "cpp"] {
+    let root = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .standardizedFileURL
+        .resolvingSymlinksInPath()
+    let rootPath = root.path
+    let bases = ["ios", "common/cpp", "cpp"]
+    var dirs = Set<String>(bases)
+    for base in bases {
         let baseURL = root.appendingPathComponent(base)
         guard let enumerator = FileManager.default.enumerator(
             at: baseURL, includingPropertiesForKeys: nil
         ) else { continue }
         for case let url as URL in enumerator
             where url.pathExtension == "h" && !url.path.contains(".xcodeproj") {
-            let dir = url.deletingLastPathComponent().path
-                .replacingOccurrences(of: root.path + "/", with: "")
-            dirs.insert(dir)
+            let dirPath = url.deletingLastPathComponent()
+                .standardizedFileURL
+                .resolvingSymlinksInPath()
+                .path
+            guard dirPath.hasPrefix(rootPath + "/") else { continue }
+            // rootPath.count + 1 skips the root plus the separating "/".
+            dirs.insert(String(dirPath.dropFirst(rootPath.count + 1)))
         }
     }
     return dirs.sorted()


### PR DESCRIPTION
## Description

Create headerSearchPaths list dynamically for spm

## Changes

Change static `headerSearchPaths` list into dynamic headers lookup.

## Before & after - visual documentation

N/A

## Test plan

CI pass

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
