### PR TITLE
fix(Android, Stack v4+): append SwipeRefreshLayout transition filler (backport of #4519)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/Screen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/Screen.kt
@@ -495,8 +495,10 @@ class Screen(
                     // It has a custom `getChildDrawingOrder` method which returns
                     // wrong index if we called `startViewTransition` on the views on new arch.
                     // We add a simple View to bump the number of children to make it work.
+                    // Appended, not inserted at `i`: a filler before the circle inflates the
+                    // index `onMeasure` caches for it, which then outlives the child it points at.
                     // TODO: find a better way to handle this scenario
-                    it.addView(View(context), i)
+                    it.addView(View(context))
                 } else {
                     child?.let { view -> it.startViewTransition(view) }
                 }

--- a/apps/src/tests/issue-tests/Test4519.tsx
+++ b/apps/src/tests/issue-tests/Test4519.tsx
@@ -1,0 +1,35 @@
+import React, { useState } from 'react';
+import { Button, RefreshControl, ScrollView, View } from 'react-native';
+import {
+  Screen,
+  ScreenStack,
+  ScreenStackHeaderConfig,
+} from 'react-native-screens';
+
+export default function App() {
+  const [showRefresh, setShowRefresh] = useState(false);
+  const pop = () => setShowRefresh(false);
+
+  return (
+    <ScreenStack style={{ flex: 1 }}>
+      <Screen key="home" activityState={2} isNativeStack>
+        <ScreenStackHeaderConfig title="Home" />
+        <View style={{ flex: 1, justifyContent: 'center' }}>
+          <Button
+            title="Push refresh screen"
+            onPress={() => setShowRefresh(true)}
+          />
+        </View>
+      </Screen>
+      {showRefresh && (
+        <Screen key="refresh" activityState={2} isNativeStack onDismissed={pop}>
+          <ScreenStackHeaderConfig title="Infinite refresh" />
+          <ScrollView
+            refreshControl={<RefreshControl refreshing onRefresh={() => {}} />}>
+            <Button title="Go back" onPress={pop} />
+          </ScrollView>
+        </Screen>
+      )}
+    </ScreenStack>
+  );
+}

--- a/apps/src/tests/issue-tests/index.ts
+++ b/apps/src/tests/issue-tests/index.ts
@@ -210,6 +210,7 @@ export { default as Test4351 } from './Test4351';
 export { default as Test4357 } from './Test4357';
 export { default as Test4361 } from './Test4361';
 export { default as Test4423 } from './Test4423';
+export { default as Test4519 } from './Test4519';
 export { default as Test4571 } from './Test4571';
 export { default as TestScreenAnimation } from './TestScreenAnimation';
 // The following test was meant to demo the "go back" gesture using Reanimated


### PR DESCRIPTION
## Description

`Screen.startTransitionRecursive` inserts a filler `View` into every `SwipeRefreshLayout`
it walks, at the progress circle's own index:

```kotlin
if (parent is SwipeRefreshLayout && child is ImageView) {
    // ...
    // We add a simple View to bump the number of children to make it work.
    // TODO: find a better way to handle this scenario
    it.addView(View(context), i)   // `i` is the circle's index
}
```

That placement pushes the circle one slot down the child list. AndroidX `SwipeRefreshLayout` recomputes `mCircleViewIndex` **only in `onMeasure`**, and consumes it on every draw:

```java
protected int getChildDrawingOrder(int childCount, int i) {
    if (mCircleViewIndex < 0)      return i;
    else if (i == childCount - 1)  return mCircleViewIndex;  // draw the circle last
    else if (i >= mCircleViewIndex) return i + 1;
    else                            return i;
}
```

So if a layout pass lands while the filler is in place, the layout caches the *inflated* circle index. When the content child is then removed into a view transition, `childCount` drops but the cache does not — and the next draw returns an index past the end of the list. `ViewGroup.getAndVerifyPreorderedIndex` throws:

```
java.lang.IndexOutOfBoundsException: getChildDrawingOrder() returned invalid index 2 (child count is 2)
  at android.view.ViewGroup.getAndVerifyPreorderedIndex(ViewGroup.java:2239)
  at android.view.ViewGroup.dispatchDraw(ViewGroup.java:4522)
  ...
  at com.swmansion.rnscreens.ScreenStack.drawAndRelease(ScreenStack.kt:64)
  at com.swmansion.rnscreens.ScreenStack.performDraw(ScreenStack.kt:334)
```

The reported index always equals the child count, which is the signature of this particular cache going stale.

### Why appending fixes it

Walking every state, with `C` = content, `O` = circle, `X` = filler:

| state | children (before) | count / cached | children (after) | count / cached |
| --- | --- | --- | --- | --- |
| measured while filler present | `C X O` | 3 / **2** | `C O X` | 3 / **1** |
| content detached into the transition | `X O` | 2 / **2** → 💥 | `O X` | 2 / **1** → ok |

The cached index only has to stay inside the child list, and the circle only has to be the last child *drawn*. Appending satisfies both in every state, because the circle's index no longer moves when a filler is added. In the healthy case the two placements produce **identical paint order** — `content, filler, circle` either way — because `getChildDrawingOrder` already hoists the circle to last regardless of where it sits.

In the stale window the patched layout draws the circle first and the filler last, which is the one behavioural difference. The filler is a bare `View` with no background, so it paints nothing and cannot occlude the circle.

Any placement *before* the circle has the same defect — inserting at index `0` gives `X C O` / cached `2`, which fails identically once `C` leaves. Appending is the only placement that survives.

### Why the filler itself has to stay

It looks removable, but it is load-bearing. With no filler at all, the content child leaving takes `childCount` to 1 against a cached index of 1:

```
getChildDrawingOrder() returned invalid index 1 (child count is 1)
```

That is what the filler is compensating for — it holds `childCount` above the stale cached index. This change keeps that property and only moves where the filler sits.

### Why it is hard to reproduce interactively

If the pop unmounts the whole subtree in a single mount transaction, **no layout pass runs between the filler insert and the content child's detachment**, so the cached index is still the pre-filler value (`1`) and *both* placements are safe. The crash needs something to measure the outgoing `SwipeRefreshLayout` while the filler is in place.

In the production traces we have, the frames underneath `ScreenStack.performDraw` include `RecyclerView`/ViewPager2 — a pager (`react-native-pager-view` under a tab view) hosting the refresh control. The pager keeps offscreen pages mounted and measures them, which supplies exactly the layout pass the bug needs while the exit animation is still running.

The `invalid index 3 (child count is 3)` variant in #3096 is the same defect one slot further along, consistent with a `SwipeRefreshLayout` that survives a removal cycle with a filler still attached (nothing removes them) and accumulates another on the next one.

Closes #4513.
Likely the same root cause as #3096.

## Changes

- `legacy/Screen.kt`: append the transition filler (`it.addView(View(context))`) rather than inserting it at the circle's index, and record why the placement matters.

## Test plan

**Deterministic reproduction (JVM, Robolectric).** Reproduced and verified against `react-native-screens` 4.23.0 on RN 0.83.6, Robolectric 4.15.1, `@Config(sdk = [34])`. This drives the real `Screen.startRemovalTransition()` path — it throws on stock 4.23.0 and passes with this change:

<details><summary>RefreshControlScreenRemovalTest.kt</summary>

```kotlin
@RunWith(RobolectricTestRunner::class)
@Config(sdk = [34])
class RefreshControlScreenRemovalTest {
    private lateinit var activity: Activity
    private lateinit var reactContext: ReactApplicationContext

    @Before
    fun setUp() {
        activity = Robolectric.buildActivity(Activity::class.java).setup().get()
        DisplayMetricsHolder.initDisplayMetricsIfNotInitialized(activity)
        reactContext = BridgeReactContext(RuntimeEnvironment.getApplication())
    }

    /** Reproduces the crash against upstream's filler placement, independently of the fix. */
    @Test
    fun `filler inserted ahead of the progress circle crashes the next draw`() {
        val refreshLayout = ReactSwipeRefreshLayout(reactContext)
        val content = View(activity)
        refreshLayout.addView(content, 0)
        activity.setContentView(refreshLayout)

        layOut(refreshLayout)
        assertEquals("circle starts after the content child", 1, indexOfCircle(refreshLayout))

        // Screen.kt today: `it.addView(View(context), i)`, with `i` the circle's index.
        refreshLayout.addView(View(activity), indexOfCircle(refreshLayout))
        layOut(refreshLayout)
        assertEquals("filler pushed the circle down a slot", 2, indexOfCircle(refreshLayout))

        refreshLayout.startViewTransition(content)
        refreshLayout.removeView(content)
        assertEquals(2, refreshLayout.childCount)

        try {
            draw(refreshLayout)
            fail("expected the stale circle index to be rejected while drawing")
        } catch (e: IndexOutOfBoundsException) {
            assertTrue(
                "expected the drawing-order failure, got: ${e.message}",
                e.message.orEmpty().contains("getChildDrawingOrder() returned invalid index 2"),
            )
        }
    }

    /** The same sequence through the real removal path. Fails on 4.23.0, passes with this change. */
    @Test
    fun `refresh control still draws after a patched screen removal`() {
        val screen = Screen(ThemedReactContext(reactContext, activity, null, -1))
        val refreshLayout = ReactSwipeRefreshLayout(reactContext)
        val content = View(activity)
        refreshLayout.addView(content, 0)
        screen.addView(refreshLayout)
        activity.setContentView(screen)

        // Measure the refresh layout itself: ReactViewGroup sizes its children from the shadow
        // tree rather than measuring them, so laying out the Screen alone never refreshes the cache.
        layOut(refreshLayout)
        assertEquals("circle starts after the content child", 1, indexOfCircle(refreshLayout))

        screen.startRemovalTransition()
        assertEquals("screens adds one filler view", 3, refreshLayout.childCount)
        // The measure that caches the circle's index while the filler is in place.
        layOut(refreshLayout)

        refreshLayout.removeView(content)
        assertEquals(2, refreshLayout.childCount)

        draw(screen)   // throws IndexOutOfBoundsException on stock 4.23.0
    }

    private fun layOut(view: View) {
        view.measure(
            MeasureSpec.makeMeasureSpec(WIDTH, MeasureSpec.EXACTLY),
            MeasureSpec.makeMeasureSpec(HEIGHT, MeasureSpec.EXACTLY),
        )
        view.layout(0, 0, WIDTH, HEIGHT)
    }

    private fun draw(view: View) {
        view.draw(Canvas(Bitmap.createBitmap(WIDTH, HEIGHT, Bitmap.Config.ARGB_8888)))
    }

    private fun indexOfCircle(parent: ViewGroup): Int =
        (0 until parent.childCount).first { parent.getChildAt(it) is ImageView }

    private companion object {
        const val WIDTH = 1080
        const val HEIGHT = 1920
    }
}
```

</details>

Verified by reverting `Screen.kt` in `node_modules` to the current upstream form and re-running: the second test fails with `getChildDrawingOrder() returned invalid index 2 (child count is 2)`, and passes again with the filler appended.

**Production evidence.** This is the fix we are shipping. The crash affected 18 users on our latest production build, skewed to Android 16 and Samsung devices, on `react-native-screens` 4.23.0 with RN 0.83.6 / Fabric.

**Repro.** I do not have a reliable interactive on-device reproducer — the timing window is narrow, and per the analysis above it needs a layout pass on the refresh layout during the exit animation. What I do have is a deterministic reproduction of the exact mechanism, production crash data, and the state analysis showing the change is a no-op whenever the cache is fresh.

---------




(cherry picked from commit 8a697f8bcb198ee9655502259fe160c8892ff918)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
