### PR TITLE
fix(Android): use-after-free of RNSScreenRemovalListener registered as mounting override delegate (backport of #4413)

### DIFF
--- a/android/src/main/cpp/NativeProxy.cpp
+++ b/android/src/main/cpp/NativeProxy.cpp
@@ -2,6 +2,7 @@
 #include <react/fabric/Binding.h>
 #include <react/renderer/scheduler/Scheduler.h>
 
+#include <memory>
 #include <string>
 
 #include "NativeProxy.h"
@@ -10,6 +11,19 @@ using namespace facebook;
 using namespace react;
 
 namespace rnscreens {
+
+namespace {
+// Keep this listener process-lifetime to avoid races during initialization,
+// when nativeAddMutationsListener() can be called concurrently from different
+// threads. A function-local static initializes thread-safely, and an immortal
+// instance suits core's delegate list, which is append-only. For more details:
+// https://github.com/software-mansion/react-native-screens/pull/4413
+const std::shared_ptr<RNSScreenRemovalListener> &removalListener() {
+  static const std::shared_ptr<RNSScreenRemovalListener> instance =
+      std::make_shared<RNSScreenRemovalListener>();
+  return instance;
+}
+} // namespace
 
 NativeProxy::NativeProxy(jni::alias_ref<NativeProxy::javaobject> jThis)
     : javaPart_(jni::make_global(jThis)) {}
@@ -32,13 +46,18 @@ void NativeProxy::nativeAddMutationsListener(
   auto uiManager =
       fabricUIManager->getBinding()->getScheduler()->getUIManager();
 
-  if (!screenRemovalListener_) {
-    screenRemovalListener_ =
-        std::make_shared<RNSScreenRemovalListener>([this](int tag) {
+  {
+    // Capture a copy of the global ref, never `this`: the listener outlives
+    // this NativeProxy, and the old live read of javaPart_ at call time raced
+    // invalidateNative(). installMutex_ keeps the copy from racing the
+    // invalidation write and keeps the stored token matching the last install.
+    std::lock_guard<std::mutex> lock(installMutex_);
+    removalListenerToken_ =
+        removalListener()->setListener([javaPart = javaPart_](int tag) {
           static const auto method =
-              javaPart_->getClass()->getMethod<void(jint)>(
+              javaPart->getClass()->getMethod<void(jint)>(
                   "notifyScreenRemoved");
-          method(javaPart_, tag);
+          method(javaPart, tag);
         });
   }
 
@@ -79,7 +98,7 @@ void NativeProxy::addMountingCoordinatorIfNeeded(
       });
 
   if (!wasRegistered) {
-    coordinator->setMountingOverrideDelegate(screenRemovalListener_);
+    coordinator->setMountingOverrideDelegate(removalListener());
     coordinatorsWithMountingOverrides_.push_back(coordinator);
   }
 }
@@ -90,6 +109,11 @@ jni::local_ref<NativeProxy::jhybriddata> NativeProxy::initHybrid(
 }
 
 void NativeProxy::invalidateNative() {
+  // Disarm before the hybrid is collected; also releases the captured global
+  // ref so the Java NativeProxy stays collectable. Serialized with the install
+  // path so the token is never stale and javaPart_ is not nulled mid-capture.
+  std::lock_guard<std::mutex> lock(installMutex_);
+  removalListener()->clearListener(removalListenerToken_);
   javaPart_ = nullptr;
 }
 

--- a/android/src/main/cpp/NativeProxy.h
+++ b/android/src/main/cpp/NativeProxy.h
@@ -4,6 +4,7 @@
 #include <react/fabric/JFabricUIManager.h>
 #include "RNSScreenRemovalListener.h"
 
+#include <cstdint>
 #include <mutex>
 #include <string>
 
@@ -13,7 +14,6 @@ using namespace facebook::jni;
 
 class NativeProxy : public jni::HybridClass<NativeProxy> {
  public:
-  std::shared_ptr<RNSScreenRemovalListener> screenRemovalListener_;
   std::vector<std::weak_ptr<const facebook::react::MountingCoordinator>>
       coordinatorsWithMountingOverrides_;
   static auto constexpr kJavaDescriptor =
@@ -27,6 +27,12 @@ class NativeProxy : public jni::HybridClass<NativeProxy> {
   jni::global_ref<NativeProxy::javaobject> javaPart_;
 
   std::mutex coordinatorsMutex_;
+
+  // Serializes callback install (nativeAddMutationsListener) with
+  // invalidateNative: the install-time copy of javaPart_ must not race the
+  // invalidation write, and the stored token must match the last install.
+  std::mutex installMutex_;
+  uint64_t removalListenerToken_{0};
 
   explicit NativeProxy(jni::alias_ref<NativeProxy::javaobject> jThis);
 

--- a/cpp/RNSScreenRemovalListener.cpp
+++ b/cpp/RNSScreenRemovalListener.cpp
@@ -1,12 +1,42 @@
 #include "RNSScreenRemovalListener.h"
 #include <react/renderer/mounting/ShadowViewMutation.h>
+#include <utility>
 using namespace facebook::react;
+
+uint64_t RNSScreenRemovalListener::setListener(
+    std::function<void(int)> &&listenerFunction) {
+  std::lock_guard<std::mutex> lock(listenerMutex_);
+  listenerFunction_ = std::move(listenerFunction);
+  return ++currentToken_;
+}
+
+void RNSScreenRemovalListener::clearListener(uint64_t token) {
+  std::lock_guard<std::mutex> lock(listenerMutex_);
+  if (token == currentToken_) {
+    listenerFunction_ = nullptr;
+  }
+}
 
 std::optional<MountingTransaction> RNSScreenRemovalListener::pullTransaction(
     SurfaceId surfaceId,
     MountingTransaction::Number transactionNumber,
     const TransactionTelemetry &telemetry,
     ShadowViewMutationList mutations) const {
+  // Copy under the lock, invoke outside it: the callback makes a JNI call and
+  // must not run while holding a lock the module thread also takes.
+  std::function<void(int)> listener;
+  {
+    std::lock_guard<std::mutex> lock(listenerMutex_);
+    listener = listenerFunction_;
+  }
+
+  if (!listener) {
+    // Orphaned between module teardown and the next install: pass the
+    // transaction through untouched.
+    return MountingTransaction{
+        surfaceId, transactionNumber, std::move(mutations), telemetry};
+  }
+
   for (const ShadowViewMutation &mutation : mutations) {
     // When using RNSModalScreen on Android it should be added here.
     if (mutation.type == ShadowViewMutation::Type::Remove &&
@@ -16,7 +46,7 @@ std::optional<MountingTransaction> RNSScreenRemovalListener::pullTransaction(
       // We call the listener function even if this screen has not been owned
       // by RNSScreenStack as since RN 0.78 we do not have enough information
       // here. This final filter is applied later in NativeProxy.
-      listenerFunction_(mutation.oldChildShadowView.tag);
+      listener(mutation.oldChildShadowView.tag);
     }
   }
 

--- a/cpp/RNSScreenRemovalListener.h
+++ b/cpp/RNSScreenRemovalListener.h
@@ -4,12 +4,22 @@
 #include <react/renderer/mounting/MountingOverrideDelegate.h>
 #include <react/renderer/mounting/ShadowView.h>
 
+#include <cstdint>
+#include <functional>
+#include <mutex>
+
 using namespace facebook::react;
 
 struct RNSScreenRemovalListener : public MountingOverrideDelegate {
-  std::function<void(int)> listenerFunction_;
-  RNSScreenRemovalListener(std::function<void(int)> &&listenerFunction_)
-      : listenerFunction_(std::move(listenerFunction_)) {}
+  RNSScreenRemovalListener() = default;
+
+  // RN core lacks a `removeMountingOverrideDelegate` API, so this instance is
+  // process-immortal and swaps its callback instead of being replaced. The
+  // ownership token keeps a stale proxy's teardown from clearing a newer
+  // proxy's listener.
+  // See https://github.com/software-mansion/react-native-screens/pull/4413
+  uint64_t setListener(std::function<void(int)> &&listenerFunction);
+  void clearListener(uint64_t token);
 
   bool shouldOverridePullTransaction() const override;
   std::optional<MountingTransaction> pullTransaction(
@@ -17,4 +27,9 @@ struct RNSScreenRemovalListener : public MountingOverrideDelegate {
       MountingTransaction::Number number,
       const TransactionTelemetry &telemetry,
       ShadowViewMutationList mutations) const override;
+
+ private:
+  mutable std::mutex listenerMutex_;
+  std::function<void(int)> listenerFunction_;
+  uint64_t currentToken_{0};
 };


### PR DESCRIPTION
## Description

Fixes an Android SIGSEGV in
`facebook::react::MountingCoordinator::pullTransaction` (thread `mqt_v_js`). It surfaces in two shapes at the same `shouldOverridePullTransaction()` dispatch, depending on what recycles the freed
block: `SEGV_ACCERR` with the fault address inside `[anon:scudo:primary]`, or
`SEGV_MAPERR` with fault address `0x0` when the vtable slot reads back as zero.
The second looks like a core-renderer null deref; see the analysis in the thread.

Mechanism — an unsynchronized lazy init in
`NativeProxy::nativeAddMutationsListener`:

1. Two threads reach `nativeAddMutationsListener` concurrently on a cold launch.
`ScreensModule.initialize()` registers its lifecycle listener *before* calling
`setupFabric()`; when the host is already resumed, `onHostResume()` is dispatched
to the UI thread at registration time — so `setupFabric()` runs on the module-init
   thread while the same call is already queued on the UI thread.
2. Both threads can pass the `if (!screenRemovalListener_)` null check. The racing
`shared_ptr` assignments are UB: libc++'s move-assign swaps pointer and control
block as two independent words, so the member can be left holding one thread's
object pointer with the other thread's control block — and the other thread's
   temporary then destroys and frees the pointed-to listener on release.
3. The registered delegate now reports `use_count=1, expired=0` forever while pointing
at freed memory. The next `pullTransaction` locks the `weak_ptr` successfully and
virtual-calls through a recycled vtable slot — SIGSEGV. (A listener destroyed
*normally* through its own control block is harmless: `expired=1`, `lock()` returns
   null, and core already null-checks that path.)

History: #3241 added the `onHostResume` entry path (its description notes "the order
of lifecycle events is not guaranteed"); #3363 then added `coordinatorsMutex_` because
this function is entered concurrently — but guarded only the vector operations below,
leaving the listener init unsynchronized. A second tear site: `setMountingOverrideDelegate`
takes its `weak_ptr` by value, so registration constructs it from the racing member
with two separate loads.

A second, related bug fixed here: the old callback captured raw `this` and read
`javaPart_` live at call time, while `invalidateNative()` nulls `javaPart_` with the
listener still registered (core's `mountingOverrideDelegates_` is append-only — no
`removeMountingOverrideDelegate` as of 0.87). A notification delivered between
invalidation and the hybrid's destruction called `GetObjectClass` on a null jobject.

Reports of this signature:

- Closes #4151
- Expensify/App#93842 (active, bountied)
- leon-zym/plogkit#54 (react-native 0.86 / Expo SDK 57, e2e stop/launch cycle)

## Changes

- `RNSScreenRemovalListener` is now a process-lifetime singleton (function-local
static `shared_ptr` in `NativeProxy.cpp`): thread-safe initialization removes the
racing lazy init entirely, and the entry in core's non-removable delegate list can
  never dangle.
- The listener holds a mutex-guarded swappable callback instead of being constructed
around one. The callback captures the JNI global reference by value — never `this` —
  so it cannot dereference a finalized `NativeProxy`.
- `setListener` returns a monotonic ownership token; `invalidateNative()` disarms via
`clearListener(token)`, which is a no-op when a newer install owns the callback
(protects apps running a second `ReactHost`, e.g. brownfield/hybrid setups, from a
  stale proxy's late teardown).
- Install and invalidate serialize on a per-proxy mutex, so the stored token always
matches the last install and the install-time copy of the global reference cannot
  race the invalidation write.
- A disarmed listener passes the transaction through untouched (same `MountingTransaction` the function already returned) and releases the Java reference
  so the proxy stays collectable.

The durable fix belongs in react-native core (a
`removeMountingOverrideDelegate` API
called from delegate owners' teardown); this patch makes the listener safe without it
and stays correct once such an API exists.

## Test plan

The race branch is directly measurable — a far more powerful signal than waiting for
the ~1-in-1000 crash. Minimal repro against **unpatched** code: add one log line
inside the lazy-init branch of
`NativeProxy::nativeAddMutationsListener`:

```cpp
// unpatched NativeProxy.cpp, inside `if (!screenRemovalListener_)`:
auto tmp = std::make_shared<RNSScreenRemovalListener>([this](int tag) { /* unchanged */ });
__android_log_print(ANDROID_LOG_ERROR, "RNSInitRace", "alloc listener=%p tid=%d",
    (void *)tmp.get(), gettid());
screenRemovalListener_ = std::move(tmp);
```

then cold-relaunch in a loop:

```bash
while true; do
  adb shell am force-stop <pkg>
  adb shell am start -W -n <pkg>/<main-activity>
  sleep 15
done
```

Two `RNSInitRace` lines with different `tid`s in one launch prove both threads
entered the branch; two distinct `listener=` addresses prove the double allocation.

Results:

- In one app reproducing the crash, both threads executed the init branch on 7/9
cold launches and it crashed on 3/9; with the init serialized: 0/20 and 0/20. In a
dev build of the app from Expensify/App#93842: double-init on 1/150 launches
unguarded vs 0/1000 serialized, with the racy entry window still opening at an
unchanged rate (30.0% vs 30.4%) — the fix removes the race, not the code path.
- This exact patch ships today via patch-package in two production codebases
  (react-native-screens 4.25.0 and 4.26.2 — files identical to `main`'s `cpp/legacy/` copies). Independent verification in the thread below: physical
  arm64 device, 6/128 launches crashing unpatched → 0/88 patched.
- No new automated test file: the race is not deterministically triggerable without
test-only timing code (a `usleep` widener in the pull path). Behavioral regression
of the removal path is covered by the existing FabricExample transition e2e suites,
  and the new code compiles in CI for all ABIs.

## Checklist

- [x] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change. — N/A, no visual changes.
- [ ] For API changes, updated relevant public types. — N/A, no public JS/TS API change (internal C++ member removed).
- [ ] Ensured that CI passes — no workflow run has been triggered on this PR yet (fork).

(cherry picked from commit b3badd012f83679b12f4e29f2e28eceaa4830efd)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
