### PR TITLE
chore(iOS): silence release build warnings (backport of #4486)

### DIFF
--- a/ios/RNSScreen.mm
+++ b/ios/RNSScreen.mm
@@ -1582,24 +1582,6 @@ Class<RCTComponentViewProtocol> RNSScreenCls(void)
   return NO;
 }
 
-- (CGSize)getStatusBarHeightIsModal:(BOOL)isModal
-{
-#if !TARGET_OS_TV && !TARGET_OS_VISION
-  CGSize fallbackStatusBarSize = [[UIApplication sharedApplication] statusBarFrame].size;
-
-  CGSize primaryStatusBarSize = self.view.window.windowScene.statusBarManager.statusBarFrame.size;
-  if (primaryStatusBarSize.height == 0 || primaryStatusBarSize.width == 0) {
-    return fallbackStatusBarSize;
-  }
-
-  return primaryStatusBarSize;
-
-#else
-  // TVOS does not have status bar.
-  return CGSizeMake(0, 0);
-#endif // !TARGET_OS_TV
-}
-
 - (UINavigationController *)getVisibleNavigationControllerIsModal:(BOOL)isModal
 {
   UINavigationController *navctr = self.navigationController;

--- a/ios/RNSScreenStackHeaderConfig.mm
+++ b/ios/RNSScreenStackHeaderConfig.mm
@@ -947,6 +947,7 @@ RNS_IGNORE_SUPER_CALL_END
   }
 }
 
+#ifndef NDEBUG
 static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
 {
   switch (resizeMode) {
@@ -965,6 +966,7 @@ static RCTResizeMode resizeModeFromCppEquiv(react::ImageResizeMode resizeMode)
       return RCTResizeModeStretch;
   }
 }
