### PR TITLE
feat(iOS, Tabs): add `tabBarHiddenAnimationEnabled` prop (#4627)

### DIFF
--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/index.tsx
@@ -1,6 +1,6 @@
 import { SettingsSwitch } from '@apps/shared/SettingsSwitch';
 import React from 'react';
-import { ScrollView, Text } from 'react-native';
+import { Platform, ScrollView, Text } from 'react-native';
 import { scenarioDescription } from './scenario-description';
 import { createScenario } from '@apps/tests/shared/helpers';
 import {
@@ -25,6 +25,17 @@ function ConfigScreen() {
         onValueChange={value => updateHostConfig({ tabBarHidden: value })}
         testID="tab-bar-hidden-switch"
       />
+      {Platform.OS === 'ios' && (
+        <SettingsSwitch
+          style={{ marginBottom: 15 }}
+          label="ios.tabBarHiddenAnimationEnabled"
+          value={hostConfig.ios?.tabBarHiddenAnimationEnabled ?? true}
+          onValueChange={value =>
+            updateHostConfig({ ios: { tabBarHiddenAnimationEnabled: value } })
+          }
+          testID="tab-bar-hidden-animation-enabled-switch"
+        />
+      )}
     </ScrollView>
   );
 }

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario-description.ts
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario-description.ts
@@ -4,7 +4,7 @@ export const scenarioDescription: ScenarioDescription = {
   name: 'Tab Bar Hidden',
   key: 'test-tabs-tab-bar-hidden',
   details:
-    'Test tabBarHidden prop on TabsHost - toggle to show/hide the tab bar at runtime',
+    'Test tabBarHidden prop on TabsHost - toggle to show/hide the tab bar at runtime. On iOS, also toggles ios.tabBarHiddenAnimationEnabled to compare animated and immediate transitions.',
   platforms: ['ios', 'android'],
   e2eCoverage: 'full',
   smokeTest: false,

--- a/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
+++ b/apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden/scenario.md
@@ -2,7 +2,7 @@
 
 ## Details
 
-**Description:** This test scenario focuses on the visibility management of the tab bar. It validates the tabBarHidden property, ensuring that the UI responds dynamically to state changes without layout shifts or persistence errors.
+**Description:** This test scenario focuses on the visibility management of the tab bar. It validates the tabBarHidden property, ensuring that the UI responds dynamically to state changes without layout shifts or persistence errors. On iOS, it also validates the `ios.tabBarHiddenAnimationEnabled` property, which controls whether the transition is animated (iOS 18+).
 
 **OS test creation version:** iOS: 18.6 and 26.2, Android: API Level 36.
 
@@ -23,8 +23,16 @@ Full: Covers all manual scenario steps.
 
 2. Toggle `tabBarHidden` to `true`.
 
-- [ ] Tab bar should disappear immediately.
+- [ ] Tab bar should disappear. On iOS 18+, the transition should be animated (`ios.tabBarHiddenAnimationEnabled` defaults to `true`); on Android and iOS < 18 the tab bar disappears immediately.
 
 3. Toggle back to `false`.
 
-- [ ] Tab bar should reappear.
+- [ ] Tab bar should reappear, with the same animation behavior as in step 2.
+
+4. (iOS only) Toggle `ios.tabBarHiddenAnimationEnabled` to `false`, then repeat steps 2-3.
+
+- [ ] Tab bar should disappear and reappear immediately, without animation.
+
+5. (iOS only) Toggle `ios.tabBarHiddenAnimationEnabled` back to `true`, then repeat steps 2-3.
+
+- [ ] Tab bar should disappear and reappear with animation again.

--- a/ios/tabs/host/RNSTabsHostComponentView.h
+++ b/ios/tabs/host/RNSTabsHostComponentView.h
@@ -44,6 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly) BOOL tabBarHidden;
 
+@property (nonatomic, readonly) BOOL tabBarHiddenAnimationEnabled;
+
 @property (nonatomic, readonly) BOOL bottomAccessoryHidden;
 
 @property (nonatomic, strong, readonly, nullable) UIColor *nativeContainerBackgroundColor;

--- a/ios/tabs/host/RNSTabsHostComponentView.mm
+++ b/ios/tabs/host/RNSTabsHostComponentView.mm
@@ -98,6 +98,7 @@ namespace react = facebook::react;
   _layoutDirection = UITraitEnvironmentLayoutDirectionUnspecified;
   _colorScheme = UIUserInterfaceStyleUnspecified;
   _rejectStaleNavStateUpdates = NO;
+  _tabBarHiddenAnimationEnabled = YES;
   _bottomAccessoryHidden = NO;
 #if !TARGET_OS_TV
   _nativeContainerBackgroundColor = [UIColor systemBackgroundColor];
@@ -239,11 +240,17 @@ namespace react = facebook::react;
     _tabBarTintColor = RCTUIColorFromSharedColor(newComponentProps.tabBarTintColor);
   }
 
