### PR TITLE
fix(Android, Tabs): handle forceLayout to ensure tab bar is properly laid out after configuration change (backport of #4582)

### DIFF
--- a/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/gamma/tabs/host/TabsHost.kt
@@ -161,6 +161,16 @@ class TabsHost(
         refreshLayout()
     }
 
+    // On window configuration changes ViewRootImpl calls forceLayout() recursively on every view
+    // in the hierarchy, bypassing requestLayout(). React views never lay out their children during
+    // framework traversals, so nothing would clear the force-layout flags in our subtree — and once
+    // they are set, any subsequent requestLayout() from a descendant short-circuits before reaching
+    // the override above, permanently disabling the manual pass. Schedule it from here as well.
+    override fun forceLayout() {
+        super.forceLayout()
+        refreshLayout()
+    }
+
     private fun forceSubtreeMeasureAndLayoutPass() {
         measure(
             MeasureSpec.makeMeasureSpec(width, MeasureSpec.EXACTLY),


### PR DESCRIPTION
## Description

With React Native's JS color-scheme override active (`Appearance.setColorScheme('light' | 'dark')`), toggling the **device** dark mode a few times permanently freezes native layout inside `TabsHost`'s subtree. Unlike the Stack case, the tab bar is re-styled in place (no view rebuild), so the freeze has no immediate visual symptom — it shows the moment something must actually move: with `android.tabBarRespectsIMEInsets` enabled the tab bar no longer lifts above the keyboard, and tab content stops being laid out.

This PR fixes the freeze by overriding `forceLayout()` in `TabsHost` to schedule the same manual measure-and-layout pass that `requestLayout()` already schedules. It is the Tabs counterpart of
https://github.com/software-mansion/react-native-screens/pull/4580 — same root cause, same fix.

### Details

**Background — why rnscreens needs a manual layout pass at all.** React Native deliberately suppresses native Android layout: `ReactViewGroup.requestLayout()` is a no-op and React views don't measure or lay out their children during framework traversals — Fabric sets child frames directly via mount instructions. A `requestLayout()` originating inside the tabs subtree therefore can't propagate to `ViewRootImpl` the way it would in a plain Android app. `TabsHost` works around this by overriding `requestLayout()` to schedule a `forceSubtreeMeasureAndLayoutPass()` (measure with `EXACTLY` specs + `layout()`) through `TabsHostLayoutCoordinator` — via `Handler.post` until the first layout with insets, via `ReactChoreographer` afterwards (see #4161), both coalesced. That override is the **single point** that turns layout requests from the subtree (tab-bar repositioning, tab content changes) into an actual measure/layout pass.

**The hole: `forceLayout()` bypasses that single point.** On any window configuration change, `ViewRootImpl.handleResized` recursively calls `forceLayout()` on **every** view in the window and then relies on the next traversal to service the flags. `View.forceLayout()` sets `PFLAG_FORCE_LAYOUT | PFLAG_INVALIDATED` directly — it does **not** go through anyone's `requestLayout()` override and does not propagate anywhere. The framework's follow-up traversal never descends below the React views (they don't lay out their children), so the flags on `TabsHost` and everything beneath it are set and left set. This matters because of how `View.requestLayout()` walks up the tree: it stops the moment it reaches a parent that already has a layout request pending (`if (mParent != null && !mParent.isLayoutRequested()) mParent.requestLayout()`). Once an ancestor is stuck in the "layout requested" state, every later `requestLayout()` from a descendant is swallowed before it can reach `TabsHost`'s override.

**Why a device toggle reaches rnscreens at all — the double dispatch.** Intuitively, with the JS override pinning the appearance, device dark-mode toggles should be invisible to rnscreens — and in the end state they are, but not during dispatch. RN's
`Appearance.setColorScheme` maps to
`AppCompatDelegate.setDefaultNightMode`, and because the activity declares `uiMode` in `android:configChanges`, AppCompat cannot recreate the activity to re-apply the override — it has to fix the configuration up after the fact. So when the device toggles **away from** the pinned value, the activity and its fragments first receive `onConfigurationChanged` with the raw **device** configuration (`AppCompatActivity` runs `super.onConfigurationChanged`, which dispatches to fragments, before `getDelegate().onConfigurationChanged`), and only afterwards does `AppCompatDelegateImpl` re-impose the override on the resources and synthesize a **second**, re-entrant `onConfigurationChanged` carrying the overridden value. rnscreens therefore transiently observes the device value and re-themes to it, then re-themes back (wasteful, but as shown below not itself the cause of the freeze). When the device toggles **back to** the pinned value, the effective configuration doesn't change, so a single callback arrives carrying the value that is already applied — and rnscreens correctly does nothing with it. Both cases matter below.

**Step by step — what the three toggles do.** The callbacks reach rnscreens through `TabsScreenFragment.onConfigurationChanged` → `TabsContainer` → `ColorSchemeCoordinator`. Start with the device in light mode and the override set to `light` (so the last applied night mode is light):

1. **Toggle 1 (device → dark — the away-from-pinned case).** The first callback delivers the device value (`NIGHT_YES`):
`ColorSchemeCoordinator` resolves a night mode different from `lastAppliedUiNightMode`, so `TabsContainer.applyDayNightUiMode()` re-styles the `BottomNavigationView` in place (`updateTabAppearance`) and posts a `requestLayout()`. The synthesized second callback then delivers the overridden `NIGHT_NO` and re-styles back to light. Each `requestLayout()` reaches `TabsHost` and schedules the (coalesced) manual pass. `ViewRootImpl`'s recursive `forceLayout()` also runs for this window configuration change, but the already-scheduled pass then measures the whole subtree and clears every flag. This toggle survives only by ordering luck — a pass happened to be pending.
2. **Toggle 2 (device → light — the back-to-pinned case).** The device returns to the value the JS override already pins, so a single callback arrives and `ColorSchemeCoordinator` resolves the same night mode as last applied and **dedupes**: it returns early without touching any view. No `requestLayout()`, no pass scheduled. But the OS still delivered a genuine window configuration change, so `ViewRootImpl` still runs its recursive `forceLayout()`, setting `PFLAG_FORCE_LAYOUT` on `TabsHost` and its entire subtree — with **nothing scheduled to clear it**. This is the silent poisoning step: the dedupe is correct in itself (there is genuinely nothing to re-theme), but it means rnscreens schedules no pass on exactly the toggle where the framework still force-flags the tree.
3. **Toggle 3 (device → dark — away-from-pinned again).** Both callbacks arrive and the tab bar re-styles just like in toggle 1, calling `requestLayout()` — but the parents are already `isLayoutRequested() == true` from toggle 2, so the request short-circuits before reaching `TabsHost` and no pass is scheduled. Because the re-style only mutates colors in place, nothing visibly breaks at this moment — the freeze surfaces as soon as layout must actually change: the tab-bar reposition that should follow IME insets never runs (the layout requests it issues are swallowed the same way), and tab content changes stop being laid out. The subtree is frozen for good.

This is also why the JS override is a required ingredient: without it, every device toggle is a real change, so every toggle schedules a pass that cleans up the framework's flags and they never accumulate.

**The fix.** Schedule the manual measure-and-layout pass from `forceLayout()` too:

```kotlin
override fun forceLayout() {
    super.forceLayout()
    refreshLayout()
}
```

`ViewRootImpl`'s recursion visits the host on every window config change, so the pass is now always scheduled exactly when the framework sets the flags. The pass measures the subtree with `EXACTLY` specs — `View.measure()` honors this even with unchanged specs because `PFLAG_FORCE_LAYOUT` is set — and `View.layout()` clears the flags everywhere below. The single host-level override is sufficient for the whole subtree, and it's harmless for any other `forceLayout()` caller: both scheduling paths in `TabsHostLayoutCoordinator` are coalesced via their pending flags.

## Changes

- override `forceLayout()` in `TabsHost` to schedule the manual measure-and-layout pass, mirroring the existing `requestLayout()` override

## Before & after - visual documentation

| Before | After |
| ------ | ----- |
| <video
src="https://github.com/user-attachments/assets/2f9df336-3038-47c9-8e20-064fe2688571" /> | <video
src="https://github.com/user-attachments/assets/1b32d0de-4ff5-4619-b620-b894efe74312" /> |

## Test plan

Run `test-tabs-tab-bar-color-scheme` in FabricExample, **with one temporary modification to make the freeze observable** — pass `android={{ tabBarRespectsIMEInsets: true }}` to the `TabsContainerWithHostConfigContext` in the test's `index.tsx` (the freeze doesn't repaint anything by itself; the IME-driven tab-bar reposition is the check):

1. Start with the device in **light** mode; set React Native's color scheme override to **light** using the on-screen picker (leave the host color scheme at `inherit`).
2. Toggle the device dark mode three times: **dark → light → dark** (quick-settings tile, or `adb shell "cmd uimode night yes"` / `no` / `yes`).
3. Switch to the **Keyboard** tab and focus the `TextInput`.
4. Before the fix: the tab bar stays stuck behind the keyboard. After the fix: the tab bar lifts above the IME, and tab switching and re-theming keep working after any number of toggles.

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] Ensured that CI passes

(cherry picked from commit 3e101ff2896bffd5660281153e5543ef59921d1f)

## Description

<!--
Description and motivation for this PR. 
This section should include "what & why".

Please link all related issues that merging this PR should close,
by using the `Closes #<issue-number>` syntax.

For example: 
Closes #12345.
-->

## Changes

<!--
This is "how" of the PR description.

Please describe things you've changed here, make a **high level** overview, 
if change is simple you can omit this section.

For example:

- Updated `about.md` docs
-->

## Before & after - visual documentation

<!--
This section is MANDATORY for any PR that introduces any visual changes.

If your PR does not introduce such changes, please omit this section.

Consider using a table here to position the recordings / screenshots 
next to each other.

| Before | After |
| --- | --- |
| ![Before](before.png) | ![After](after.png) |

Alternatively add two sections - Before & After

### Before

### After
-->

## Test plan

<!--
Please name all newly added and existing test files that you tested the changes with.
This section should also contain short description of steps to reproduce the issue.

The reproduction code should be minimal & complete. Don't exclude exports or remove "not important" parts of reproduction example.
-->

## Checklist

- [ ] Included code example that can be used to test this change.
- [ ] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [ ] For API changes, updated relevant public types.
- [ ] Ensured that CI passes
