### PR TITLE
release: 4.28.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-screens",
-  "version": "1000.0.0",
+  "version": "4.28.0",
   "description": "Native navigation primitives for your React Native app.",
   "scripts": {
     "submodules": "git submodule update --init --recursive && (cd react-navigation && yarn && yarn build && cd ../)",


### PR DESCRIPTION
Branch for testing 4.28.0 release. Changed library version to 4.28.0 in package.json.
