### PR TITLE
fix(Android, Stack v4): prevent adding preloaded and dismissed fragments when popping from opaque to translucent screen (backport of #4571)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/ScreenStack.kt
@@ -283,6 +283,8 @@ class ScreenStack(
                 screenWrappers
                     .asSequence()
                     .dropWhile { it !== visibleBottom } // ignore all screens beneath the visible bottom
+                    // dismissed screens are already removed above & preloaded ones must stay detached
+                    .filter { !dismissedWrappers.contains(it) && it.screen.activityState !== Screen.ActivityState.INACTIVE }
                     .forEach { wrapper ->
                         // TODO: It should be enough to dispatch this on commit action once.
                         transaction.add(id, wrapper.fragment).runOnCommit {

--- a/apps/src/tests/issue-tests/Test4571.tsx
+++ b/apps/src/tests/issue-tests/Test4571.tsx
@@ -1,0 +1,262 @@
+import React, { useState } from 'react';
+
+import { View, Text, Button, StyleSheet } from 'react-native';
+import {
+  useNavigation,
+  CommonActions,
+  NavigationContainer,
+} from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { ScreenStack, ScreenStackItem } from 'react-native-screens';
+
+// Repros for the ScreenStack.onUpdate attach pass ("attach screens that just
+// became visible") re-adding fragments that must stay detached. Both scenarios
+// dismiss an opaque screen sitting above a transparent modal whose anchor got
+// detached, which triggers the pile-restore attach pass:
+// 1. react-navigation + preload: the preloaded (activityState INACTIVE) route
+//    is the stack's last child and gets attached on top of the visible stack.
+// 2. Bare screens API + native header back dismissal: the dismissed screen is
+//    still a React child (dismissedWrappers path) and gets re-added right
+//    after the remove pass removed it.
+
+export default function App() {
+  const [scenario, setScenario] = useState<'preload' | 'native-dismiss'>();
+
+  if (scenario === 'preload') {
+    return <PreloadScenario />;
+  }
+  if (scenario === 'native-dismiss') {
+    return <NativeDismissScenario />;
+  }
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>Pick a scenario:</Text>
+      <Button
+        title="react-navigation + preload"
+        onPress={() => setScenario('preload')}
+      />
+      <Button
+        title="Screens API + native dismiss"
+        onPress={() => setScenario('native-dismiss')}
+      />
+    </View>
+  );
+}
+
+function Counter() {
+  const [count, setCount] = useState(0);
+
+  return (
+    <Button title={`Counter: ${count}`} onPress={() => setCount(c => c + 1)} />
+  );
+}
+
+// #region react-navigation + preload scenario
+
+function HomeScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>Steps:</Text>
+      <Text>1. Preload screen</Text>
+      <Text>2. Open transparent modal</Text>
+      <Text>3. Push opaque modal (from the transparent one)</Text>
+      <Text>4. Dismiss opaque modal</Text>
+      <Text>
+        5. Tap the counter on the transparent modal. If it does not respond (or
+        a magenta screen appears), the bug reproduced. Hardware back should heal
+        it.
+      </Text>
+      <Button
+        title="1. Preload screen"
+        onPress={() => navigation.dispatch(CommonActions.preload('Preloaded'))}
+      />
+      <Button
+        title="2. Open transparent modal"
+        onPress={() =>
+          navigation.dispatch(CommonActions.navigate('TransparentModal'))
+        }
+      />
+    </View>
+  );
+}
+
+function TransparentModalScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={styles.transparentModalBackdrop}>
+      <View style={styles.transparentModalCard}>
+        <Text style={styles.title}>Transparent modal</Text>
+        <Counter />
+        <Button
+          title="3. Push opaque modal"
+          onPress={() =>
+            navigation.dispatch(CommonActions.navigate('OpaqueModal'))
+          }
+        />
+        <Button title="Go back" onPress={() => navigation.goBack()} />
+      </View>
+    </View>
+  );
+}
+
+function OpaqueModalScreen() {
+  const navigation = useNavigation();
+
+  return (
+    <View style={styles.screen}>
+      <Text style={styles.title}>Opaque modal</Text>
+      <Button
+        title="4. Dismiss opaque modal"
+        onPress={() => navigation.goBack()}
+      />
+    </View>
+  );
+}
+
+function PreloadedScreen() {
+  React.useEffect(() => {
+    console.log('PreloadedScreen mounted');
+    return () => console.log('PreloadedScreen unmounted');
+  }, []);
+
+  return (
+    <View style={styles.preloaded}>
+      <Text style={styles.title}>PRELOADED SCREEN</Text>
+      <Text>You should never see this without navigating to it!</Text>
+    </View>
+  );
+}
+
+const Stack = createNativeStackNavigator();
+
+const PreloadScenario = () => (
+  <NavigationContainer>
+    <Stack.Navigator>
+      <Stack.Screen name="Home" component={HomeScreen} />
+      <Stack.Screen
+        name="TransparentModal"
+        component={TransparentModalScreen}
+        options={{ presentation: 'transparentModal', headerShown: false }}
+      />
+      <Stack.Screen
+        name="OpaqueModal"
+        component={OpaqueModalScreen}
+        options={{ presentation: 'modal' }}
+      />
+      <Stack.Screen name="Preloaded" component={PreloadedScreen} />
+    </Stack.Navigator>
+  </NavigationContainer>
+);
+
+// #region Screens API + native dismiss scenario
+
+function NativeDismissScenario() {
+  const [routes, setRoutes] = useState<string[]>(['home']);
+
+  const pushRoute = (route: string) => setRoutes(prev => [...prev, route]);
+  const popRoute = (route: string) =>
+    setRoutes(prev => prev.filter(r => r !== route));
+
+  return (
+    <ScreenStack style={styles.container}>
+      <ScreenStackItem
+        screenId="home"
+        style={StyleSheet.absoluteFill}
+        headerConfig={{ title: 'Test4571' }}>
+        <View style={styles.screen}>
+          <Text style={styles.title}>Steps:</Text>
+          <Text>1. Open transparent modal</Text>
+          <Text>2. Push opaque screen (from the modal)</Text>
+          <Text>3. Tap the NATIVE header back button on the opaque screen</Text>
+          <Text>
+            Expected: the opaque screen plays its close animation and the
+            transparent modal is restored with a working counter. Broken: the
+            first back tap does nothing (or the screen pops with no animation)
+            and a second tap is needed to recover.
+          </Text>
+          <Button
+            title="1. Open transparent modal"
+            onPress={() => pushRoute('transparent-modal')}
+          />
+        </View>
+      </ScreenStackItem>
+      {routes.includes('transparent-modal') && (
+        <ScreenStackItem
+          screenId="transparent-modal"
+          style={StyleSheet.absoluteFill}
+          stackPresentation="transparentModal"
+          headerConfig={{ hidden: true }}
+          onDismissed={() => popRoute('transparent-modal')}>
+          <View style={styles.transparentModalBackdrop}>
+            <View style={styles.transparentModalCard}>
+              <Text style={styles.title}>Transparent modal</Text>
+              <Counter />
+              <Button
+                title="2. Push opaque screen"
+                onPress={() => pushRoute('opaque')}
+              />
+              <Button
+                title="Close"
+                onPress={() => popRoute('transparent-modal')}
+              />
+            </View>
+          </View>
+        </ScreenStackItem>
+      )}
+      {routes.includes('opaque') && (
+        <ScreenStackItem
+          screenId="opaque"
+          style={StyleSheet.absoluteFill}
+          stackAnimation="slide_from_bottom"
+          nativeBackButtonDismissalEnabled
+          headerConfig={{ title: 'Opaque screen' }}
+          onDismissed={() => popRoute('opaque')}>
+          <View style={styles.screen}>
+            <Text style={styles.title}>Opaque screen</Text>
+            <Text>3. Tap the native back button in the header above.</Text>
+          </View>
+        </ScreenStackItem>
+      )}
+    </ScreenStack>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  screen: {
+    flex: 1,
+    gap: 8,
+    padding: 16,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'white',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+  },
+  transparentModalBackdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    padding: 16,
+  },
+  transparentModalCard: {
+    backgroundColor: 'white',
+    borderRadius: 16,
+    padding: 16,
+    gap: 8,
+  },
+  preloaded: {
+    flex: 1,
+    gap: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: 'magenta',
+  },
+});

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as Test4571 } from './Test4571';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated
 // but the associated PR in react-navigation is currently put on hold


