### PR TITLE
fix(Example): Upgrade kotlin to 2.3.* (backport of #4536)

### DIFF
--- a/FabricExample/android/build.gradle
+++ b/FabricExample/android/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         compileSdkVersion = 37
         targetSdkVersion = 36
         ndkVersion = "27.1.12297006"
-        kotlinVersion = "2.2.0"
+        kotlinVersion = "2.3.21"
     }
     repositories {
         google()
@@ -25,7 +25,10 @@ buildscript {
     dependencies {
         classpath("com.android.tools.build:gradle")
         classpath("com.facebook.react:react-native-gradle-plugin")
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin")
+        // TODO: Can be removed when RN ships Kotlin >= 2.3.0
+        // Pin KGP explicitly, because the version-less classpath entry resolves to the
+        // version pinned by RN's gradle-plugin.
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
         classpath rnrepoClasspath()
     }
 }

--- a/FabricExample/android/settings.gradle
+++ b/FabricExample/android/settings.gradle
@@ -4,16 +4,3 @@ extensions.configure(com.facebook.react.ReactSettingsExtension) { ex -> ex.autol
 rootProject.name = 'FabricExample'
 include ':app'
 includeBuild('../node_modules/@react-native/gradle-plugin')
-
-// Kotlin 2.2 incremental compilation can't see a module's own `internal` declarations 
-// when the project path goes through a symlink (see: https://youtrack.jetbrains.com/issue/KT-80039): 
-// KGP registers the previous compilation output as a canonicalized
-// "friend path" while the classpath keeps the symlinked path, so the visibility
-// check never matches. node_modules/react-native-screens is a symlink to the repo
-// root, so resolve autolinked project dirs to their real paths.
-// TODO: Can be removed when RN ships Kotlin >= 2.3.0 which resolved the issue.
-gradle.settingsEvaluated { settings ->
-    settings.rootProject.children.each { p ->
-        p.projectDir = p.projectDir.canonicalFile
-    }
-}


### PR DESCRIPTION
## Description

For RCA, please see:
https://github.com/software-mansion/react-native-screens/pull/4443 . We've internally discussed with @kkafar that the Kotlin upgrade should be safe because of their backward compatibility policy. This still diverges app from the RN template, but seems to be slightly better approach than applying the workaround with resolve RNS sources to its realpath.

Please note that bumping the `kotlinVersion` alone does nothing. The versionless KGP classpath entry resolves to the version pinned by `@react-native/gradle-plugin` that pins Kotlin 2.2.0, so the module kept compiling with Kotlin 2.2.* After pinning KGP explicitly, the resolved compiler is 2.3.*.

## Changes

- upgrade Kotlin to 2.3, remove stale workaround

## Before & after - visual documentation

N/A

## Test plan

How to reproduce the issue:

1. Downgrade kotlin to 2.2
2. Build FabricExample
3. Make any edit in `ScreenStackHeaderConfig.onUpdate`
4. Build FabricExample again - the incremental compilation fails witj

```
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:35:71 Cannot access 'class PointerEventsBoxNoneImpl : ReactPointerEventsView': it is internal in file.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:264:32 Cannot access 'fun trySetWindowTraits(screen: Screen, activity: Activity?, context: ReactContext?): Unit': it is internal in 'com/swmansion/rnscreens/legacy/ScreenWindowTraits'.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:361:75 Cannot access 'var isHiddenBySearchBar: Boolean': it is internal in 'com/swmansion/rnscreens/legacy/ScreenStackHeaderSubview'.
e: file:///Users/tomaszboron/react-native-screens/FabricExample/node_modules/react-native-screens/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenStackHeaderConfig.kt:362:22 Cannot access 'fun setHiddenBySearchBar(hidden: Boolean): Unit': it is internal in 'com/swmansion/rnscreens/legacy/ScreenStackHeaderSubview'.
```

This should NOT happen after changing the Kotlin version to 2.3

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
* Updated the Android build configuration for improved compatibility with the latest Kotlin version.
* Removed a workaround that could interfere with incremental compilation and linked project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

(cherry picked from commit bb797828a1978ec186c9b074b00086c2aaa07514)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