+#endif // !NDEBUG
 
 + (RCTImageSource *)imageSourceFromImageView:(RCTImageComponentView *)view
 {

--- a/ios/RNSScreenWindowTraits.mm
+++ b/ios/RNSScreenWindowTraits.mm
@@ -101,7 +101,8 @@
 {
 #if !TARGET_OS_TV && !TARGET_OS_VISION
   dispatch_async(dispatch_get_main_queue(), ^{
-    UIInterfaceOrientationMask orientationMask = [RCTKeyWindow().rootViewController supportedInterfaceOrientations];
+    UIWindow *window = RCTKeyWindow();
+    UIInterfaceOrientationMask orientationMask = [window.rootViewController supportedInterfaceOrientations];
 
     UIInterfaceOrientation currentDeviceOrientation =
         [RNSScreenWindowTraits interfaceOrientationFromDeviceOrientation:[[UIDevice currentDevice] orientation]];
@@ -130,17 +131,7 @@
     if (newOrientation != UIInterfaceOrientationUnknown) {
 #if RNS_IPHONE_OS_VERSION_AVAILABLE(16_0)
       if (@available(iOS 16.0, *)) {
-        NSArray *array = [[[UIApplication sharedApplication] connectedScenes] allObjects];
-
-        // when an app supports multiple scenes (e.g. CarPlay), it is possible that
-        // UIWindowScene is not the first scene, or it may not be present at all
-        UIWindowScene *scene = nil;
-        for (id connectedScene in array) {
-          if ([connectedScene isKindOfClass:[UIWindowScene class]]) {
-            scene = connectedScene;
-            break;
-          }
-        }
+        UIWindowScene *scene = window.windowScene;
 
         if (scene == nil) {
           return;
@@ -154,7 +145,8 @@
 
         // `attemptRotationToDeviceOrientation` is deprecated for modern OS versions
         // so we need to use `setNeedsUpdateOfSupportedInterfaceOrientations`
-        UIViewController *topController = [UIApplication sharedApplication].keyWindow.rootViewController;
+
+        UIViewController *topController = window.rootViewController;
         while (topController.presentedViewController) {
           topController = topController.presentedViewController;
         }

--- a/ios/conversion/RNSConversions-Tabs.mm
+++ b/ios/conversion/RNSConversions-Tabs.mm
@@ -323,11 +323,11 @@ RNSTabsScreenSystemItem RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(
   }
 }
 
-UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem)
+std::optional<UITabBarSystemItem> RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem)
 {
-  RCTAssert(systemItem != RNSTabsScreenSystemItemNone,
-            @"Attempt to convert tabs systemItem none to UITabBarSystemItem");
   switch (systemItem) {
+    case RNSTabsScreenSystemItemNone:
+      return std::nullopt;
     case RNSTabsScreenSystemItemBookmarks:
       return UITabBarSystemItemBookmarks;
     case RNSTabsScreenSystemItemContacts:
@@ -353,8 +353,7 @@ UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSyst
     case RNSTabsScreenSystemItemTopRated:
       return UITabBarSystemItemTopRated;
   }
-  RCTAssert(true, @"Attempt to convert unknown tabs screen systemItem to UITabBarSystemItem [%d]", systemItem);
-  return UITabBarSystemItemSearch;
+  return std::nullopt;
 }
 
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE

--- a/ios/conversion/RNSConversions.h
+++ b/ios/conversion/RNSConversions.h
@@ -54,7 +54,7 @@ RNSTabsIconType RNSTabsIconTypeFromIcon(react::RNSTabsScreenIOSIconType iconType
 RNSTabsScreenSystemItem RNSTabsScreenSystemItemFromReactRNSTabsScreenSystemItem(
     react::RNSTabsScreenIOSSystemItem systemItem);
 
-UITabBarSystemItem RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem);
+std::optional<UITabBarSystemItem> RNSTabsScreenSystemItemToUITabBarSystemItem(RNSTabsScreenSystemItem systemItem);
 
 #if RNS_TABS_BOTTOM_ACCESSORY_AVAILABLE
 

--- a/ios/tabs/RNSTabBarAppearanceCoordinator.mm
+++ b/ios/tabs/RNSTabBarAppearanceCoordinator.mm
@@ -1,6 +1,7 @@
 #import "RNSTabBarAppearanceCoordinator.h"
 #import <React/RCTFont.h>
 #import <React/RCTImageLoader.h>
+#import <React/RCTLog.h>
 #import "RCTConvert+RNSTabs.h"
 #import "RNSConversions.h"
 #import "RNSImageLoadingHelper.h"
@@ -68,9 +69,15 @@
       }
     } else if (screenView.systemItem != RNSTabsScreenSystemItemNone) {
       // Restore default system item icon
-      UITabBarSystemItem systemItem =
+      std::optional<UITabBarSystemItem> systemItem =
           rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(screenView.systemItem);
-      tabBarItem.image = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem tag:0].image;
+      if (!systemItem) {
+        RCTLogError(
+            @"[RNScreens] Conversion from tabs screen systemItem to UITabBarSystemItem failed for systemItem [%ld]",
+            (long)screenView.systemItem);
+        return;
+      }
+      tabBarItem.image = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem.value() tag:0].image;
     } else {
       tabBarItem.image = nil;
     }
@@ -83,9 +90,15 @@
       }
     } else if (screenView.systemItem != RNSTabsScreenSystemItemNone) {
       // Restore default system item icon
-      UITabBarSystemItem systemItem =
+      std::optional<UITabBarSystemItem> systemItem =
           rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(screenView.systemItem);
-      tabBarItem.selectedImage = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem tag:0].selectedImage;
+      if (!systemItem) {
+        RCTLogError(
+            @"[RNScreens] Conversion from tabs screen systemItem to UITabBarSystemItem failed for systemItem [%ld]",
+            (long)screenView.systemItem);
+        return;
+      }
+      tabBarItem.selectedImage = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem.value() tag:0].selectedImage;
     } else {
       tabBarItem.selectedImage = nil;
     }