### PR DESCRIPTION
## Description

In Stack v4 on Android, when opaque screen was popped and screen below was translucent, `ScreenStack.onUpdate` would add all fragments from `visibleBottom` to `fragmentManager` without filtering out preloaded and dismissed screens. This would result in incorrect screen being visible to the user. This PR ensures that preloaded and dimissed screens are not added to `fragmentManager` in such case. More details here: https://github.com/software-mansion/react-native-screens-labs/issues/1759.

Closes
https://github.com/software-mansion/react-native-screens-labs/issues/1759.

## Changes

- filter out preloaded and dismissed screens when re-adding translucent screen(s) to `fragmentManager`
- add issue test

## Before & after - visual documentation

### Preloaded

| before           | after            |
| ---------------- | ---------------- |
| <video
src="https://github.com/user-attachments/assets/3d0c2d29-24c4-4b93-9ddc-e9c3935d6faa"
/> | <video
src="https://github.com/user-attachments/assets/d26fb02b-60cc-42c9-932a-b9ac3835d8ac"
/> |

### Dismissed

| before           | after            |
| ---------------- | ---------------- |
| <video
src="https://github.com/user-attachments/assets/1f8a7c0e-a6fb-4a87-a073-9b63af4b1797"
/> | <video
src="https://github.com/user-attachments/assets/56d2629a-f0cf-4ce3-8883-c888b49bfdb3"
/> |

## Test plan

Run `Test4571`.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] Ensured that CI passes

(cherry picked from commit 95189b94f69a4d88e07a558f8489e3b465df55b6)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