+  // Must be applied before `tabBarHidden`, so that both props changing in the same
+  // update use the new animation setting.
+  if (newComponentProps.tabBarHiddenAnimationEnabled != oldComponentProps.tabBarHiddenAnimationEnabled) {
+    _tabBarHiddenAnimationEnabled = newComponentProps.tabBarHiddenAnimationEnabled;
+  }
+
   if (newComponentProps.tabBarHidden != oldComponentProps.tabBarHidden) {
     _tabBarHidden = newComponentProps.tabBarHidden;
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(18_0)
     if (@available(iOS 18.0, *)) {
-      [_controller setTabBarHidden:_tabBarHidden animated:NO];
+      [_controller setTabBarHidden:_tabBarHidden animated:_tabBarHiddenAnimationEnabled];
     } else
 #endif // RNS_IPHONE_OS_VERSION_AVAILABLE(18_0)
     {

--- a/src/components/tabs/host/TabsHost.ios.tsx
+++ b/src/components/tabs/host/TabsHost.ios.tsx
@@ -48,6 +48,7 @@ function TabsHost(props: TabsHostProps) {
       {...filteredBaseProps}
       // iOS-specific
       layoutDirection={direction}
+      tabBarHiddenAnimationEnabled={ios?.tabBarHiddenAnimationEnabled}
       tabBarControllerMode={ios?.tabBarControllerMode}
       tabBarMinimizeBehavior={ios?.tabBarMinimizeBehavior}
       tabBarTintColor={ios?.tabBarTintColor}

--- a/src/components/tabs/host/TabsHost.ios.types.ts
+++ b/src/components/tabs/host/TabsHost.ios.types.ts
@@ -35,6 +35,22 @@ export type TabBarControllerMode = 'automatic' | 'tabBar' | 'tabSidebar';
 
 export interface TabsHostPropsIOS {
   /**
+   * @summary Whether changes of `tabBarHidden` are animated.
+   *
+   * When `true`, the tab bar is hidden and shown with the system transition
+   * (`UITabBarController.setTabBarHidden(_:animated:)`). When `false`, the
+   * tab bar disappears and reappears immediately.
+   *
+   * Available starting from iOS 18. On earlier versions the tab bar visibility
+   * is never animated, regardless of this prop.
+   *
+   * @default true
+   *
+   * @platform ios
+   * @supported iOS 18 or higher
+   */
+  tabBarHiddenAnimationEnabled?: boolean | undefined;
+  /**
    * @summary Specifies the color used for selected tab's text and icon color.
    *
    * Starting from iOS 26, it also impacts glow of Liquid Glass tab

--- a/src/components/tabs/host/TabsHost.types.ts
+++ b/src/components/tabs/host/TabsHost.types.ts
@@ -181,6 +181,9 @@ export interface TabsHostPropsBase {
   /**
    * @summary Hides the tab bar.
    *
+   * On iOS 18+, whether the change is animated is controlled by
+   * `ios.tabBarHiddenAnimationEnabled`.
+   *
    * @default false
    *
    * @platform android, ios

--- a/src/fabric/tabs/TabsHostIOSNativeComponent.ts
+++ b/src/fabric/tabs/TabsHostIOSNativeComponent.ts
@@ -85,6 +85,7 @@ export interface NativeProps extends ViewProps {
   layoutDirection?: CT.WithDefault<LayoutDirection, 'inherit'>;
 
   // iOS-specific props
+  tabBarHiddenAnimationEnabled?: CT.WithDefault<boolean, true>;
   tabBarTintColor?: ColorValue | undefined;
   tabBarMinimizeBehavior?: CT.WithDefault<TabBarMinimizeBehavior, 'automatic'>;
   tabBarControllerMode?: CT.WithDefault<TabBarControllerMode, 'automatic'>;


### PR DESCRIPTION
## Description

`tabBarHidden` is applied on iOS 18+ through `[UITabBarController setTabBarHidden:animated:]`, with the `animated` flag hardcoded to `NO`. UIKit is able to animate that transition, but the library never asks for it, so the tab bar can only pop in and out. On iOS 26, where the Liquid Glass tab bar floats over the content, this reads as a flash rather than as a bar arriving or leaving.

This PR adds the `ios.tabBarHiddenAnimationEnabled` prop to `TabsHost`, as agreed with @kkafar in the linked issue. It defaults to `true`, so the animated transition becomes the out-of-the-box experience; apps that rely on the instant behaviour can opt out with `false`.

Closes #4627.

## Changes

- `TabsHostIOSNativeComponent.ts`: new codegen prop `tabBarHiddenAnimationEnabled` (`WithDefault<boolean, true>`).
- `TabsHost.ios.types.ts`: new documented `tabBarHiddenAnimationEnabled` prop in `TabsHostPropsIOS`; `TabsHost.ios.tsx` forwards `ios?.tabBarHiddenAnimationEnabled` to the native component.
- `TabsHost.types.ts`: `tabBarHidden` docs now point to the iOS prop that controls the animation.
- `RNSTabsHostComponentView.{h,mm}`: new `tabBarHiddenAnimationEnabled` property (default `YES` in `resetProps`), read in `updateProps` **before** `tabBarHidden` so that both props changing in the same update use the new setting, and passed as the `animated:` argument.
- `test-tabs-tab-bar-hidden` SFT: iOS-only switch for `ios.tabBarHiddenAnimationEnabled`, and `scenario.md` updated with the animated expectation plus two steps that exercise the opt-out.

Notes for reviewers:

- The prop is placed under `ios` because the animation only exists on the iOS path; on Android `tabBarHidden` toggles `isVisible` on the `BottomNavigationView` and there is nothing to animate. Happy to move it to the top level if you'd rather keep it next to `tabBarHidden`.
- On iOS < 18 the `tabBar.hidden` fallback is unchanged and the prop is a no-op, as documented.
- `Detox` synchronises with UIKit animations, so the existing `test-tabs-tab-bar-hidden.e2e.ts` assertions should keep passing with the animated default. I could not run the iOS e2e suite locally; please let me know if you'd like the e2e test extended to cover the new switch as well.

## Before & after - visual documentation

Recorded on an iPhone 17 Pro simulator, iOS 26.5, `FabricExample` → `Single Feature Tests` → `Tabs` → `Tab Bar Hidden`. The first two hide/show cycles run with `ios.tabBarHiddenAnimationEnabled: true` (the new default), then the switch is turned off and the two following cycles show the previous, immediate behaviour.

https://github.com/user-attachments/assets/fbfd5338-500c-4e6c-9362-6802b6a07a3e



Measured on the recording (30 fps), counting frames in which the tab bar strip is neither fully shown nor fully hidden:

| Cycle | `tabBarHiddenAnimationEnabled` | Hide | Show |
| --- | --- | --- | --- |
| 1 | `true` | 0 transition frames | 4 transition frames (~130 ms) |
| 2 | `true` | 1 transition frame | 4 transition frames (~130 ms) |
| 3 | `false` | 0 transition frames | 0 transition frames |
| 4 | `false` | 0 transition frames | 0 transition frames |

UIKit animates the alpha of the bar rather than sliding it, so the visible difference is a short fade on reveal instead of a single-frame pop.

## Test plan

- `yarn lint-js`, `yarn check-types` and `prettier --check` on the changed files pass locally.
- `RNSTabsHostComponentView.{h,mm}` are clean under the repository `.clang-format`.
- `FabricExample` builds for the iOS Simulator with the change (Xcode 26.6, RN 0.87).
- Manual: `Single feature tests` → `Tabs` → `Tab Bar Hidden` (`apps/src/tests/single-feature-tests/tabs/test-tabs-tab-bar-hidden`), following the updated `scenario.md`: toggle `tabBarHidden` with the animation switch on (default) and off, and compare.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
