### PR TITLE
fix(android): prevent containers from delaying child pressed state

### DIFF
--- a/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledHeaderConfigViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledHeaderConfigViewGroup.kt
@@ -71,6 +71,8 @@ abstract class FabricEnabledHeaderConfigViewGroup(
         mStateWrapper?.updateState(map)
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     companion object {
         private const val DELTA = 0.9f
     }

--- a/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledHeaderSubviewViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledHeaderSubviewViewGroup.kt
@@ -72,6 +72,8 @@ abstract class FabricEnabledHeaderSubviewViewGroup(
         mStateWrapper?.updateState(map)
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     companion object {
         private const val DELTA = 0.9f
     }

--- a/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledViewGroup.kt
+++ b/android/src/fabric/java/com/swmansion/rnscreens/legacy/FabricEnabledViewGroup.kt
@@ -57,4 +57,6 @@ abstract class FabricEnabledViewGroup(
             }
         mStateWrapper?.updateState(map)
     }
+
+    override fun shouldDelayChildPressedState(): Boolean = false
 }

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenContainer.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/ScreenContainer.kt
@@ -43,6 +43,8 @@ open class ScreenContainer(
         }
     private var parentScreenWrapper: ScreenFragmentWrapper? = null
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     override fun onLayout(
         changed: Boolean,
         l: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/bottomsheet/DimmingView.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/bottomsheet/DimmingView.kt
@@ -51,6 +51,8 @@ internal class DimmingView(
         b: Int,
     ) = Unit
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     // We do not want to have any action defined here. We just want listeners notified that the click happened.
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent?): Boolean {

--- a/android/src/main/java/com/swmansion/rnscreens/legacy/stack/views/ScreensCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/legacy/stack/views/ScreensCoordinatorLayout.kt
@@ -111,6 +111,8 @@ internal class ScreensCoordinatorLayout(
         }
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = fragment.screen.usesFormSheetPresentation()
+
     override fun onLayout(
         changed: Boolean,
         l: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/modals/formsheet/react/host/FormSheetHost.kt
@@ -76,6 +76,8 @@ class FormSheetHost(
     // hit-testing so touches reach the views behind it.
     override val pointerEvents: PointerEvents = PointerEvents.NONE
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     override fun onLayout(
         changed: Boolean,
         l: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/header/StackHeaderCoordinatorLayout.kt
@@ -313,6 +313,8 @@ internal class StackHeaderCoordinatorLayout(
 
     // region Content behavior
 
+    override fun shouldDelayChildPressedState(): Boolean = (appBarLayout?.totalScrollRange ?: 0) > 0
+
     internal fun setContentBehavior() {
         val params = stackScreenWrapper.layoutParams as LayoutParams
         if (params.behavior == null) {

--- a/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/host/StackHost.kt
@@ -97,6 +97,8 @@ class StackHost(
         }
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     override fun onMeasure(
         widthMeasureSpec: Int,
         heightMeasureSpec: Int,

--- a/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/stack/screen/StackScreen.kt
@@ -91,6 +91,8 @@ class StackScreen(
 
     // endregion
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     // region Header config
 
     internal var headerConfig: StackHeaderConfig? = null

--- a/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
+++ b/android/src/main/java/com/swmansion/rnscreens/tabs/screen/TabsScreen.kt
@@ -121,6 +121,8 @@ class TabsScreen(
         super.onAttachedToWindow()
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     override fun onLayout(
         changed: Boolean,
         l: Int,


### PR DESCRIPTION
## Description

[`shouldDelayChildPressedState`](https://developer.android.com/reference/android/view/ViewGroup#shouldDelayChildPressedState%28%29) returns `true` by default and should be overridden by non-scrolling containers to return false. Having it return `true` causes a slight delay before showing interaction feedback on native buttons.

Related: https://github.com/react/react-native/pull/57127, https://github.com/software-mansion/react-native-gesture-handler/pull/4296

I'm not sure whether the decisions behind when to simply return `false` and when to make it conditional make sense. Generally, when something is scrollable/draggable, it should return true. Let me know if I missed anything.

## Changes

Adds `shouldDelayChildPressedState` override to container views.

## Before & after - visual documentation

Video at 1/4 speed

https://github.com/user-attachments/assets/d6021082-a96d-4a37-8c9b-832e33393232

## Test plan

<details>
<summary>Tested using Gesture Handler 3 `Touchable`</summary>

```jsx
import React from 'react';
import { StatusBar, StyleSheet, Text, View } from 'react-native';
import {
  GestureHandlerRootView,
  Touchable,
} from 'react-native-gesture-handler';
import {
  Screen,
  ScreenStack,
  ScreenStackHeaderConfig,
} from 'react-native-screens';

export default function TouchablePressedState() {
  return (
    <GestureHandlerRootView style={styles.root}>
      <StatusBar hidden />
      <ScreenStack style={styles.root}>
        <Screen activityState={2} stackAnimation="none" style={styles.root}>
          <ScreenStackHeaderConfig hidden />
          <View style={styles.content}>
            <Text style={styles.eyebrow}>ANDROID · NATIVE STACK</Text>
            <Text style={styles.title}>Pressed state timing</Text>
            <Text style={styles.description}>
              Hold the button. The Android touch circle marks contact; blue
              marks the native pressed feedback.
            </Text>
            <Touchable
              testID="pressed-state-touchable"
              accessibilityLabel="Hold to show pressed feedback"
              animationDuration={0}
              underlayColor="#2563eb"
              activeUnderlayOpacity={1}
              style={styles.button}
              onPress={() => {}}>
              <Text style={styles.buttonText}>PRESS AND HOLD</Text>
            </Touchable>
            <Text style={styles.detail}>RNGH 3 Touchable</Text>
            <Text style={styles.code}>animationDuration={0}</Text>
            <Text style={styles.footnote}>
              Same screen and held gesture in both builds. Only the Screens
              native overrides change.
            </Text>
          </View>
        </Screen>
      </ScreenStack>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  root: { flex: 1, backgroundColor: '#0f172a' },
  content: { flex: 1, justifyContent: 'center', padding: 28 },
  eyebrow: {
    color: '#94a3b8',
    fontSize: 12,
    fontWeight: '700',
    letterSpacing: 2,
  },
  title: { color: '#f8fafc', fontSize: 30, fontWeight: '700', marginTop: 12 },
  description: {
    color: '#cbd5e1',
    fontSize: 16,
    lineHeight: 24,
    marginTop: 16,
  },
  button: {
    height: 148,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#334155',
    borderRadius: 18,
    marginTop: 36,
    marginBottom: 28,
  },
  buttonText: { color: '#ffffff', fontSize: 20, fontWeight: '700' },
  detail: { color: '#cbd5e1', fontSize: 15 },
  code: {
    color: '#93c5fd',
    fontFamily: 'monospace',
    fontSize: 15,
    marginTop: 6,
  },
  footnote: { color: '#94a3b8', fontSize: 13, lineHeight: 20, marginTop: 28 },
});

```

</details>

## Checklist

- [x] Included code example that can be used to test this change.
- [x] For visual changes, included screenshots / GIFs / recordings documenting the change.
- [x] For API changes, updated relevant public types.
- [x] Ensured that CI passes