--- a/ios/tabs/screen/RNSTabsScreenComponentView.mm
+++ b/ios/tabs/screen/RNSTabsScreenComponentView.mm
@@ -11,6 +11,7 @@
 
 #import <React/RCTConversions.h>
 #import <React/RCTImageSource.h>
+#import <React/RCTLog.h>
 #import <react/renderer/components/rnscreens/ComponentDescriptors.h>
 #import <react/renderer/components/rnscreens/EventEmitters.h>
 #import <react/renderer/components/rnscreens/Props.h>
@@ -169,12 +170,18 @@ RNS_IGNORE_SUPER_CALL_END
 {
   UITabBarItem *tabBarItem = nil;
   if (_systemItem != RNSTabsScreenSystemItemNone) {
-    UITabBarSystemItem systemItem = rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(_systemItem);
-    tabBarItem = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem tag:0];
+    std::optional<UITabBarSystemItem> systemItem =
+        rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(_systemItem);
+    if (!systemItem) {
+      RCTLogError(
+          @"[RNScreens] Conversion from tabs screen systemItem to UITabBarSystemItem failed for systemItem [%ld]",
+          (long)_systemItem);
+      return;
+    }
+    tabBarItem = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem.value() tag:0];
   } else {
     tabBarItem = [[UITabBarItem alloc] init];
   }
-
   _controller.tabBarItem = tabBarItem;
 }
 
@@ -185,8 +192,15 @@ RNS_IGNORE_SUPER_CALL_END
   NSString *evaluatedTitle = _title;
   if (_title == nil && _systemItem != RNSTabsScreenSystemItemNone) {
     // Restore default system item title
-    UITabBarSystemItem systemItem = rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(_systemItem);
-    evaluatedTitle = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem tag:0].title;
+    std::optional<UITabBarSystemItem> systemItem =
+        rnscreens::conversion::RNSTabsScreenSystemItemToUITabBarSystemItem(_systemItem);
+    if (!systemItem) {
+      RCTLogError(
+          @"[RNScreens] Conversion from tabs screen systemItem to UITabBarSystemItem failed for systemItem [%ld]",
+          (long)_systemItem);
+      return;
+    }
+    evaluatedTitle = [[UITabBarItem alloc] initWithTabBarSystemItem:systemItem.value() tag:0].title;
   }
 
   [self updateTabBarItemTitle:evaluatedTitle];


### PR DESCRIPTION
## Description

Silence Release build warnings.
Closes
https://github.com/software-mansion/react-native-screens/issues/4319

Follow-up:
- Clean up remaining warnings from Stack v5
- Refactor `enforceDesiredDeviceOrientation` in `ios/legacy/RNSScreenWindowTraits.mm`

## Changes

- Make the `RNSTabsScreenSystemItem` switch exhaustive (include `None`) and fix the fallback assert (`RCTAssert(true, …)` → `RCTAssert(false, …)`) so unknown values actually fail in debug
(`ios/conversion/RNSConversions-Tabs.mm`)
- Remove unused `getStatusBarHeightIsModal` from `ios/legacy/RNSScreen.mm`.
- Guard `resizeModeFromCppEquiv` with `#ifndef NDEBUG` in `ios/legacy/RNSScreenStackHeaderConfig.mm`
- Replace deprecated `UIApplication.keyWindow` and the manual `connectedScenes` lookup with `RCTKeyWindow()` in
`ios/legacy/RNSScreenWindowTraits.mm`. This is safe because `RCTKeyWindow()` filters to `UIWindowScene` and selects the foreground-active scene before returning keyWindow, which should be at least as safe for multi-scene setups as choosing the first UIWindowScene.

## Test plan

- Confirm these 4 warnings no longer appear
- Run FabricExample app a check `apps/src/tests/single-feature-tests/tabs/test-tabs-system-item-ios`

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

---------


(cherry picked from commit 244e348c6a2c9568515371b849960cd5da2a08ec)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
